### PR TITLE
WIP Replace textIsSelectable="true" with long-click to copy to clipboard

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
@@ -57,6 +57,7 @@ import com.battlelancer.seriesguide.ui.FullscreenImageActivity;
 import com.battlelancer.seriesguide.ui.SeriesGuidePreferences;
 import com.battlelancer.seriesguide.ui.comments.TraktCommentsActivity;
 import com.battlelancer.seriesguide.ui.lists.ManageListsDialogFragment;
+import com.battlelancer.seriesguide.util.ClipboardTools;
 import com.battlelancer.seriesguide.util.LanguageTools;
 import com.battlelancer.seriesguide.util.ServiceUtils;
 import com.battlelancer.seriesguide.util.ShareUtils;
@@ -191,6 +192,16 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         ViewTools.setVectorIconLeft(theme, imdbButton, R.drawable.ic_link_black_24dp);
         ViewTools.setVectorIconLeft(theme, tvdbButton, R.drawable.ic_link_black_24dp);
         ViewTools.setVectorIconLeft(theme, traktButton, R.drawable.ic_link_black_24dp);
+
+        // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewTitle);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewReleaseTime);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewDescription);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewGuestStars);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewDirectors);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewWriters);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewDvd);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewReleaseDate);
 
         return v;
     }
@@ -528,6 +539,8 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         boolean isConnectedToTrakt = TraktCredentials.get(requireContext()).hasCredentials();
         boolean displayCheckIn = isConnectedToTrakt && !HexagonSettings.isEnabled(requireContext());
         buttonCheckin.setVisibility(displayCheckIn ? View.VISIBLE : View.GONE);
+        buttonJustWatch
+                .setNextFocusUpId(displayCheckIn ? R.id.buttonCheckIn : R.id.buttonEpisodeWatched);
         // hide JustWatch if turned off
         boolean displayJustWatch = !JustWatchSearch.isTurnedOff(requireContext());
         buttonJustWatch.setVisibility(displayJustWatch ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.java
@@ -61,6 +61,7 @@ import com.battlelancer.seriesguide.ui.comments.TraktCommentsActivity;
 import com.battlelancer.seriesguide.ui.dialogs.LanguageChoiceDialogFragment;
 import com.battlelancer.seriesguide.ui.people.MovieCreditsLoader;
 import com.battlelancer.seriesguide.ui.people.PeopleListHelper;
+import com.battlelancer.seriesguide.util.ClipboardTools;
 import com.battlelancer.seriesguide.util.LanguageTools;
 import com.battlelancer.seriesguide.util.ServiceUtils;
 import com.battlelancer.seriesguide.util.ShareUtils;
@@ -194,6 +195,12 @@ public class MovieDetailsFragment extends Fragment implements MovieActionsContra
         // cast and crew
         setCastVisibility(false);
         setCrewVisibility(false);
+
+        // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewMovieTitle);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewMovieDate);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewMovieDescription);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewMovieGenres);
 
         return view;
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
@@ -67,6 +67,7 @@ import com.battlelancer.seriesguide.ui.episodes.EpisodeTools;
 import com.battlelancer.seriesguide.ui.episodes.EpisodesActivity;
 import com.battlelancer.seriesguide.ui.lists.ManageListsDialogFragment;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
+import com.battlelancer.seriesguide.util.ClipboardTools;
 import com.battlelancer.seriesguide.util.DBUtils;
 import com.battlelancer.seriesguide.util.LanguageTools;
 import com.battlelancer.seriesguide.util.ServiceUtils;
@@ -200,6 +201,11 @@ public class OverviewFragment extends Fragment implements
         ViewTools.setVectorIconLeft(theme, buttonImdb, R.drawable.ic_link_black_24dp);
         ViewTools.setVectorIconLeft(theme, buttonTvdb, R.drawable.ic_link_black_24dp);
         ViewTools.setVectorIconLeft(theme, buttonTrakt, R.drawable.ic_link_black_24dp);
+
+        // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
+        ClipboardTools.copyTextToClipboardOnLongClick(textDescription);
+        ClipboardTools.copyTextToClipboardOnLongClick(textGuestStars);
+        ClipboardTools.copyTextToClipboardOnLongClick(textDvdNumber);
 
         return v;
     }
@@ -644,6 +650,8 @@ public class OverviewFragment extends Fragment implements
             boolean displayCheckIn = isConnectedToTrakt
                     && !HexagonSettings.isEnabled(getActivity());
             buttonCheckin.setVisibility(displayCheckIn ? View.VISIBLE : View.GONE);
+            buttonJustWatch.setNextFocusUpId(
+                    displayCheckIn ? R.id.buttonCheckIn : R.id.buttonEpisodeWatched);
             // hide JustWatch if turned off
             boolean displayJustWatch = !JustWatchSearch.isTurnedOff(requireContext());
             buttonJustWatch.setVisibility(displayJustWatch ? View.VISIBLE : View.GONE);
@@ -925,6 +933,8 @@ public class OverviewFragment extends Fragment implements
         }
         TextView textViewNetworkAndTime = getView().findViewById(R.id.showmeta);
         textViewNetworkAndTime.setText(TextTools.dotSeparate(network, time));
+        // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewNetworkAndTime);
 
         // episode description might need show language, so update it here as well
         populateEpisodeDescriptionAndTvdbButton();

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.java
@@ -47,6 +47,7 @@ import com.battlelancer.seriesguide.ui.lists.ManageListsDialogFragment;
 import com.battlelancer.seriesguide.ui.people.PeopleListHelper;
 import com.battlelancer.seriesguide.ui.people.ShowCreditsLoader;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
+import com.battlelancer.seriesguide.util.ClipboardTools;
 import com.battlelancer.seriesguide.util.LanguageTools;
 import com.battlelancer.seriesguide.util.ServiceUtils;
 import com.battlelancer.seriesguide.util.ShareUtils;
@@ -195,6 +196,13 @@ public class ShowFragment extends Fragment {
 
         setCastVisibility(false);
         setCrewVisibility(false);
+
+        // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewOverview);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewGenres);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewContentRating);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewReleaseCountry);
+        ClipboardTools.copyTextToClipboardOnLongClick(textViewFirstRelease);
 
         return v;
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ClipboardTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ClipboardTools.kt
@@ -1,0 +1,30 @@
+@file:JvmName("ClipboardTools")
+
+package com.battlelancer.seriesguide.util
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import com.battlelancer.seriesguide.R
+
+private val onLongClickListener = View.OnLongClickListener {
+    if (it is TextView) {
+        val clip = ClipData.newPlainText("text", it.text)
+        val clipboard = it.getContext().getSystemService(
+                Context.CLIPBOARD_SERVICE) as ClipboardManager?
+        if (clipboard != null) {
+            clipboard.primaryClip = clip
+            Toast.makeText(it.getContext(), R.string.copy_to_clipboard,
+                    Toast.LENGTH_SHORT).show()
+            return@OnLongClickListener true
+        }
+    }
+    return@OnLongClickListener false
+}
+
+fun TextView.copyTextToClipboardOnLongClick() {
+    setOnLongClickListener(onLongClickListener)
+}

--- a/app/src/main/res/layout-w1024dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w1024dp/fragment_movie.xml
@@ -30,13 +30,10 @@
             android:clipToPadding="false"
             android:paddingTop="?attr/actionBarSize">
 
-            <!-- Make container focusable to prevent ScrollView from scrolling to selectable TextViews. -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:animateLayoutChanges="true"
-                android:descendantFocusability="beforeDescendants"
-                android:focusableInTouchMode="true"
                 android:orientation="horizontal">
 
                 <RelativeLayout
@@ -80,8 +77,9 @@
                             android:layout_marginRight="@dimen/large_padding"
                             android:layout_marginTop="@dimen/inline_padding"
                             android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                            android:background="?attr/selectableItemBackground"
+                            android:focusable="true"
                             android:textAppearance="@style/TextAppearance.Headline"
-                            android:textIsSelectable="true"
                             tools:text="Awesome Movie Title" />
 
                         <TextView
@@ -93,8 +91,9 @@
                             android:layout_marginLeft="@dimen/default_padding"
                             android:layout_marginRight="@dimen/large_padding"
                             android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                            android:background="?attr/selectableItemBackground"
+                            android:focusable="true"
                             android:textAppearance="@style/TextAppearance.Caption"
-                            android:textIsSelectable="true"
                             tools:text="20 Oct 2013" />
 
                     </RelativeLayout>
@@ -145,8 +144,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/buttonMovieLanguage"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Body"
-                        android:textIsSelectable="true"
                         tools:text="Description for a super awesome movie..." />
 
                     <TextView
@@ -164,8 +164,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/textViewMovieGenresLabel"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Body"
-                        android:textIsSelectable="true"
                         tools:text="Action, Comedy, Drama" />
 
                     <View

--- a/app/src/main/res/layout-w590dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w590dp/fragment_movie.xml
@@ -30,13 +30,10 @@
             android:clipToPadding="false"
             android:paddingTop="?attr/actionBarSize">
 
-            <!-- Make container focusable to prevent ScrollView from scrolling to selectable TextViews. -->
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:animateLayoutChanges="true"
-                android:descendantFocusability="beforeDescendants"
-                android:focusableInTouchMode="true"
                 android:paddingBottom="@dimen/default_padding"
                 android:paddingTop="@dimen/default_padding">
 
@@ -73,8 +70,9 @@
                         android:layout_marginRight="@dimen/large_padding"
                         android:layout_marginTop="@dimen/inline_padding"
                         android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Headline"
-                        android:textIsSelectable="true"
                         tools:text="Awesome Movie Title" />
 
                     <TextView
@@ -86,8 +84,9 @@
                         android:layout_marginLeft="@dimen/default_padding"
                         android:layout_marginRight="@dimen/large_padding"
                         android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Caption"
-                        android:textIsSelectable="true"
                         tools:text="20 Oct 2013" />
 
                     <include
@@ -122,8 +121,9 @@
                         style="@style/Block.FlowText"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Body"
-                        android:textIsSelectable="true"
                         tools:text="Description for a super awesome movie..." />
 
                     <TextView
@@ -139,8 +139,9 @@
                         style="@style/Block"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Body"
-                        android:textIsSelectable="true"
                         tools:text="Action, Comedy, Drama" />
 
                     <View

--- a/app/src/main/res/layout/buttons_episode.xml
+++ b/app/src/main/res/layout/buttons_episode.xml
@@ -76,6 +76,7 @@
         android:contentDescription="@string/checkin"
         android:drawablePadding="8dp"
         android:gravity="center_vertical|start"
+        android:nextFocusUp="@+id/buttonEpisodeWatched"
         android:text="@string/checkin"
         tools:drawableLeft="@drawable/ic_checkin_black_24dp"
         tools:drawableTint="?attr/sgColorIcon" />

--- a/app/src/main/res/layout/fragment_movie.xml
+++ b/app/src/main/res/layout/fragment_movie.xml
@@ -21,13 +21,10 @@
         android:clipToPadding="false"
         android:paddingTop="?attr/actionBarSize">
 
-        <!-- Make container focusable to prevent ScrollView from scrolling to selectable TextViews. -->
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:animateLayoutChanges="true"
-            android:descendantFocusability="beforeDescendants"
-            android:focusableInTouchMode="true"
             android:paddingBottom="@dimen/default_padding"
             android:paddingTop="@dimen/default_padding"
             tools:ignore="RtlHardcoded">
@@ -66,8 +63,9 @@
                     android:layout_marginRight="@dimen/large_padding"
                     android:layout_marginTop="@dimen/default_padding"
                     android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                    android:background="?attr/selectableItemBackground"
+                    android:focusable="true"
                     android:textAppearance="@style/TextAppearance.Title"
-                    android:textIsSelectable="true"
                     tools:text="Awesome Movie Title" />
 
                 <TextView
@@ -79,8 +77,9 @@
                     android:layout_marginLeft="@dimen/default_padding"
                     android:layout_marginRight="@dimen/large_padding"
                     android:layout_toRightOf="@id/frameLayoutMoviePoster"
+                    android:background="?attr/selectableItemBackground"
+                    android:focusable="true"
                     android:textAppearance="@style/TextAppearance.Caption"
-                    android:textIsSelectable="true"
                     tools:text="20 Oct 2013" />
 
             </RelativeLayout>
@@ -119,8 +118,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/buttonMovieLanguage"
+                android:background="?attr/selectableItemBackground"
+                android:focusable="true"
                 android:textAppearance="@style/TextAppearance.Body"
-                android:textIsSelectable="true"
                 tools:text="Description for a super awesome movie..." />
 
             <View
@@ -167,8 +167,9 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/textViewMovieGenresLabel"
                 android:layout_marginBottom="@dimen/large_padding"
+                android:background="?attr/selectableItemBackground"
+                android:focusable="true"
                 android:textAppearance="@style/TextAppearance.Body"
-                android:textIsSelectable="true"
                 tools:text="Action, Comedy, Drama" />
 
             <LinearLayout

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -23,14 +23,10 @@
         android:nestedScrollingEnabled="true"
         tools:ignore="UnusedAttribute">
 
-        <!-- Set focus to work around textIsSelectable auto-scroll -->
         <LinearLayout
             android:id="@+id/overview_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:descendantFocusability="beforeDescendants"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
             android:orientation="vertical"
             android:paddingTop="@dimen/default_padding">
 
@@ -64,8 +60,9 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/showStatus"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
                         android:textAppearance="@style/TextAppearance.Body"
-                        android:textIsSelectable="true"
                         tools:text="Tue 5:00 AM on CBS" />
                 </RelativeLayout>
 
@@ -114,6 +111,7 @@
                         android:layout_marginRight="@dimen/large_padding"
                         android:layout_marginTop="@dimen/default_padding"
                         android:foreground="?attr/selectableItemBackground"
+                        android:nextFocusDown="@+id/buttonEpisodeWatched"
                         app:cardBackgroundColor="?attr/sgColorBackgroundCard"
                         app:cardPreventCornerOverlap="false">
 
@@ -206,8 +204,9 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginBottom="@dimen/large_padding"
+                            android:background="?attr/selectableItemBackground"
+                            android:focusable="true"
                             android:textAppearance="@style/TextAppearance.Body"
-                            android:textIsSelectable="true"
                             tools:text="This is a sample description of what happens in this episode. A lot." />
 
                         <View
@@ -239,8 +238,9 @@
                             style="@style/Block.FlowText"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:textAppearance="@style/TextAppearance.Body"
-                            android:textIsSelectable="true" />
+                            android:background="?attr/selectableItemBackground"
+                            android:focusable="true"
+                            android:textAppearance="@style/TextAppearance.Body" />
 
                         <TextView
                             android:id="@+id/labelDvd"
@@ -255,6 +255,8 @@
                             style="@style/Block"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:background="?attr/selectableItemBackground"
+                            android:focusable="true"
                             android:textAppearance="@style/TextAppearance.Body" />
 
                         <View

--- a/app/src/main/res/layout/fragment_show_meta.xml
+++ b/app/src/main/res/layout/fragment_show_meta.xml
@@ -16,8 +16,9 @@
         style="@style/Block.FlowText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="A multi-line description of this show. Which is rather lenghty." />
 
     <View
@@ -55,8 +56,9 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true" />
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:textAppearance="@style/TextAppearance.Body" />
 
     <TextView
         style="@style/Block.WithTopMargin"
@@ -70,8 +72,9 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true" />
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:textAppearance="@style/TextAppearance.Body" />
 
     <TextView
         style="@style/Block.WithTopMargin"
@@ -85,8 +88,9 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true" />
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:textAppearance="@style/TextAppearance.Body" />
 
     <TextView
         style="@style/Block.WithTopMargin"
@@ -100,7 +104,8 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true" />
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:textAppearance="@style/TextAppearance.Body" />
 
 </merge>

--- a/app/src/main/res/layout/fragment_show_narrow.xml
+++ b/app/src/main/res/layout/fragment_show_narrow.xml
@@ -6,13 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- Set focus to work around textIsSelectable auto-scroll -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="beforeDescendants"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
         android:orientation="vertical"
         android:paddingBottom="@dimen/large_padding">
 

--- a/app/src/main/res/layout/fragment_show_regular.xml
+++ b/app/src/main/res/layout/fragment_show_regular.xml
@@ -10,13 +10,9 @@
     android:nestedScrollingEnabled="true"
     tools:ignore="UnusedAttribute">
 
-    <!-- Set focus to work around textIsSelectable auto-scroll -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="beforeDescendants"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
         android:orientation="vertical"
         android:paddingBottom="@dimen/large_padding">
 

--- a/app/src/main/res/layout/layout_episode.xml
+++ b/app/src/main/res/layout/layout_episode.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Set focus to work around textIsSelectable auto-scroll -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/containerEpisode"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:descendantFocusability="beforeDescendants"
-    android:focusable="true"
-    android:focusableInTouchMode="true"
     android:orientation="vertical"
     tools:showIn="@layout/fragment_episode">
 
@@ -21,8 +17,10 @@
         android:layout_marginLeft="@dimen/large_padding"
         android:layout_marginRight="@dimen/large_padding"
         android:layout_marginTop="12dp"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:nextFocusDown="@+id/textViewEpisodeReleaseTime"
         android:textAppearance="@style/TextAppearance.Title"
-        android:textIsSelectable="true"
         tools:text="Episode Title Of Episode" />
 
     <!-- Text appearance set in code. -->
@@ -32,8 +30,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/large_padding"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:nextFocusDown="@+id/containerEpisodeImage"
+        android:nextFocusUp="@+id/textViewEpisodeTitle"
         android:textAppearance="@style/TextAppearance.Caption"
-        android:textIsSelectable="true"
         tools:text="OCT 15, 2013 (TUE) · 52" />
 
     <android.support.constraint.ConstraintLayout
@@ -46,6 +47,8 @@
         android:background="?attr/sgColorBackgroundDim"
         android:focusable="true"
         android:foreground="?attr/selectableItemBackground"
+        android:nextFocusDown="@+id/buttonEpisodeWatched"
+        android:nextFocusUp="@+id/textViewEpisodeReleaseTime"
         tools:ignore="Overdraw">
 
         <ImageView
@@ -78,8 +81,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/large_padding"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="This is a sample description of what happens in this episode. A lot." />
 
     <View
@@ -111,8 +115,9 @@
         style="@style/Block.FlowText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="Daniel Craig, Jaimie Alexander, Kiefer Sutherland, Stephanie Leonidas" />
 
     <TextView
@@ -128,8 +133,9 @@
         style="@style/Block.FlowText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="Daniel Craig" />
 
     <TextView
@@ -145,8 +151,9 @@
         style="@style/Block.FlowText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="Daniel Craig, Jaimie Alexander" />
 
     <TextView
@@ -162,8 +169,9 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="42.0" />
 
     <TextView
@@ -179,8 +187,9 @@
         style="@style/Block"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
         android:textAppearance="@style/TextAppearance.Body"
-        android:textIsSelectable="true"
         tools:text="2014/07/25 CEST (Fri)" />
 
     <View

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">حاول أخد نسخة احتياطية، اعادة تثبيت البرنامج ومن ثم استعادة البيانات</string>
   <string name="api_error_generic">لا يمكن الاتصال ب %s. الرجاء المحاولة لاحقا.</string>
   <string name="api_failed">فشل: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">مشاركة</string>
   <string name="share_show">مشاركة المسلسل</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Опитайте се да архивирате от настройките, преинсталирайте и възстановете.</string>
   <string name="api_error_generic">Няма връзка с %s. trakt. Опитайте отново по-късно.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Сподели</string>
   <string name="share_show">Сподели ТВ предаване</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Intenta fer un backup en el panell de Configuraciò, torneu a instal·lar i restaurar.</string>
   <string name="api_error_generic">No és possible contactar amb %s. Proveu-ho més tard.</string>
   <string name="api_failed">Ha fallat: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Comparteix</string>
   <string name="share_show">Comparteix la serie</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Zkuste možnost v nastavení, reinstalovat a obnovit</string>
   <string name="api_error_generic">Nemohl kontaktovat %s. Zkuste prosím později.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Sdílet</string>
   <string name="share_show">Sdílet seriál</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Prøv fra Indstillinger at oprette en sikkerhedskopi, geninstallere og gendanne.</string>
   <string name="api_error_generic">Kunne ikke tale med %s. Forsøg venligst igen senere.</string>
   <string name="api_failed">Mislykkedes: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Del</string>
   <string name="share_show">Del serie</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Versuchen Sie ein Backup in den Einstellungen, dann Neu-Installation und Wiederherstellung</string>
   <string name="api_error_generic">Konnte %s nicht erreichen. Versuchen Sie es später erneut.</string>
   <string name="api_failed">Gescheitert: %s</string>
+  <string name="copy_to_clipboard">In Zwischenablage kopiert</string>
   <!-- Sharing -->
   <string name="share">Teilen</string>
   <string name="share_show">Serie teilen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Προσπαθήστε να κρατήσετε αντίγραφο ασφαλείας στις Ρυθμίσεις, να εγκαταστήσετε ξανά την εφαρμογή και να κάνετε επαναφορά.</string>
   <string name="api_error_generic">Δεν είναι δυνατή η επικοινωνία με το %s. Ξαναδοκιμάστε αργότερα.</string>
   <string name="api_failed">Αποτυχία: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Μοίρασε</string>
   <string name="share_show">Κοινοποίηση σειράς</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Intenta salvar los datos en Opciones, re-instalar y restauralos.</string>
   <string name="api_error_generic">No se pudo hablar con %s. Intenta nuevamente.</string>
   <string name="api_failed">Error: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Compartir</string>
   <string name="share_show">Compartir serie</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">در تنظیمات پشتیبان گرفته، دوباره نصب و بازیابی کنید.</string>
   <string name="api_error_generic">نمی‌توان با %s صحبت کرد. بعداً دوباره تلاش کنید.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">هم‌رسانی</string>
   <string name="share_show">هم‌رسانی نمایش</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Yritä varmuuskopioida asetuksista, asenna uudelleen ja palauta.</string>
   <string name="api_error_generic">Kommunikointi %sin kanssa ei onnistu. Yritä myöhemmin uudelleen.</string>
   <string name="api_failed">Epäonnistui: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Jaa</string>
   <string name="share_show">Jaa ohjelma</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Essayez de sauvegarde les paramètres, puis réinstallez et restaurez.</string>
   <string name="api_error_generic">Impossible de communiquer avec %s. Réessayez ultérieurement.</string>
   <string name="api_failed">Échec : %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Partager</string>
   <string name="share_show">Partager la série</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Tenta facer unha copia de seguridade nos Axustes, reinstalar e restarurar</string>
   <string name="api_error_generic">Non se puido conectar con %s. Tenta máis tarde.</string>
   <string name="api_failed">Fallou: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Partillar</string>
   <string name="share_show">Partillar serie</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Pokušajte sigurnosno kopirati postavke, ponovno instalirajte i vratite sig. kopiju.</string>
   <string name="api_error_generic">%s nedostupan. Pokušajte kasnije.</string>
   <string name="api_failed">Nije uspjelo: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Podijeli</string>
   <string name="share_show">Podijeli seriju</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Próbálj biztonsági mentést készíteni a Beállításokban, újra telepíteni az alkalmazást és visszaállítani a biztonsági mentést.</string>
   <string name="api_error_generic">Nincs kapcsolat ezzel: %s. Próbáld újra később.</string>
   <string name="api_failed">Meghiúsult: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Megosztás</string>
   <string name="share_show">Műsor megosztása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Coba cadangkan di pengaturan, pasang ulang dan pulihkan.</string>
   <string name="api_error_generic">Tidak dapat bicara ke %s. Coba lagi nanti.</string>
   <string name="api_failed">Gagal: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Bagikan</string>
   <string name="share_show">Bagikan acara</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Prova a eseguire un backup dalle impostazioni, reinstalla e ripristina.</string>
   <string name="api_error_generic">Non è possibile contattare %s. Riprova più tardi.</string>
   <string name="api_failed">Fallito: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Condividi</string>
   <string name="share_show">Condividi la serie</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">נסה לגבות את ההגדרות, להתקין מחדש, ולשחזר.</string>
   <string name="api_error_generic">לא יכולה לדבר עם %s. נסה שוב מאוחר יותר.</string>
   <string name="api_failed">נכשל: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">שתף</string>
   <string name="share_show">שתף סדרה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">設定で、バックアップ、再インストール、復元を試してください。</string>
   <string name="api_error_generic">%s に通信できませんでした。後でもう一度やり直してください。</string>
   <string name="api_failed">失敗しました: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">共有</string>
   <string name="share_show">番組を共有</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">공유</string>
   <string name="share_show">쇼 공유</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Pabandykite sukurti atsarginę kopiją parametrų, iš naujo įdiegti ir atkurti.</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Dalintis</string>
   <string name="share_show">Dalintis serialu</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Dalīties</string>
   <string name="share_show">Kopīgot seriālu</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Неможе да се конектира со %s. Пробајте подоцна.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Сподели</string>
   <string name="share_show">Сподели серија</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Forsøk å sikkerhetskopiere under innstillinger, installer på nytt og gjenopprett</string>
   <string name="api_error_generic">Klarte ikke å koble til %s. Prøv igjen senere.</string>
   <string name="api_failed">Mislyktes: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Del</string>
   <string name="share_show">Del serie</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Maak een backup, installeer opnieuw en herstel.</string>
   <string name="api_error_generic">Kon niet praten met %s. Probeer later opnieuw</string>
   <string name="api_failed">Mislukt: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Delen</string>
   <string name="share_show">Serie delen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Spróbuj zrobić kopię zapasową w ustawieniach, przeinstalować program i przywrócić ustawienia.</string>
   <string name="api_error_generic">Nie można połączyć z %s. Spróbuj ponownie później.</string>
   <string name="api_failed">Błąd: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Udostępnij</string>
   <string name="share_show">Współdziel serial</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Tente fazer o backup nas configurações, reinstalar e restaurar o backup.</string>
   <string name="api_error_generic">Não foi possível conectar-se com %s. Tente mais tarde.</string>
   <string name="api_failed">Falhou: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Compartilhar</string>
   <string name="share_show">Compartilhar série</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Tenta fazer uma cópia de segurança nas Configurações, reinstalar e restaurar.</string>
   <string name="api_error_generic">Houve uma falha ao comunicar com o %s. Tenta mais tarde.</string>
   <string name="api_failed">Falhou: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Partilhar</string>
   <string name="share_show">Partilhar série</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Încercați sa creați o copie de rezerva în Setări, reinstalati și restaurati.</string>
   <string name="api_error_generic">Nu s-a putut comunica cu %s. Încercați mai tarziu.</string>
   <string name="api_failed">Eroare: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Distribuie</string>
   <string name="share_show">Distribuie emisiunea</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Попробуйте сделать бэкап в настройках, переустановите приложение и восстановите данные.</string>
   <string name="api_error_generic">Не могу связаться с %s. Попробуйте позже.</string>
   <string name="api_failed">Не удалось: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Отправить</string>
   <string name="share_show">Поделиться сериалом</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Skúste zálohovať cez nastavenia, preinštalovať a obnoviť.</string>
   <string name="api_error_generic">Nemožno komunikovať s %s. Skúste to znova neskôr.</string>
   <string name="api_failed">Zlyhanie: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Zdieľať</string>
   <string name="share_show">Zdieľať seriál</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Deli</string>
   <string name="share_show">Deli oddajo</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Подели</string>
   <string name="share_show">Подели серију</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -54,6 +54,7 @@
   <string name="reinstall_info">Försök att säkerhetskopiera i inställningar, installera om och återställ.</string>
   <string name="api_error_generic">Kunde inte kommunicera med %s. Försök igen senare.</string>
   <string name="api_failed">Misslyckades: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Dela</string>
   <string name="share_show">Dela serie</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
   <string name="api_error_generic">Could not talk to %s. Try again later.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">பகிர்</string>
   <string name="share_show">பங்கு காண்பி</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">ลองสำรองข้อมูลในการตั้งค่า, ติดตั้งแอปใหม่ และเรียกคืนข้อมูล</string>
   <string name="api_error_generic">ไม่สามารถติดต่อกับ %s ลองอีกครั้งในภายหลัง</string>
   <string name="api_failed">ล้มเหลว: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">แบ่งปัน</string>
   <string name="share_show">แบ่งปันซีรีส์</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Ayarlardan yedeklemeyi deneyin. Uygulamayı yediden yükleyip, veri tabanınızı geri yükleyin.</string>
   <string name="api_error_generic">%s ile iletişim kurulamadı. Daha sonra tekrar deneyin.</string>
   <string name="api_failed">%s başarısız oldu</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Paylaş</string>
   <string name="share_show">Diziyi paylaş</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">Спробуйте зберегти копію в Налаштування, повторна інсталяція та відновлення.</string>
   <string name="api_error_generic">Не вдалося зв\'язатися з %s. Спробуйте пізніше.</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">Поділитись</string>
   <string name="share_show">Поділитись серіалом</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">请尝试在设置中进行备份，然后重新安装本程序并恢复备份。</string>
   <string name="api_error_generic">无法连接到 %s。请稍后再试。</string>
   <string name="api_failed">失败：%s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">分享</string>
   <string name="share_show">分享此节目</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -53,6 +53,7 @@
   <string name="reinstall_info">嘗試在設置中備份，然後重新安裝應用並恢復備份。</string>
   <string name="api_error_generic">無法移除節目%s。請稍後再試。</string>
   <string name="api_failed">Failed: %s</string>
+  <string name="copy_to_clipboard">Copied to clipboard</string>
   <!-- Sharing -->
   <string name="share">分享</string>
   <string name="share_show">分享節目</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="reinstall_info">Try to backup in Settings, re-install and restore</string>
     <string name="api_error_generic">Could not talk to %s. Try again later.</string>
     <string name="api_failed">Failed: %s</string>
+    <string name="copy_to_clipboard">Copied to clipboard</string>
 
     <!-- Sharing -->
     <string name="share">Share</string>


### PR DESCRIPTION
Part of #556

When using D-Pad or arrow key navigation every line of text has to be passed. Also there is no highlighting/cursor so it is unclear that this is what happens.

So get rid of `textIsSelectable="true` attributes and create long-click listeners instead which copy the text to the clipboard.

- [x] Rebase onto `dev`.
- [x] Make sure all `Set focus to work around textIsSelectable auto-scroll` are dropped.
- [x] Add translations for new string.
