### PR TITLE
Fixing possible NPEs when CheckInDialogFragment.newInstance returns null

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ActivityFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ActivityFragment.java
@@ -212,7 +212,9 @@ public class ActivityFragment extends Fragment implements
 
     public void checkInEpisode(int episodeTvdbId) {
         CheckInDialogFragment f = CheckInDialogFragment.newInstance(getActivity(), episodeTvdbId);
-        f.show(getFragmentManager(), "checkin-dialog");
+        if (f != null) {
+	    f.show(getFragmentManager(), "checkin-dialog");
+        }
     }
 
     private void updateEpisodeCollectionState(int showTvdbId, int episodeTvdbId, int seasonNumber,

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ActivityFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ActivityFragment.java
@@ -213,7 +213,7 @@ public class ActivityFragment extends Fragment implements
     public void checkInEpisode(int episodeTvdbId) {
         CheckInDialogFragment f = CheckInDialogFragment.newInstance(getActivity(), episodeTvdbId);
         if (f != null) {
-	    f.show(getFragmentManager(), "checkin-dialog");
+            f.show(getFragmentManager(), "checkin-dialog");
         }
     }
 

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
@@ -441,8 +441,8 @@ public class EpisodeDetailsFragment extends Fragment implements ActionsFragmentC
                 CheckInDialogFragment f = CheckInDialogFragment.newInstance(getActivity(),
                         episodeTvdbId);
                 if (f != null) {
-		    f.show(getFragmentManager(), "checkin-dialog");
-		    fireTrackerEvent("Check-In");
+                    f.show(getFragmentManager(), "checkin-dialog");
+                    fireTrackerEvent("Check-In");
                 }
             }
         });

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsFragment.java
@@ -440,8 +440,10 @@ public class EpisodeDetailsFragment extends Fragment implements ActionsFragmentC
                 // display a check-in dialog
                 CheckInDialogFragment f = CheckInDialogFragment.newInstance(getActivity(),
                         episodeTvdbId);
-                f.show(getFragmentManager(), "checkin-dialog");
-                fireTrackerEvent("Check-In");
+                if (f != null) {
+		    f.show(getFragmentManager(), "checkin-dialog");
+		    fireTrackerEvent("Check-In");
+                }
             }
         });
         CheatSheet.setup(mCheckinButton);

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/OverviewFragment.java
@@ -372,7 +372,9 @@ public class OverviewFragment extends Fragment implements
             // check in
             CheckInDialogFragment f = CheckInDialogFragment.newInstance(getActivity(),
                     episodeTvdbId);
-            f.show(getFragmentManager(), "checkin-dialog");
+            if (f != null) {
+                f.show(getFragmentManager(), "checkin-dialog");
+            }
         }
     }
 

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/QuickCheckInActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/QuickCheckInActivity.java
@@ -56,8 +56,12 @@ public class QuickCheckInActivity extends FragmentActivity {
             return;
         }
 
-        // show check-in dialog
         mCheckInDialogFragment = CheckInDialogFragment.newInstance(this, episodeTvdbId);
+        if (mCheckInDialogFragment == null) {
+	    finish();
+	    return;
+        }
+        // show check-in dialog
         mCheckInDialogFragment.show(getSupportFragmentManager(), "checkin-dialog");
     }
 

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/QuickCheckInActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/QuickCheckInActivity.java
@@ -58,8 +58,8 @@ public class QuickCheckInActivity extends FragmentActivity {
 
         mCheckInDialogFragment = CheckInDialogFragment.newInstance(this, episodeTvdbId);
         if (mCheckInDialogFragment == null) {
-	    finish();
-	    return;
+            finish();
+            return;
         }
         // show check-in dialog
         mCheckInDialogFragment.show(getSupportFragmentManager(), "checkin-dialog");


### PR DESCRIPTION
CheckinDialogFragment.newInstance can return [null](https://github.com/UweTrottmann/SeriesGuide/blob/2662ddd061f9c74df9b72451e6005ae02d2fb6b4/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/dialogs/CheckInDialogFragment.java#L40), but its return value is dereferenced without checked in several places. This pull request adds null checks in each place where this method is called.

Like #449, this bug was identified using a static analysis tool that I have been developing and I have not attempted to reproduce this issue while running the app.