### PR TITLE
`ExtensionsConfigurationActivity` is exported.

### DIFF
--- a/SeriesGuide/src/main/AndroidManifest.xml
+++ b/SeriesGuide/src/main/AndroidManifest.xml
@@ -130,7 +130,8 @@
         </activity>
         <activity
             android:name="com.battlelancer.seriesguide.extensions.ExtensionsConfigurationActivity"
-            android:label="@string/action_extensions_configure" />
+            android:label="@string/action_extensions_configure"
+            android:exported="true" />
 
         <!-- Import and Export -->
         <activity


### PR DESCRIPTION
This is done because extension applications can open extension configuration Activity to guide users.