### PR TITLE
Fix "Set all older watched"

### DIFF
--- a/SeriesGuide/build.gradle
+++ b/SeriesGuide/build.gradle
@@ -123,6 +123,10 @@ android {
             pseudoLocalesEnabled false
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 endpointsClient {
@@ -215,6 +219,9 @@ dependencies {
     amazonCompile files('libs/amazon/in-app-purchasing-2.0.76.jar')
 
     // Instrumented unit tests
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2') {
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
     androidTestCompile "com.android.support:support-annotations:$supportVersion"
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'

--- a/SeriesGuide/src/androidTest/java/com/battlelancer/seriesguide/ui/SetAllOlderWatchedTest.java
+++ b/SeriesGuide/src/androidTest/java/com/battlelancer/seriesguide/ui/SetAllOlderWatchedTest.java
@@ -1,0 +1,135 @@
+package com.battlelancer.seriesguide.ui;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.view.*;
+import com.battlelancer.seriesguide.R;
+import com.battlelancer.seriesguide.enums.EpisodeFlags;
+import com.battlelancer.seriesguide.widgets.WatchedBox;
+import org.hamcrest.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.*;
+import static android.support.test.espresso.assertion.ViewAssertions.*;
+import static android.support.test.espresso.matcher.CursorMatchers.*;
+import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static org.hamcrest.Matchers.*;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class SetAllOlderWatchedTest {
+
+    @Rule
+    public ActivityTestRule<ShowsActivity> mActivityTestRule = new ActivityTestRule<>(
+            ShowsActivity.class);
+
+    @Test
+    public void tvSeriesTest () throws InterruptedException {
+        seriesTest("Game of Thrones");
+    }
+
+    @Test
+    public void netflixSeriesTest() throws InterruptedException {
+        seriesTest("Sense8");
+    }
+
+    private void seriesTest(String title) throws InterruptedException {
+
+        onView(allOf(withId(R.id.buttonShowsAdd), withContentDescription(R.string.action_shows_add)))
+                .perform(click());
+
+        onView(withId(R.id.editTextSearchBar))
+                .perform(click());
+
+        onView(withId(R.id.editTextSearchBar))
+                .perform(replaceText(title), closeSoftKeyboard(), pressImeActionButton());
+
+        onView(childAtPosition(
+                allOf(withId(android.R.id.list),
+                        withParent(withId(R.id.containerAddContent))), 0))
+                .perform(click());
+
+        onView(allOf(withId(R.id.buttonPositive), withText(R.string.action_shows_add)))
+                .perform(click());
+
+        goBack();
+
+        Thread.sleep(1000);
+
+        onData(withRowString("seriestitle", startsWith(title)))
+                .perform(click());
+
+        Thread.sleep(1000);
+
+        onView(allOf(withId(R.id.pagerOverview),
+                        withParent(allOf(withId(R.id.coordinatorLayoutOverview),
+                                withParent(withId(R.id.drawer_layout))))))
+                .perform(swipeLeft());
+
+        onData(withRowInt("combinednr", 1)) // season 1
+                .perform(click());
+
+        Thread.sleep(1000);
+
+        onData(withRowInt("episodenumber", 3))
+                .onChildView(withContentDescription(R.string.description_menu_overflow))
+                .perform(click());
+
+        onView(allOf(withId(android.R.id.title), withText(R.string.mark_untilhere)))
+                .perform(click());
+
+        onData(withRowInt("episodenumber", 1))
+                .onChildView(Matchers.<View>instanceOf(WatchedBox.class))
+                .check(matches(new CustomTypeSafeMatcher<View>("WatchedBox flagged as Watched") {
+                    @Override
+                    protected boolean matchesSafely(View view) {
+                        return ((WatchedBox) view).getEpisodeFlag() == EpisodeFlags.WATCHED;
+                    }
+                }));
+
+        goBack();
+
+        goBack();
+
+        onData(withRowString("seriestitle", startsWith(title)))
+                .onChildView(withContentDescription(R.string.description_menu_overflow))
+                .perform(click());
+
+        onView(allOf(withId(android.R.id.title), withText(R.string.delete_show)))
+                .perform(click());
+
+        onView(allOf(withId(R.id.buttonPositive), withText(R.string.delete_show)))
+                .perform(click());
+
+    }
+
+    private static void goBack() {
+        onView(allOf(withContentDescription("Navigate up"),
+                withParent(withId(R.id.sgToolbar))))
+                .perform(click());
+    }
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/EpisodesAdapter.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/adapters/EpisodesAdapter.java
@@ -31,7 +31,7 @@ public class EpisodesAdapter extends CursorAdapter {
 
     public interface PopupMenuClickListener {
         void onPopupMenuClick(View v, int episodeTvdbId, int episodeNumber,
-                long releaseTimeMs, int watchedFlag, boolean isCollected);
+                int absoluteNumber, int watchedFlag, boolean isCollected);
     }
 
     private PopupMenuClickListener popupMenuClickListener;
@@ -120,7 +120,7 @@ public class EpisodesAdapter extends CursorAdapter {
 
         // alternative numbers
         StringBuilder altNumbers = new StringBuilder();
-        int absoluteNumber = mCursor.getInt(EpisodesQuery.ABSOLUTE_NUMBER);
+        final int absoluteNumber = mCursor.getInt(EpisodesQuery.ABSOLUTE_NUMBER);
         if (absoluteNumber > 0) {
             altNumbers.append(mContext.getString(R.string.episode_number_absolute)).append(" ")
                     .append(absoluteNumber);
@@ -164,7 +164,7 @@ public class EpisodesAdapter extends CursorAdapter {
             public void onClick(View v) {
                 if (popupMenuClickListener != null) {
                     popupMenuClickListener.onPopupMenuClick(v, episodeId, episodeNumber,
-                            releaseTime, watchedFlag, isCollected);
+                            absoluteNumber, watchedFlag, isCollected);
                 }
             }
         });

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodesFragment.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/ui/EpisodesFragment.java
@@ -190,7 +190,7 @@ public class EpisodesFragment extends ListFragment
 
     @Override
     public void onPopupMenuClick(View v, final int episodeTvdbId, final int episodeNumber,
-            final long releaseTimeMs, final int watchedFlag, final boolean isCollected) {
+            final int absoluteNumber, final int watchedFlag, final boolean isCollected) {
         PopupMenu popupMenu = new PopupMenu(v.getContext(), v);
         popupMenu.inflate(R.menu.episodes_popup_menu);
 
@@ -239,7 +239,7 @@ public class EpisodesFragment extends ListFragment
                         return true;
                     }
                     case R.id.menu_action_episodes_watched_previous: {
-                        onMarkUntilHere(releaseTimeMs);
+                        onMarkUntilHere(absoluteNumber);
                         Utils.trackContextMenu(getActivity(), TAG, "Flag previously aired");
                         return true;
                     }
@@ -275,9 +275,9 @@ public class EpisodesFragment extends ListFragment
                 getSeasonNumber(), episode, isCollected);
     }
 
-    private void onMarkUntilHere(long episodeFirstReleaseMs) {
+    private void onMarkUntilHere(int episodeAbsoluteNumber) {
         EpisodeTools.episodeWatchedPrevious(SgApp.from(getActivity()), getShowId(),
-                episodeFirstReleaseMs);
+                episodeAbsoluteNumber);
     }
 
     private LoaderManager.LoaderCallbacks<Cursor> mLoaderCallbacks

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/EpisodeTools.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/EpisodeTools.java
@@ -122,10 +122,10 @@ public class EpisodeTools {
      * release date).
      */
     public static void episodeWatchedPrevious(SgApp app, int showTvdbId,
-            long episodeFirstAired) {
+            int episodeAbsoluteNumber) {
         execute(app,
                 new EpisodeTaskTypes.EpisodeWatchedPreviousType(app, showTvdbId,
-                        episodeFirstAired)
+                        episodeAbsoluteNumber)
         );
     }
 

--- a/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/tasks/EpisodeTaskTypes.java
+++ b/SeriesGuide/src/main/java/com/battlelancer/seriesguide/util/tasks/EpisodeTaskTypes.java
@@ -716,12 +716,12 @@ public class EpisodeTaskTypes {
 
     public static class EpisodeWatchedPreviousType extends FlagType {
 
-        private long episodeFirstAired;
+        private long episodeAbsoluteNumber;
 
-        public EpisodeWatchedPreviousType(Context context, int showTvdbId, long episodeFirstAired) {
+        public EpisodeWatchedPreviousType(Context context, int showTvdbId, int episodeAbsoluteNumber) {
             super(context, showTvdbId, EpisodeFlags.WATCHED,
                     Action.EPISODE_WATCHED_PREVIOUS);
-            this.episodeFirstAired = episodeFirstAired;
+            this.episodeAbsoluteNumber = episodeAbsoluteNumber;
         }
 
         @Override
@@ -736,7 +736,7 @@ public class EpisodeTaskTypes {
             // - be released before current episode,
             // - have a release date,
             // - be unwatched or skipped
-            return SeriesGuideContract.Episodes.FIRSTAIREDMS + "<" + episodeFirstAired
+            return SeriesGuideContract.Episodes.ABSOLUTE_NUMBER + "<" + episodeAbsoluteNumber
                     + " AND " + SeriesGuideContract.Episodes.SELECTION_HAS_RELEASE_DATE
                     + " AND " + SeriesGuideContract.Episodes.SELECTION_UNWATCHED_OR_SKIPPED;
         }


### PR DESCRIPTION
This adds some [Espresso](https://google.github.io/android-testing-support-library/docs/espresso/index.html) tests and the fix to #463. It changes the WHERE clause to compare the absolute episode number, instead of the release time (important in Netflix shows, for example).