### PR TITLE
Add Wikipedia link

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
@@ -524,9 +524,9 @@ public class EpisodeDetailsFragment extends SherlockListFragment implements
             ServiceUtils.setUpTraktButton(mShowTvdbId, mSeasonNumber, mEpisodeNumber,
                     view.findViewById(R.id.buttonTrakt), TAG);
 
-            // Wikipedia button
-            View wikiButton = view.findViewById(R.id.buttonWikipedia);
-            ServiceUtils.setUpWikipediaButton(showTitle + " " + episodeTitle, wikiButton, TAG);
+            // Web search button
+            View webSearch = view.findViewById(R.id.buttonWebSearch);
+            ServiceUtils.setUpWebSearchButton(showTitle + " " + episodeTitle, webSearch, TAG);
 
             // trakt shouts button
             view.findViewById(R.id.buttonShouts).setOnClickListener(new OnClickListener() {
@@ -616,15 +616,18 @@ public class EpisodeDetailsFragment extends SherlockListFragment implements
         int ABSOLUTE_NUMBER = 22;
     }
 
+    @Override
     public Loader<Cursor> onCreateLoader(int arg0, Bundle arg1) {
         return new CursorLoader(getActivity(), Episodes.buildEpisodeWithShowUri(String
                 .valueOf(getEpisodeTvdbId())), DetailsQuery.PROJECTION, null, null, null);
     }
 
+    @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
         mAdapter.swapCursor(data);
     }
 
+    @Override
     public void onLoaderReset(Loader<Cursor> loader) {
         mAdapter.swapCursor(null);
     }

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewFragment.java
@@ -701,9 +701,9 @@ public class OverviewFragment extends SherlockFragment implements
         ServiceUtils.setUpTraktButton(getShowId(), seasonNumber, episodeNumber, getView()
                 .findViewById(R.id.buttonTrakt), TAG);
 
-        // Wikipedia button
-        View wikiButton = getView().findViewById(R.id.buttonWikipedia);
-        ServiceUtils.setUpWikipediaButton(mShowTitle + " " + episodeTitle, wikiButton, TAG);
+        // Web search button
+        View webSearch = getView().findViewById(R.id.buttonWebSearch);
+        ServiceUtils.setUpWebSearchButton(mShowTitle + " " + episodeTitle, webSearch, TAG);
 
         // trakt shouts button
         getView().findViewById(R.id.buttonShouts).setOnClickListener(new OnClickListener() {

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ShowInfoFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ShowInfoFragment.java
@@ -257,9 +257,9 @@ public class ShowInfoFragment extends SherlockFragment implements LoaderCallback
         ServiceUtils.setUpTraktButton(getShowTvdbId(), getView().findViewById(R.id.buttonTrakt),
                 TAG);
 
-        // Wikipedia button
-        View wikiButton = getView().findViewById(R.id.buttonWikipedia);
-        ServiceUtils.setUpWikipediaButton(mShow.getTitle(), wikiButton, TAG);
+        // Web search button
+        View webSearch = getView().findViewById(R.id.buttonWebSearch);
+        ServiceUtils.setUpWebSearchButton(mShow.getTitle(), webSearch, TAG);
 
         // Shout button
         getView().findViewById(R.id.buttonShouts).setOnClickListener(new OnClickListener() {

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/ServiceUtils.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/ServiceUtils.java
@@ -17,6 +17,7 @@
 
 package com.battlelancer.seriesguide.util;
 
+import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -80,8 +81,6 @@ public final class ServiceUtils {
     private static final String YOUTUBE_SEARCH = "http://www.youtube.com/results?search_query=%s";
 
     private static final String YOUTUBE_PACKAGE = "com.google.android.youtube";
-
-    private static final String WIKIPEDIA = "http://www.google.com/search?q=%s+Wikipedia+TV&btnI=745";
 
     private static ServiceManager sTraktServiceManagerInstance;
 
@@ -571,14 +570,14 @@ public final class ServiceUtils {
     }
 
     /**
-     * Used to search Wikipedia for <code>query</code>
+     * Used to search the web for <code>query</code>
      * 
      * @param query The search query for the YouTube app
      * @param button The {@link Button} used to invoke the
      *            {@link android.view.View.OnClickListener}
      * @param logTag The log tag to use, for Analytics
      */
-    public static void setUpWikipediaButton(final String query, View button, final String logTag) {
+    public static void setUpWebSearchButton(final String query, View button, final String logTag) {
         if (button == null) {
             // Return if the button isn't initialized
             return;
@@ -591,25 +590,24 @@ public final class ServiceUtils {
         button.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                searchWikipedia(v.getContext(), query, logTag);
+                performWebSearch(v.getContext(), query, logTag);
             }
         });
     }
 
     /**
-     * Attempts to search Wikipedia for <code>query</code> using a little Google
-     * search trick
+     * Attempts to search the web for <code>query</code>
      * 
      * @param context The {@link Context} to use
      * @param query The search query
      * @param logTag The log tag to use, for Analytics
      */
-    public static void searchWikipedia(Context context, String query, String logTag) {
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse(String.format(WIKIPEDIA, Uri.encode(query))));
+    public static void performWebSearch(Context context, String query, String logTag) {
+        Intent intent = new Intent(Intent.ACTION_WEB_SEARCH);
+        intent.putExtra(SearchManager.QUERY, query);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
         Utils.tryStartActivity(context, intent, true);
-        EasyTracker.getTracker().sendEvent(logTag, "Action Item", "Wikipedia search", (long) 0);
+        EasyTracker.getTracker().sendEvent(logTag, "Action Item", "Web search", (long) 0);
     }
 
 }

--- a/SeriesGuide/src/main/res/layout/services_more.xml
+++ b/SeriesGuide/src/main/res/layout/services_more.xml
@@ -32,14 +32,14 @@
         android:text="@string/trakt" />
 
     <Button
-        android:id="@+id/buttonWikipedia"
+        android:id="@+id/buttonWebSearch"
         style="@style/Widget.SeriesGuide.Button.Borderless.Default"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:gravity="center_vertical|left"
         android:paddingLeft="@dimen/default_padding"
         android:paddingRight="@dimen/default_padding"
-        android:text="@string/wikipedia" />
+        android:text="@string/web_search" />
 
     <Button
         android:id="@+id/buttonShouts"

--- a/SeriesGuide/src/main/res/values/donottranslate.xml
+++ b/SeriesGuide/src/main/res/values/donottranslate.xml
@@ -10,7 +10,6 @@
     <string name="tvdb">TVDb</string>
     <string name="tvdb_range">/10</string>
     <string name="trakt">trakt</string>
-    <string name="wikipedia">Wikipedia</string>
     <string name="powered_by_tmdb">powered by themoviedb.org</string>
     <string name="ontrakt">on trakt</string>
     <string name="getglue">GetGlue</string>

--- a/SeriesGuide/src/main/res/values/strings.xml
+++ b/SeriesGuide/src/main/res/values/strings.xml
@@ -514,8 +514,8 @@
 
     <!-- Add to Homescreen -->
     <string name="add_to_homescreen">Add to Home screen</string>
-    
+
     <!-- Search -->
     <string name="search_within_show">Search within %s</string>
-
+    <string name="web_search">Web search</string>
 </resources>


### PR DESCRIPTION
This adds a Wikipedia button to the "more"section of a show or episode. It doesn't directly search Wikipedia, but instead searches Google for "whatever" + "Wikipedia" + "TV", then opens the first search result; 9/10 this will be the correct Wikipedia link.

For instance:

[Searching for Homeland](http://www.google.com/search?q=Homeland+Wikipedia+TV&btnI=745)
[Searching for the first episode of this season](http://www.google.com/search?q=Homeland+Tin+Man+Is+Down+Wikipedia+TV&btnI=745)
[Searching for the upcoming episode of this season](http://www.google.com/search?q=Homeland+Uh...+Oh...+Ah...+Wikipedia+TV&btnI=745)

All of those links work as expected, producing a Wikipedia article. An example of it not working is: 

[Searching for the finale to the last season of Mad Men](http://www.google.com/search?q=Mad+Men+In+Care+Of+Wikipedia+TV&btnI=745)

It still produces a relevant article, just not from Wikipedia. I suppose instead of "Wikipedia" the button could simply say "Article", or the search could be even more refined, but I think it's fine the way it is. Thoughts?
