### PR TITLE
Fix Trakt.tv Update

### DIFF
--- a/SeriesGuide/src/com/battlelancer/seriesguide/ui/OverviewFragment.java
+++ b/SeriesGuide/src/com/battlelancer/seriesguide/ui/OverviewFragment.java
@@ -419,7 +419,8 @@ public class OverviewFragment extends Fragment {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity()
                 .getApplicationContext());
         if (prefs.getBoolean("com.battlelancer.seriesguide.traktintegration", false)) {
-            new ShareUtils.TraktTask(getActivity(), getFragmentManager(), mShareData).execute();
+            //Pass in copy of bundle so its values aren't overwritten by the new episode loading below
+            new ShareUtils.TraktTask(getActivity(), getFragmentManager(), new Bundle(mShareData)).execute();
         }
 
         // load new episode, update seasons (if shown)


### PR DESCRIPTION
Use copy of episode data bundle so that a race condition is avoided causing improper marking of future episodes on Trakt.
