### PR TITLE
Change the width of the TabPageIndicator, in the MoviesActivity, to `match_parent`

### DIFF
--- a/SeriesGuide/res/layout/movies.xml
+++ b/SeriesGuide/res/layout/movies.xml
@@ -6,7 +6,7 @@
 
     <com.viewpagerindicator.TabPageIndicator
         android:id="@+id/indicatorMovies"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <android.support.v4.view.ViewPager


### PR DESCRIPTION
Not sure if this is intentional or just a small oversight. Is there a reason for it being `wrap_content`?
