### PR TITLE
Fix styling issues when using the DarkActionBar.

### DIFF
--- a/SeriesGuide/res/values-v11/themes.xml
+++ b/SeriesGuide/res/values-v11/themes.xml
@@ -41,7 +41,7 @@
         <item name="android:fastScrollThumbDrawable">@drawable/fastscroll_thumb</item>
 
         <!-- Necessary to inherit the primary accent color in the DarkActionBar -->
-        <item name="android:actionBarWidgetTheme" tools:targetApi="jelly_bean">@null</item>
+        <item name="android:actionBarWidgetTheme" tools:targetApi="ice_cream_sandwich">@style/SeriesGuideTheme</item>
     </style>
 
     <!-- Fullscreen theme v11+ customizations -->

--- a/SeriesGuide/res/values/themes.xml
+++ b/SeriesGuide/res/values/themes.xml
@@ -172,6 +172,9 @@
         <item name="drawableArrowUp">@drawable/ic_action_arrow_top_inverse</item>
         <item name="drawableDropdown">@drawable/ic_action_contextmenu_light</item>
         <item name="drawableCheckin">@drawable/ic_action_checkin_inverse</item>
+
+        <!-- Necessary to inherit the primary accent color in the DarkActionBar (ABS) -->
+        <item name="actionBarWidgetTheme">@style/SeriesGuideTheme</item>
     </style>
 
     <style name="SeriesGuideBaseThemeLight" parent="Theme.Sherlock.Light.DarkActionBar">


### PR DESCRIPTION
When using the "SeriesGuideLight" theme, the some widgets used in the `ActionBar` aren't inherited correctly. As in, they use the holo blue color when they should be using the SeriesGuide color.

Before: [Overflow](https://dl.dropboxusercontent.com/u/2301775/before_dropdownlistview.png)
Before: [Overflow Checkbox](https://dl.dropboxusercontent.com/u/2301775/before_dropdowncheckbox.png)

After: [Overflow](https://dl.dropboxusercontent.com/u/2301775/after_dropdownlistview.png)
After: [Overflow Checkbox](https://dl.dropboxusercontent.com/u/2301775/after_dropdowncheckbox.png)

This only seems to affect the DarkActionBar. I'm not sure of a way to fix it before API 14.
