### PR TITLE
Use a more poster friendly shortcut icon size

### DIFF
--- a/SeriesGuide/src/main/res/values/dimens.xml
+++ b/SeriesGuide/src/main/res/values/dimens.xml
@@ -81,7 +81,6 @@
     <dimen name="dialog_min_width">300dp</dimen>
     <dimen name="addpager_width">450dp</dimen>
     <dimen name="empty_view_width">250dp</dimen>
-    <dimen name="shortcut_icon_size">48dp</dimen>
     <dimen name="tab_padding_horizontal">12dp</dimen>
     <dimen name="search_padding_right">16dp</dimen>
 


### PR DESCRIPTION
This change removes the old shortcut icon size in favor of a more poster friendly size while also applying a nice round effect to the icons.

I basically just swapped the shortcut icon dimens with the poster dimens. I noticed that the poster dimens vary across a few densities, but there are actually only two variations. So, I'm not sure if you'd rather create a unique icon size for the shortcuts or just continue using the poster size. I mean:

**show_poster_width/height** is in:
* values/
* values-xlarge/
* values-xlarge-land/
* values-sw720dp/

But the sames dimens are used in all of the fancy values folder. So, maybe those could be cleaned up?

[The inspiration for it comes from this G+ post from this morning.](https://plus.google.com/+PavelAzroyan/posts/UiWpyCH52wT) Personally, I like the rounded corners a little more, but it's not like the `Picasso.Transformation` is necessary. 

Here's a screenshot of the change (I only tested this on a Nexus 6)

<img width="1420" alt="screen shot" src="https://cloud.githubusercontent.com/assets/489364/10265337/c9408d98-69f2-11e5-83ff-7caebd988378.png">