### PR TITLE
Shared element transitions improvements

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/MoviesAdapter.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/MoviesAdapter.java
@@ -106,7 +106,7 @@ public class MoviesAdapter extends ArrayAdapter<Movie> {
 
         // set unique transition names
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            holder.poster.setTransitionName("moviesAdapterPoster_" + position);
+            holder.poster.setTransitionName("moviesAdapterPoster_" + movieTmdbId);
         }
 
         return convertView;

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/MoviesCursorAdapter.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/MoviesCursorAdapter.java
@@ -106,7 +106,7 @@ public class MoviesCursorAdapter extends CursorAdapter {
         // set unique transition names
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             holder.poster.setTransitionName(
-                    "moviesCursorAdapterPoster_" + uniqueId + "_" + cursor.getPosition());
+                    "moviesCursorAdapterPoster_" + uniqueId + "_" + movieTmdbId);
         }
     }
 

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/PeopleAdapter.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/PeopleAdapter.java
@@ -68,7 +68,7 @@ public class PeopleAdapter extends ArrayAdapter<PeopleListHelper.Person> {
 
         // set unique transition names
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            viewHolder.headshot.setTransitionName("peopleAdapterPoster_" + position);
+            viewHolder.headshot.setTransitionName("peopleAdapterPoster_" + person.tmdbId);
         }
 
         return convertView;

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/MoviesActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/MoviesActivity.java
@@ -1,5 +1,7 @@
 package com.battlelancer.seriesguide.ui;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.view.ViewPager;
@@ -38,6 +40,20 @@ public class MoviesActivity extends BaseTopActivity {
 
         setupViews(savedInstanceState);
         setupSyncProgressBar(R.id.progressBarTabs);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (savedInstanceState != null) {
+                postponeEnterTransition();
+                viewPager.post(new Runnable() {
+                    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+                    @Override
+                    public void run() {
+                        // Allow the adapters to repopulate during the next layout pass before starting the transition animation
+                        startPostponedEnterTransition();
+                    }
+                });
+            }
+        }
     }
 
     private void setupViews(Bundle savedInstanceState) {


### PR DESCRIPTION
These commits fix 2 issues with the poster shared element transitions:

1) The adapter position is replaced with a stable id for the transition name. This allows to match the correct poster even if the items have changed position after the activity has been re-created.

2) When MoviesActivity is re-created, the transition is postponed until after the next layout pass. This gives a chance to the adapters to repopulate the posters, since adapter population is asynchronous. Thanks to this, the poster animation will also work properly after changing the orientation in the details page then navigating back to MoviesActivity, which doesn't work currently.