### PR TITLE
Only Season Episodes As Next

### DIFF
--- a/SeriesGuide/res/layout/preferences.xml
+++ b/SeriesGuide/res/layout/preferences.xml
@@ -32,6 +32,11 @@
             android:summary="@string/pref_onlyfuturesummary"
             android:key="onlyFutureEpisodes"
             android:defaultValue="False" />
+        <CheckBoxPreference
+            android:title="@string/pref_onlyseasoneps"
+            android:summary="@string/pref_onlyseasonepssummary"
+            android:key="onlySeasonEpisodes"
+            android:defaultValue="False" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/pref_content">

--- a/SeriesGuide/res/values/strings.xml
+++ b/SeriesGuide/res/values/strings.xml
@@ -134,6 +134,8 @@
 	<string name="pref_showlist">Show list</string>
 	<string name="pref_onlyfuture">Only future episodes</string>
 	<string name="pref_onlyfuturesummary">\"next:\" only shows unaired episodes</string>
+	<string name="pref_onlyseasoneps">Only season episodes</string>
+	<string name="pref_onlyseasonepssummary">\"next:\" only shows episodes from seasons</string>
 	<string name="pref_content">Content</string>
 	<string name="pref_language">TheTVDB Language</string>
 	<string name="pref_languagesummary">Local content not available for every show/episode, update your shows after changing this</string>

--- a/SeriesGuide/src/com/battlelancer/seriesguide/SeriesGuidePreferences.java
+++ b/SeriesGuide/src/com/battlelancer/seriesguide/SeriesGuidePreferences.java
@@ -41,7 +41,9 @@ public class SeriesGuidePreferences extends PreferenceActivity {
 
     public static final String KEY_USE_MY_TIMEZONE = "com.battlelancer.seriesguide.usemytimezone";
 
-    private static final String KEY_ONLY_FUTURE_EPISODES = "onlyFutureEpisodes";
+    public static final String KEY_ONLY_FUTURE_EPISODES = "onlyFutureEpisodes";
+    
+    public static final String KEY_ONLY_SEASON_EPISODES = "onlySeasonEpisodes";
 
     protected static final int ABOUT_DIALOG = 0;
 
@@ -167,6 +169,23 @@ public class SeriesGuidePreferences extends PreferenceActivity {
                     // track event
                     AnalyticsUtils.getInstance(activity).trackEvent("Settings",
                             "OnlyFutureEpisodes", "Disable", 0);
+                }
+                return false;
+            }
+        });
+
+        Preference seasonEpisodes = (Preference) findPreference(KEY_ONLY_SEASON_EPISODES);
+        seasonEpisodes.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+
+            public boolean onPreferenceClick(Preference preference) {
+                if (((CheckBoxPreference) preference).isChecked()) {
+                    // track event
+                    AnalyticsUtils.getInstance(activity).trackEvent("Settings",
+                            "OnlySeasonEpisodes", "Enable", 0);
+                } else {
+                    // track event
+                    AnalyticsUtils.getInstance(activity).trackEvent("Settings",
+                            "OnlySeasonEpisodes", "Disable", 0);
                 }
                 return false;
             }


### PR DESCRIPTION
Add preference toggle for showing only episodes which occur in a season (i.e., are not specials) for the "next" field.
