### PR TITLE
Fixing possible NPE in OverviewActivity.launchSearch

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewActivity.java
@@ -241,15 +241,15 @@ public class OverviewActivity extends BaseNavDrawerActivity {
         // refine search with the show's title
         final Series show = DBUtils.getShow(this, showTvdbId);
         if (show != null) {
-	    final String showTitle = show.getTitle();
+            final String showTitle = show.getTitle();
 
-	    Bundle appSearchData = new Bundle();
-	    appSearchData.putString(EpisodeSearchFragment.InitBundle.SHOW_TITLE, showTitle);
+            Bundle appSearchData = new Bundle();
+            appSearchData.putString(EpisodeSearchFragment.InitBundle.SHOW_TITLE, showTitle);
 
-	    Intent intent = new Intent(this, SearchActivity.class);
-	    intent.putExtra(SearchManager.APP_DATA, appSearchData);
-	    intent.setAction(Intent.ACTION_SEARCH);
-	    startActivity(intent);
+            Intent intent = new Intent(this, SearchActivity.class);
+            intent.putExtra(SearchManager.APP_DATA, appSearchData);
+            intent.setAction(Intent.ACTION_SEARCH);
+            startActivity(intent);
         }
     }
 }

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewActivity.java
@@ -240,14 +240,16 @@ public class OverviewActivity extends BaseNavDrawerActivity {
     private void launchSearch() {
         // refine search with the show's title
         final Series show = DBUtils.getShow(this, showTvdbId);
-        final String showTitle = show.getTitle();
+        if (show != null) {
+	    final String showTitle = show.getTitle();
 
-        Bundle appSearchData = new Bundle();
-        appSearchData.putString(EpisodeSearchFragment.InitBundle.SHOW_TITLE, showTitle);
+	    Bundle appSearchData = new Bundle();
+	    appSearchData.putString(EpisodeSearchFragment.InitBundle.SHOW_TITLE, showTitle);
 
-        Intent intent = new Intent(this, SearchActivity.class);
-        intent.putExtra(SearchManager.APP_DATA, appSearchData);
-        intent.setAction(Intent.ACTION_SEARCH);
-        startActivity(intent);
+	    Intent intent = new Intent(this, SearchActivity.class);
+	    intent.putExtra(SearchManager.APP_DATA, appSearchData);
+	    intent.setAction(Intent.ACTION_SEARCH);
+	    startActivity(intent);
+        }
     }
 }


### PR DESCRIPTION
DBUtils.getShow can return [null](https://github.com/UweTrottmann/SeriesGuide/blob/master/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/DBUtils.java#L391) and its return value is checked for null in other [places](https://github.com/UweTrottmann/SeriesGuide/blob/1596acfc4e59953eddb974270567306d2fec7bc2/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodesActivity.java#L164) where the method is called. This pull request fixes a possible NPE on an call to DBUtils.getShow where the return value is not checked for null before dereferencing.

Just to be clear, I identified this bug using a static analysis [tool](https://github.com/cuplv/hopper) that I have been developing and have not attempted to reproduce this issue while running the app.