### PR TITLE
[EpisodeDetailsActivity] Fixed current season not being restored properly

### DIFF
--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsActivity.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodeDetailsActivity.java
@@ -75,12 +75,21 @@ public class EpisodeDetailsActivity extends BaseNavDrawerActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         noSavedInstanceState = savedInstanceState == null;
+        if (!noSavedInstanceState) {
+            seasonTvdbId = savedInstanceState.getInt(ARGS_SEASON_TVDB_ID, 0);
+        }
 
         setContentView(R.layout.activity_episode);
         setupActionBar();
         setupNavDrawer();
 
         setupViews();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(ARGS_SEASON_TVDB_ID, seasonTvdbId);
     }
 
     @Override
@@ -197,9 +206,6 @@ public class EpisodeDetailsActivity extends BaseNavDrawerActivity {
         // set up season switcher
         spinnerAdapter = new SeasonSpinnerAdapter(this, basicInfo.seasonsOfShow);
         toolbarSpinner.setAdapter(spinnerAdapter);
-        // if there is saved state the spinner will restore the last selection (for example on
-        // config changes)
-        // this listener will be called and automatically re-load the last shown season
         toolbarSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -228,6 +234,19 @@ public class EpisodeDetailsActivity extends BaseNavDrawerActivity {
             // ...and schedule a show update
             if (showTvdbId != 0) {
                 updateShowDelayed(showTvdbId);
+            }
+        } else {
+            // Restore previously selected season manually:
+            // Spinner will attempt to restore the last selection automatically but will only
+            // succeed if the data has already been loaded when the spinner is laid out for the
+            // first time.
+            for (int i = 0, size = basicInfo.seasonsOfShow.size(); i < size; i++) {
+                Season season = basicInfo.seasonsOfShow.get(i);
+                if (season.tvdbId == seasonTvdbId) {
+                    loadSeason(season, showTitle);
+                    toolbarSpinner.setSelection(i, false);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Recently I noticed a bug when using the app: I left the app open in `EpisodeDetailsActivity` then came back much later to it. The Activity had been fully unloaded from memory and restored improperly: it was still showing the correct episode but the season was wrong.

To reproduce the issue, simply check "don't preserve activities" in the phone's developer options, navigate to an episode in `EpisodeDetailsActivity`, switch to another app then go back to it. Notice the season has changed and is now the first one in the list (the last season of the show) which leads to a confusing display where the current episode appears to be part of another season.

The bug is due to how Spinner works: it tries to restore the selection during its first layout pass, then stops trying. So when changing the orientation, because the loader sends back the previous data immediately, the spinner is able to restore the correct position, but in other cases, when we need to wait for the initial loader's data to be returned a bit later (after the Spinner has been laid out), the Spinner will select position 0 instead.

This is a fix which restores the season manually by saving and restoring the `seasonTvdbId` variable.