### PR TITLE
This change fixes issue #257

### DIFF
--- a/SeriesGuide/src/com/battlelancer/seriesguide/ui/UpcomingFragment.java
+++ b/SeriesGuide/src/com/battlelancer/seriesguide/ui/UpcomingFragment.java
@@ -17,7 +17,6 @@
 
 package com.battlelancer.seriesguide.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -26,6 +25,7 @@ import android.database.Cursor;
 import android.database.DataSetObserver;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
@@ -125,7 +125,7 @@ public class UpcomingFragment extends SherlockFragment implements
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        Activity activity = getActivity();
+        FragmentActivity activity = getActivity();
 
         // Check to see if we have a frame in which to embed the details
         // fragment directly in the containing UI.
@@ -136,12 +136,12 @@ public class UpcomingFragment extends SherlockFragment implements
         mAdapter = new SlowAdapter(activity, null, 0);
         mAdapter.setIsShowingHeaders(!ActivitySettings.isInfiniteScrolling(activity));
 
-        // Start loading data
-        getLoaderManager().initLoader(getLoaderId(), null, this);
-
         // Setup grid view
         mGridView.setAdapter(mAdapter);
         mGridView.setOnItemClickListener(this);
+
+        // Start loading data
+        activity.getSupportLoaderManager().initLoader(getLoaderId(), null, this);
 
         // Register the preference change listener
         PreferenceManager.getDefaultSharedPreferences(activity)
@@ -156,13 +156,14 @@ public class UpcomingFragment extends SherlockFragment implements
         super.onStart();
         final String tag = getArguments().getString("analyticstag");
         EasyTracker.getTracker().sendView(tag);
+        // Ensure the correct data is displayed after an orientation change
+        onRequery();
     }
 
     @Override
     public void onDestroy() {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
         prefs.unregisterOnSharedPreferenceChangeListener(this);
-
         super.onDestroy();
     }
 
@@ -170,7 +171,7 @@ public class UpcomingFragment extends SherlockFragment implements
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
 
-        // only display the action appropiate for the items current state
+        // only display the action appropriate for the items current state
         menu.add(0, CONTEXT_CHECKIN_ID, 0, R.string.checkin);
         AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuInfo;
         WatchedBox watchedBox = (WatchedBox) info.targetView.findViewById(R.id.watchedBoxUpcoming);


### PR DESCRIPTION
I closed that previous pull request after a little more testing. I noticed that the StickyGridHeaders weren't showing up back up if you toggled the infinite scrolling then switched orientations repeatedly. But that was seemingly related to calling `getLoaderManager` instead of `getSupportLoaderManager`. Bottom line here, just requery when the user switches orientations. Doing that in `onStart` is fine.
