### PR TITLE
This change ensures any requested MenuItems are adjusted correctly in

### DIFF
--- a/SeriesGuide/src/com/battlelancer/seriesguide/ui/BaseNavDrawerActivity.java
+++ b/SeriesGuide/src/com/battlelancer/seriesguide/ui/BaseNavDrawerActivity.java
@@ -55,10 +55,8 @@ public abstract class BaseNavDrawerActivity extends BaseActivity {
         mMenuDrawer.setOnDrawerStateChangeListener(new OnDrawerStateChangeListener() {
             @Override
             public void onDrawerStateChange(int oldState, int newState) {
-                // helps hiding actions when the drawer is open
-                if (newState == MenuDrawer.STATE_CLOSED || newState == MenuDrawer.STATE_OPENING) {
-                    supportInvalidateOptionsMenu();
-                }
+                // Helps hiding actions when the drawer is open
+                supportInvalidateOptionsMenu();
             }
 
             @Override


### PR DESCRIPTION
If you quickly drag the MenuDrawer open, `supportInvalidateOptionsMenu` isn't always called and as a result the MenuItems you're hiding when it's open remain in the ActionBar.
