### PR TITLE
Add option to sort shows by their network

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/settings/ShowsDistillationSettings.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/settings/ShowsDistillationSettings.java
@@ -18,12 +18,12 @@ package com.battlelancer.seriesguide.settings;
 
 import android.content.Context;
 import android.preference.PreferenceManager;
+import com.battlelancer.seriesguide.ui.ShowsFragment;
 
 import static com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
 
 /**
- * Provides settings used to filter and sort displayed shows in
- * {@link com.battlelancer.seriesguide.ui.ShowsFragment}.
+ * Provides settings used to filter and sort displayed shows in {@link ShowsFragment}.
  */
 public class ShowsDistillationSettings {
 
@@ -49,6 +49,12 @@ public class ShowsDistillationSettings {
         if (sortOrderId == ShowsSortOrder.TITLE_REVERSE_ID) {
             query.append(isSortIgnoreArticles ?
                     ShowsSortOrder.TITLE_REVERSE_NOARTICLE : ShowsSortOrder.TITLE_REVERSE);
+        } else if (sortOrderId == ShowsSortOrder.NETWORK_ID) {
+            query.append(isSortIgnoreArticles ? ShowsSortOrder.NETWORK_NO_ARTICLE
+                    : ShowsSortOrder.NETWORK);
+        } else if (sortOrderId == ShowsSortOrder.NETWORK_REVERSE_ID) {
+            query.append(isSortIgnoreArticles ? ShowsSortOrder.NETWORK_REVERSE_NO_ARTICLE
+                    : ShowsSortOrder.NETWORK_REVERSE);
         } else if (sortOrderId == ShowsSortOrder.EPISODE_ID) {
             query.append(ShowsSortOrder.EPISODE);
         } else if (sortOrderId == ShowsSortOrder.EPISODE_REVERSE_ID) {
@@ -62,9 +68,7 @@ public class ShowsDistillationSettings {
     }
 
     /**
-     * Returns the id as of
-     * {@link com.battlelancer.seriesguide.settings.ShowsDistillationSettings.ShowsSortOrder}
-     * of the current show sort order.
+     * Returns the id as of {@link ShowsSortOrder} of the current show sort order.
      */
     public static int getSortOrderId(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getInt(KEY_SORT_ORDER, 0);
@@ -96,10 +100,12 @@ public class ShowsDistillationSettings {
     }
 
     /**
-     * Used by {@link com.battlelancer.seriesguide.ui.ShowsFragment} loader to sort the list of
-     * shows.
+     * Used by {@link ShowsFragment} loader to sort the list of shows.
      */
     public interface ShowsSortOrder {
+        // add as prefix to sort favorites first
+        String FAVORITES_FIRST_PREFIX = Shows.FAVORITE + " DESC,";
+
         // alphabetical by title
         String TITLE = Shows.TITLE + " COLLATE NOCASE ASC";
         // alphabetical by title
@@ -108,18 +114,29 @@ public class ShowsDistillationSettings {
         String TITLE_REVERSE = Shows.TITLE + " COLLATE NOCASE DESC";
         // reverse alphabetical by title
         String TITLE_REVERSE_NOARTICLE = Shows.TITLE_NOARTICLE + " COLLATE NOCASE DESC";
+
         // by next episode release time, oldest first
         String EPISODE = Shows.NEXTAIRDATEMS + " ASC," + Shows.STATUS + " DESC,"
                 + Shows.TITLE + " COLLATE NOCASE ASC";
         // by next episode release time, newest first
         String EPISODE_REVERSE = Shows.NEXTAIRDATEMS + " DESC," + Shows.STATUS + " DESC,"
                 + Shows.TITLE + " COLLATE NOCASE ASC";
-        // add as prefix to sort favorites first
-        String FAVORITES_FIRST_PREFIX = Shows.FAVORITE + " DESC,";
+
+        // Alphabetical by network and title
+        String NETWORK = Shows.NETWORK + " ASC," + TITLE;
+        // Reverse alphabetical by network and title
+        String NETWORK_REVERSE = Shows.NETWORK + " DESC," + TITLE_REVERSE;
+        // Alphabetical by network and title
+        String NETWORK_NO_ARTICLE = Shows.NETWORK + " ASC," + TITLE_NOARTICLE;
+        // Reverse alphabetical by network and title
+        String NETWORK_REVERSE_NO_ARTICLE = Shows.NETWORK + " DESC," + TITLE_REVERSE_NOARTICLE;
+
         // ids used for storing in preferences
         int TITLE_ID = 0;
         int TITLE_REVERSE_ID = 1;
         int EPISODE_ID = 2;
         int EPISODE_REVERSE_ID = 3;
+        int NETWORK_ID = 4;
+        int NETWORK_REVERSE_ID = 5;
     }
 }

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ShowsFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/ShowsFragment.java
@@ -28,7 +28,6 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
@@ -340,6 +339,16 @@ public class ShowsFragment extends Fragment implements
             changeSort();
 
             fireTrackerEventAction("Sort Title");
+            return true;
+        } else if (itemId == R.id.menu_action_shows_sort_network) {
+            if (mSortOrderId == ShowsDistillationSettings.ShowsSortOrder.NETWORK_ID) {
+                mSortOrderId = ShowsDistillationSettings.ShowsSortOrder.NETWORK_REVERSE_ID;
+            } else {
+                mSortOrderId = ShowsDistillationSettings.ShowsSortOrder.NETWORK_ID;
+            }
+            changeSort();
+
+            fireTrackerEventAction("Sort Network");
             return true;
         } else if (itemId == R.id.menu_action_shows_sort_episode) {
             if (mSortOrderId == ShowsDistillationSettings.ShowsSortOrder.EPISODE_ID) {

--- a/SeriesGuide/src/main/res/menu/shows_menu.xml
+++ b/SeriesGuide/src/main/res/menu/shows_menu.xml
@@ -55,6 +55,9 @@
                 android:id="@+id/menu_action_shows_sort_title"
                 android:title="@string/action_shows_sort_title" />
             <item
+                android:id="@+id/menu_action_shows_sort_network"
+                android:title="@string/action_shows_sort_network" />
+            <item
                 android:id="@+id/menu_action_shows_sort_episode"
                 android:title="@string/action_shows_sort_episode" />
             <item

--- a/SeriesGuide/src/main/res/values/strings.xml
+++ b/SeriesGuide/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="action_shows_filter_hidden">Hidden</string>
     <string name="action_shows_sort">Sort shows</string>
     <string name="action_shows_sort_title">Title</string>
+    <string name="action_shows_sort_network">Network</string>
     <string name="action_shows_sort_episode">Next episode</string>
     <string name="action_shows_sort_favorites">Favorites first</string>
     <string name="updateall_yes">Update (all)</string>


### PR DESCRIPTION
This change adds the option to sort shows by their network.

[Taken from this suggestion](https://seriesguide.uservoice.com/forums/189742-requests/suggestions/6485178-allow-to-sort-shows-by-network). I hadn't thought about this, but I kinda like it. What do you think?

Also, what do you think about appending an indicator for A-Z or Z-A ordering?

* Title (A-Z)
* Title (Z-A)
* etc