### PR TITLE
Support TVDB slug for links

### DIFF
--- a/app/schemas/com.battlelancer.seriesguide.provider.SgRoomDatabase/46.json
+++ b/app/schemas/com.battlelancer.seriesguide.provider.SgRoomDatabase/46.json
@@ -1,0 +1,869 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "9e1e6fa7993bbd6db23b3075df8d68f0",
+    "entities": [
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `series_slug` TEXT, `seriestitle` TEXT NOT NULL, `series_title_noarticle` TEXT, `overview` TEXT, `airstime` INTEGER, `airsdayofweek` INTEGER, `series_airtime` TEXT, `series_timezone` TEXT, `firstaired` TEXT, `genres` TEXT, `network` TEXT, `rating` REAL, `series_rating_votes` INTEGER, `series_rating_user` INTEGER, `runtime` TEXT, `status` TEXT, `contentrating` TEXT, `next` TEXT, `poster` TEXT, `series_nextairdate` INTEGER, `nexttext` TEXT, `imdbid` TEXT, `series_trakt_id` INTEGER, `series_favorite` INTEGER NOT NULL, `series_syncenabled` INTEGER NOT NULL, `series_hidden` INTEGER NOT NULL, `series_lastupdate` INTEGER NOT NULL, `series_lastedit` INTEGER NOT NULL, `series_lastwatchedid` INTEGER NOT NULL, `series_lastwatched_ms` INTEGER NOT NULL, `series_language` TEXT, `series_unwatched_count` INTEGER NOT NULL, `series_notify` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "series_slug",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "seriestitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleNoArticle",
+            "columnName": "series_title_noarticle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseTime",
+            "columnName": "airstime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseWeekDay",
+            "columnName": "airsdayofweek",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseCountry",
+            "columnName": "series_airtime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseTimeZone",
+            "columnName": "series_timezone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstRelease",
+            "columnName": "firstaired",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingGlobal",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotes",
+            "columnName": "series_rating_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "series_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentrating",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextEpisode",
+            "columnName": "next",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poster",
+            "columnName": "poster",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextAirdateMs",
+            "columnName": "series_nextairdate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextText",
+            "columnName": "nexttext",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "series_trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "series_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hexagonMergeComplete",
+            "columnName": "series_syncenabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "series_hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedMs",
+            "columnName": "series_lastupdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEditedSec",
+            "columnName": "series_lastedit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastWatchedEpisodeId",
+            "columnName": "series_lastwatchedid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastWatchedMs",
+            "columnName": "series_lastwatched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "series_language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "unwatchedCount",
+            "columnName": "series_unwatched_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notify",
+            "columnName": "series_notify",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER, `combinednr` INTEGER, `series_id` TEXT, `watchcount` INTEGER, `willaircount` INTEGER, `noairdatecount` INTEGER, `seasonposter` TEXT, `season_totalcount` INTEGER, PRIMARY KEY(`_id`), FOREIGN KEY(`series_id`) REFERENCES `series`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "combinednr",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watchCount",
+            "columnName": "watchcount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notReleasedCount",
+            "columnName": "willaircount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noReleaseDateCount",
+            "columnName": "noairdatecount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "seasonposter",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "season_totalcount",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_seasons_series_id",
+            "unique": false,
+            "columnNames": [
+              "series_id"
+            ],
+            "createSql": "CREATE  INDEX `index_seasons_series_id` ON `${TABLE_NAME}` (`series_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "series_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `episodetitle` TEXT NOT NULL, `episodedescription` TEXT, `episodenumber` INTEGER NOT NULL, `season` INTEGER NOT NULL, `dvdnumber` REAL, `season_id` INTEGER NOT NULL, `series_id` INTEGER NOT NULL, `watched` INTEGER NOT NULL, `directors` TEXT, `gueststars` TEXT, `writers` TEXT, `episodeimage` TEXT, `episode_firstairedms` INTEGER NOT NULL, `episode_collected` INTEGER NOT NULL, `rating` REAL, `episode_rating_votes` INTEGER, `episode_rating_user` INTEGER, `episode_imdbid` TEXT, `episode_lastedit` INTEGER NOT NULL, `absolute_number` INTEGER, `episode_lastupdate` INTEGER NOT NULL, PRIMARY KEY(`_id`), FOREIGN KEY(`season_id`) REFERENCES `seasons`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`series_id`) REFERENCES `series`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "episodetitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "episodedescription",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "episodenumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dvdNumber",
+            "columnName": "dvdnumber",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seasonTvdbId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "series_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "watched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "directors",
+            "columnName": "directors",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "guestStars",
+            "columnName": "gueststars",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "writers",
+            "columnName": "writers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "episodeimage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstReleasedMs",
+            "columnName": "episode_firstairedms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collected",
+            "columnName": "episode_collected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingGlobal",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotes",
+            "columnName": "episode_rating_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "episode_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "episode_imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastEditedSec",
+            "columnName": "episode_lastedit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absoluteNumber",
+            "columnName": "absolute_number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedSec",
+            "columnName": "episode_lastupdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_episodes_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "createSql": "CREATE  INDEX `index_episodes_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_episodes_series_id",
+            "unique": false,
+            "columnNames": [
+              "series_id"
+            ],
+            "createSql": "CREATE  INDEX `index_episodes_series_id` ON `${TABLE_NAME}` (`series_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "seasons",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "series_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `list_id` TEXT NOT NULL, `list_name` TEXT NOT NULL, `list_order` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "list_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "list_order",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_lists_list_id",
+            "unique": true,
+            "columnNames": [
+              "list_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_lists_list_id` ON `${TABLE_NAME}` (`list_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "listitems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `list_item_id` TEXT NOT NULL, `item_ref_id` TEXT NOT NULL, `item_type` INTEGER NOT NULL, `list_id` TEXT, FOREIGN KEY(`list_id`) REFERENCES `lists`(`list_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "list_item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemRefId",
+            "columnName": "item_ref_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "item_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_listitems_list_item_id",
+            "unique": true,
+            "columnNames": [
+              "list_item_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_listitems_list_item_id` ON `${TABLE_NAME}` (`list_item_id`)"
+          },
+          {
+            "name": "index_listitems_list_id",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "createSql": "CREATE  INDEX `index_listitems_list_id` ON `${TABLE_NAME}` (`list_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "list_id"
+            ],
+            "referencedColumns": [
+              "list_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `movies_tmdbid` INTEGER NOT NULL, `movies_imdbid` TEXT, `movies_title` TEXT, `movies_title_noarticle` TEXT, `movies_poster` TEXT, `movies_genres` TEXT, `movies_overview` TEXT, `movies_released` INTEGER, `movies_runtime` INTEGER, `movies_trailer` TEXT, `movies_certification` TEXT, `movies_incollection` INTEGER, `movies_inwatchlist` INTEGER, `movies_plays` INTEGER, `movies_watched` INTEGER, `movies_rating_tmdb` REAL, `movies_rating_votes_tmdb` INTEGER, `movies_rating_trakt` INTEGER, `movies_rating_votes_trakt` INTEGER, `movies_rating_user` INTEGER, `movies_last_updated` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "movies_tmdbid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "movies_imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "movies_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "titleNoArticle",
+            "columnName": "movies_title_noarticle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poster",
+            "columnName": "movies_poster",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "movies_genres",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "movies_overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releasedMs",
+            "columnName": "movies_released",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runtimeMin",
+            "columnName": "movies_runtime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trailer",
+            "columnName": "movies_trailer",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "certification",
+            "columnName": "movies_certification",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inCollection",
+            "columnName": "movies_incollection",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inWatchlist",
+            "columnName": "movies_inwatchlist",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plays",
+            "columnName": "movies_plays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "movies_watched",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingTmdb",
+            "columnName": "movies_rating_tmdb",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotesTmdb",
+            "columnName": "movies_rating_votes_tmdb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingTrakt",
+            "columnName": "movies_rating_trakt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotesTrakt",
+            "columnName": "movies_rating_votes_trakt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "movies_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "movies_last_updated",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_movies_movies_tmdbid",
+            "unique": true,
+            "columnNames": [
+              "movies_tmdbid"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_movies_movies_tmdbid` ON `${TABLE_NAME}` (`movies_tmdbid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "activity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `activity_episode` TEXT NOT NULL, `activity_show` TEXT NOT NULL, `activity_time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeTvdbId",
+            "columnName": "activity_episode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "activity_show",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "activity_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_activity_activity_episode",
+            "unique": true,
+            "columnNames": [
+              "activity_episode"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_activity_activity_episode` ON `${TABLE_NAME}` (`activity_episode`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "jobs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `job_created_at` INTEGER, `job_type` INTEGER, `job_extras` BLOB)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdMs",
+            "columnName": "job_created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "job_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extras",
+            "columnName": "job_extras",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_jobs_job_created_at",
+            "unique": true,
+            "columnNames": [
+              "job_created_at"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_jobs_job_created_at` ON `${TABLE_NAME}` (`job_created_at`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"9e1e6fa7993bbd6db23b3075df8d68f0\")"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -113,7 +113,7 @@ public class MigrationTest {
     public void migrationFrom43To44_containsCorrectData() throws IOException {
         // First version that uses Room, so can use migration test helper
         SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 43);
-        RoomDatabaseTestHelper.insertShow(SHOW, db);
+        RoomDatabaseTestHelper.insertShow(SHOW, db, 43);
         RoomDatabaseTestHelper.insertSeason(SEASON, db);
         RoomDatabaseTestHelper
                 .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);
@@ -125,7 +125,7 @@ public class MigrationTest {
     @Test
     public void migrationFrom44To45_containsCorrectData() throws IOException {
         SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 44);
-        RoomDatabaseTestHelper.insertShow(SHOW, db);
+        RoomDatabaseTestHelper.insertShow(SHOW, db, 44);
         RoomDatabaseTestHelper.insertSeason(SEASON, db);
         RoomDatabaseTestHelper
                 .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);
@@ -137,7 +137,7 @@ public class MigrationTest {
     @Test
     public void migrationFrom45To46_containsCorrectData() throws IOException {
         SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 45);
-        RoomDatabaseTestHelper.insertShow(SHOW, db);
+        RoomDatabaseTestHelper.insertShow(SHOW, db, 45);
         RoomDatabaseTestHelper.insertSeason(SEASON, db);
         RoomDatabaseTestHelper
                 .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -3,7 +3,9 @@ package com.battlelancer.seriesguide.provider;
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_42_43;
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_43_44;
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_44_45;
+import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_45_46;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory;
@@ -82,7 +84,7 @@ public class MigrationTest {
         // provide MIGRATION_42_43 as the migration process.
         migrationTestHelper.runMigrationsAndValidate(TEST_DB_NAME, 43,
                 false /* adding FTS table ourselves */, MIGRATION_42_43);
-        assertTestData();
+        assertTestData(getMigratedRoomDatabase());
     }
 
     @Test
@@ -94,7 +96,7 @@ public class MigrationTest {
 
         // MigrationTestHelper automatically verifies the schema changes, but not the data validity
         // Validate that the data was migrated properly.
-        assertTestData();
+        assertTestData(getMigratedRoomDatabase());
     }
 
     private void insertTestDataSqlite() {
@@ -117,7 +119,7 @@ public class MigrationTest {
                 .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);
         db.close();
 
-        assertTestData();
+        assertTestData(getMigratedRoomDatabase());
     }
 
     @Test
@@ -129,14 +131,27 @@ public class MigrationTest {
                 .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);
         db.close();
 
-        assertTestData();
+        assertTestData(getMigratedRoomDatabase());
     }
 
-    private void assertTestData() {
+    @Test
+    public void migrationFrom45To46_containsCorrectData() throws IOException {
+        SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 45);
+        RoomDatabaseTestHelper.insertShow(SHOW, db);
+        RoomDatabaseTestHelper.insertSeason(SEASON, db);
+        RoomDatabaseTestHelper
+                .insertEpisode(EPISODE, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number, db);
+        db.close();
+
+        SgRoomDatabase database = getMigratedRoomDatabase();
+        assertTestData(database);
+        SgShow dbShow = database.showHelper().getShow();
+        assertNull(dbShow.slug);
+    }
+
+    private void assertTestData(SgRoomDatabase database) {
         // MigrationTestHelper automatically verifies the schema changes, but not the data validity
         // Validate that the data was migrated properly.
-        SgRoomDatabase database = getMigratedRoomDatabase();
-
         SgShow dbShow = database.showHelper().getShow();
         assertEquals(SHOW.tvdb_id, dbShow.tvdbId);
         assertEquals(SHOW.title, dbShow.title);
@@ -159,7 +174,12 @@ public class MigrationTest {
     private SgRoomDatabase getMigratedRoomDatabase() {
         SgRoomDatabase database = Room.databaseBuilder(InstrumentationRegistry.getTargetContext(),
                 SgRoomDatabase.class, TEST_DB_NAME)
-                .addMigrations(MIGRATION_42_43, MIGRATION_43_44, MIGRATION_44_45)
+                .addMigrations(
+                        MIGRATION_42_43,
+                        MIGRATION_43_44,
+                        MIGRATION_44_45,
+                        MIGRATION_45_46
+                )
                 .build();
         // close the database and release any stream resources when the test finishes
         migrationTestHelper.closeWhenFinished(database);

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
@@ -18,9 +18,14 @@ import com.uwetrottmann.thetvdb.entities.Episode;
  */
 public class RoomDatabaseTestHelper {
 
-    public static void insertShow(Show show, SupportSQLiteDatabase db) {
+    public static void insertShow(Show show, SupportSQLiteDatabase db, int version) {
         ContentValues values = show.toContentValues(InstrumentationRegistry.getTargetContext(),
                 true);
+
+        // remove columns added in newer versions
+        if (version < SgRoomDatabase.VERSION_46_SERIES_SLUG) {
+            values.remove(Shows.SLUG);
+        }
 
         db.insert(Tables.SHOWS, SQLiteDatabase.CONFLICT_REPLACE, values);
     }

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/SqliteDatabaseTestHelper.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/SqliteDatabaseTestHelper.java
@@ -21,6 +21,9 @@ public class SqliteDatabaseTestHelper {
         ContentValues values = show.toContentValues(InstrumentationRegistry.getTargetContext(),
                 true);
 
+        // remove columns added after version 42
+        values.remove(Shows.SLUG);
+
         db.insertWithOnConflict(Tables.SHOWS, null, values,
                 SQLiteDatabase.CONFLICT_REPLACE);
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -314,8 +314,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     private Cursor getDataCursor(@BackupType int type) {
         if (type == BACKUP_SHOWS) {
             return context.getContentResolver().query(
-                    Shows.CONTENT_URI,
-                    isFullDump ? ShowsQuery.PROJECTION_FULL : ShowsQuery.PROJECTION,
+                    Shows.CONTENT_URI, ShowsQuery.PROJECTION_FULL,
                     null, null, Shows.SORT_TITLE);
         }
         if (type == BACKUP_LISTS) {
@@ -383,6 +382,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
 
             Show show = new Show();
             show.tvdb_id = shows.getInt(ShowsQuery.ID);
+            show.tvdb_slug = shows.getString(ShowsQuery.SLUG);
             show.title = shows.getString(ShowsQuery.TITLE);
             show.favorite = shows.getInt(ShowsQuery.FAVORITE) == 1;
             show.notify = shows.getInt(ShowsQuery.NOTIFY) == 1;
@@ -427,7 +427,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         show.seasons = new ArrayList<>();
         final Cursor seasonsCursor = context.getContentResolver().query(
                 Seasons.buildSeasonsOfShowUri(String.valueOf(show.tvdb_id)),
-                new String[] {
+                new String[]{
                         Seasons._ID,
                         Seasons.COMBINED
                 }, null, null, null
@@ -525,7 +525,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         final Cursor listItems = context.getContentResolver().query(
                 ListItems.CONTENT_URI, ListItemsQuery.PROJECTION,
                 ListItemsQuery.SELECTION,
-                new String[] {
+                new String[]{
                         list.listId
                 }, null
         );
@@ -595,30 +595,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     }
 
     public interface ShowsQuery {
-        String[] PROJECTION = new String[] {
-                Shows._ID,
-                Shows.TITLE,
-                Shows.FAVORITE,
-                Shows.NOTIFY,
-                Shows.HIDDEN,
-                Shows.RELEASE_TIME,
-                Shows.RELEASE_WEEKDAY,
-                Shows.RELEASE_TIMEZONE,
-                Shows.RELEASE_COUNTRY,
-                Shows.LASTWATCHEDID,
-                Shows.LASTWATCHED_MS,
-                Shows.POSTER,
-                Shows.CONTENTRATING,
-                Shows.STATUS,
-                Shows.RUNTIME,
-                Shows.NETWORK,
-                Shows.IMDBID,
-                Shows.TRAKT_ID,
-                Shows.FIRST_RELEASE,
-                Shows.RATING_USER,
-                Shows.LANGUAGE
-        };
-        String[] PROJECTION_FULL = new String[] {
+        String[] PROJECTION_FULL = new String[]{
                 Shows._ID,
                 Shows.TITLE,
                 Shows.FAVORITE,
@@ -645,7 +622,8 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
                 Shows.RATING_VOTES,
                 Shows.GENRES,
                 Shows.LASTUPDATED,
-                Shows.LASTEDIT
+                Shows.LASTEDIT,
+                Shows.SLUG
         };
 
         int ID = 0;
@@ -669,17 +647,17 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         int FIRSTAIRED = 18;
         int RATING_USER = 19;
         int LANGUAGE = 20;
-        // Full dump only
         int OVERVIEW = 21;
         int RATING_GLOBAL = 22;
         int RATING_VOTES = 23;
         int GENRES = 24;
         int LAST_UPDATED = 25;
         int LAST_EDITED = 26;
+        int SLUG = 27;
     }
 
     public interface EpisodesQuery {
-        String[] PROJECTION = new String[] {
+        String[] PROJECTION = new String[]{
                 Episodes._ID,
                 Episodes.NUMBER,
                 Episodes.ABSOLUTE_NUMBER,
@@ -691,7 +669,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
                 Episodes.DVDNUMBER,
                 Episodes.RATING_USER
         };
-        String[] PROJECTION_FULL = new String[] {
+        String[] PROJECTION_FULL = new String[]{
                 Episodes._ID,
                 Episodes.NUMBER,
                 Episodes.ABSOLUTE_NUMBER,
@@ -737,7 +715,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     }
 
     public interface ListsQuery {
-        String[] PROJECTION = new String[] {
+        String[] PROJECTION = new String[]{
                 SeriesGuideContract.Lists.LIST_ID,
                 SeriesGuideContract.Lists.NAME,
                 SeriesGuideContract.Lists.ORDER
@@ -749,7 +727,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     }
 
     public interface ListItemsQuery {
-        String[] PROJECTION = new String[] {
+        String[] PROJECTION = new String[]{
                 ListItems.LIST_ITEM_ID, SeriesGuideContract.Lists.LIST_ID, ListItems.ITEM_REF_ID,
                 ListItems.TYPE
         };
@@ -763,7 +741,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     }
 
     public interface MoviesQuery {
-        String[] PROJECTION = new String[] {
+        String[] PROJECTION = new String[]{
                 Movies._ID,
                 Movies.TMDB_ID,
                 Movies.IMDB_ID,

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Show.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Show.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class Show {
 
     public int tvdb_id;
+    public String tvdb_slug;
     public String imdb_id;
     public Integer trakt_id;
 
@@ -62,6 +63,7 @@ public class Show {
 
         ContentValues values = new ContentValues();
         // values for new and existing shows
+        values.put(Shows.SLUG, tvdb_slug);
         // if in any case the title is empty, show a place holder
         values.put(Shows.TITLE, TextUtils.isEmpty(title) 
                 ? context.getString(R.string.no_translation_title) : title);

--- a/app/src/main/java/com/battlelancer/seriesguide/model/SgShow.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/model/SgShow.java
@@ -15,6 +15,9 @@ public class SgShow {
     @ColumnInfo(name = Shows._ID)
     public int tvdbId;
 
+    @ColumnInfo(name = Shows.SLUG)
+    public String slug = "";
+
     /**
      * Ensure this is NOT null (enforced through database constraint).
      */

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
@@ -197,11 +197,6 @@ public class SeriesGuideContract {
         String NEXTTEXT = "nexttext";
 
         /**
-         * @deprecated Use {@link #NEXTAIRDATEMS} instead. Not added on new installs.
-         */
-        String NEXTAIRDATE = "nextairdate";
-
-        /**
          * Next episode release time instant. See {@link Episodes#FIRSTAIREDMS}.
          *
          * <pre>

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
@@ -24,6 +24,12 @@ public class SeriesGuideContract {
         String REF_SHOW_ID = "series_id";
 
         /**
+         * TheTVDB slug for this show to build URLs. Always a string, but may be a number string if
+         * no slug is set (still safe to build URL with). May be null or empty.
+         */
+        String SLUG = "series_slug";
+
+        /**
          * Ensure this is NOT null (enforced through database constraint).
          */
         String TITLE = "seriestitle";

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
@@ -41,7 +41,8 @@ abstract class SgRoomDatabase : RoomDatabase() {
         private const val VERSION_43_ROOM = 43
         private const val VERSION_44_RECREATE_SERIES_EPISODES = 44
         private const val VERSION_45_RECREATE_SEASONS = 45
-        const val VERSION = VERSION_45_RECREATE_SEASONS
+        private const val VERSION_46_SERIES_SLUG = 46
+        const val VERSION = VERSION_46_SERIES_SLUG
 
         @Volatile
         private var instance: SgRoomDatabase? = null
@@ -62,6 +63,7 @@ abstract class SgRoomDatabase : RoomDatabase() {
                     val newInstance = Room.databaseBuilder(context.applicationContext,
                             SgRoomDatabase::class.java, SeriesGuideDatabase.DATABASE_NAME)
                             .addMigrations(
+                                    MIGRATION_45_46,
                                     MIGRATION_44_45,
                                     MIGRATION_42_44,
                                     MIGRATION_43_44,
@@ -101,6 +103,16 @@ abstract class SgRoomDatabase : RoomDatabase() {
                 } else {
                     db.execSQL(SeriesGuideDatabase.CREATE_SEARCH_TABLE_API_ICS)
                 }
+            }
+        }
+
+        @JvmField
+        val MIGRATION_45_46: Migration = object :
+                Migration(VERSION_45_RECREATE_SEASONS, VERSION_46_SERIES_SLUG) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                Timber.d("Migrating database from 45 to 46")
+
+                database.execSQL("ALTER TABLE series ADD COLUMN series_slug TEXT;")
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
@@ -41,7 +41,7 @@ abstract class SgRoomDatabase : RoomDatabase() {
         private const val VERSION_43_ROOM = 43
         private const val VERSION_44_RECREATE_SERIES_EPISODES = 44
         private const val VERSION_45_RECREATE_SEASONS = 45
-        private const val VERSION_46_SERIES_SLUG = 46
+        const val VERSION_46_SERIES_SLUG = 46
         const val VERSION = VERSION_46_SERIES_SLUG
 
         @Volatile

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbLinks.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbLinks.kt
@@ -4,48 +4,29 @@ class TvdbLinks {
 
     companion object {
 
-        private val languageCodeToId = mapOf(
-                "en" to 7,
-                "sv" to 8,
-                "no" to 9,
-                "da" to 10,
-                "fi" to 11,
-                "nl" to 13,
-                "de" to 14,
-                "it" to 15,
-                "es" to 16,
-                "fr" to 17,
-                "pl" to 18,
-                "hu" to 19,
-                "el" to 20,
-                "tr" to 21,
-                "ru" to 22,
-                "he" to 24,
-                "ja" to 25,
-                "pt" to 26,
-                "zh" to 27,
-                "cs" to 28,
-                "ls" to 30,
-                "hr" to 31,
-                "ko" to 32
-        )
-
-        private fun getLanguageId(languageCode: String?): Int {
-            return languageCodeToId[languageCode] ?: 7 // fall back to 'en'
+        /**
+         * TVDB link using show slug. Falls back to old series ID link if slug is null or empty.
+         */
+        @JvmStatic
+        fun show(showTvdbSlug: String?, showTvdbId: Int): String {
+            return if (showTvdbSlug.isNullOrEmpty()) {
+                "https://www.thetvdb.com/?tab=series&id=$showTvdbId"
+            } else {
+                "https://www.thetvdb.com/series/$showTvdbSlug"
+            }
         }
 
+        /**
+         * TVDB link using show slug. Falls back to old series ID link if slug is null or empty.
+         */
         @JvmStatic
-        fun show(showTvdbId: Int, languageCode: String?): String {
-            val languageId = getLanguageId(languageCode)
-            return "https://thetvdb.com/?tab=series&id=$showTvdbId&lid=$languageId"
-        }
-
-        @JvmStatic
-        fun episode(showTvdbId: Int, seasonTvdbId: Int, episodeTvdbId: Int,
-                languageCode: String?): String {
-            val languageId = getLanguageId(languageCode)
-            return "https://thetvdb.com/?tab=episode" +
-                    "&seriesid=$showTvdbId&seasonid=$seasonTvdbId&id=$episodeTvdbId&lid=$languageId"
+        fun episode(showTvdbSlug: String?, showTvdbId: Int, seasonTvdbId: Int,
+                episodeTvdbId: Int): String {
+            return if (showTvdbSlug.isNullOrEmpty()) {
+                return "https://www.thetvdb.com/?tab=episode&seriesid=$showTvdbId&seasonid=$seasonTvdbId&id=$episodeTvdbId"
+            } else {
+                "https://www.thetvdb.com/series/$showTvdbSlug/episodes/$episodeTvdbId"
+            }
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
@@ -503,6 +503,7 @@ public class TvdbTools {
 
         Show result = new Show();
         result.tvdb_id = showTvdbId;
+        result.tvdb_slug = series.slug;
         // actors are unused, are fetched from tmdb
         result.title = series.seriesName != null ? series.seriesName.trim() : null;
         result.network = series.network;

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
@@ -92,6 +92,7 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
     private boolean isInMultipane;
     private int episodeTvdbId;
     private int showTvdbId;
+    @Nullable private String showTvdbSlug;
     private int seasonTvdbId;
     private int seasonNumber;
     private int episodeNumber;
@@ -101,7 +102,6 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
     private String showTitle;
     private int showRunTime;
     private long episodeReleaseTime;
-    private String languageCode;
 
     @BindView(R.id.containerEpisode) View containerEpisode;
     @BindView(R.id.containerRatings) View containerRatings;
@@ -395,6 +395,7 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         }
 
         showTvdbId = cursor.getInt(DetailsQuery.SHOW_ID);
+        showTvdbSlug = cursor.getString(DetailsQuery.SHOW_SLUG);
         seasonNumber = cursor.getInt(DetailsQuery.SEASON);
         episodeNumber = cursor.getInt(DetailsQuery.NUMBER);
         showRunTime = cursor.getInt(DetailsQuery.SHOW_RUNTIME);
@@ -410,9 +411,9 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
                 TextTools.getEpisodeTitle(requireContext(), hideDetails ? null : episodeTitle,
                         episodeNumber));
         String overview = cursor.getString(DetailsQuery.OVERVIEW);
-        languageCode = cursor.getString(DetailsQuery.SHOW_LANGUAGE);
         if (TextUtils.isEmpty(overview)) {
             // no description available, show no translation available message
+            String languageCode = cursor.getString(DetailsQuery.SHOW_LANGUAGE);
             overview = getString(R.string.no_translation,
                     LanguageTools.getShowLanguageStringFor(getContext(), languageCode),
                     getString(R.string.tvdb));
@@ -619,8 +620,7 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
 
         // TVDb
         seasonTvdbId = cursor.getInt(DetailsQuery.SEASON_ID);
-        String tvdbUri = TvdbLinks
-                .episode(showTvdbId, seasonTvdbId, episodeTvdbId, languageCode);
+        String tvdbUri = TvdbLinks.episode(showTvdbSlug, showTvdbId, seasonTvdbId, episodeTvdbId);
         ViewTools.openUriOnClick(tvdbButton, tvdbUri, TAG, "TVDb");
         // trakt comments
         commentsButton.setOnClickListener(new OnClickListener() {
@@ -657,8 +657,8 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         if (episodeTitle == null || showTitle == null) {
             return;
         }
-        ShareUtils.shareEpisode(requireActivity(), showTvdbId, seasonTvdbId, episodeTvdbId,
-                seasonNumber, episodeNumber, showTitle, episodeTitle, languageCode);
+        ShareUtils.shareEpisode(requireActivity(), showTvdbSlug, showTvdbId, seasonTvdbId,
+                episodeTvdbId, seasonNumber, episodeNumber, showTitle, episodeTitle);
         Utils.trackAction(requireContext(), TAG, "Share");
     }
 
@@ -773,7 +773,8 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
                 Shows.IMDBID,
                 Shows.TITLE,
                 Shows.RUNTIME,
-                Shows.LANGUAGE
+                Shows.LANGUAGE,
+                Shows.SLUG
         };
 
         int _ID = 0;
@@ -801,5 +802,6 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         int SHOW_TITLE = 22;
         int SHOW_RUNTIME = 23;
         int SHOW_LANGUAGE = 24;
+        int SHOW_SLUG = 25;
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
@@ -447,10 +447,10 @@ public class OverviewFragment extends Fragment implements
         int seasonNumber = currentEpisodeCursor.getInt(EpisodeQuery.SEASON);
         int episodeNumber = currentEpisodeCursor.getInt(EpisodeQuery.NUMBER);
         String episodeTitle = currentEpisodeCursor.getString(EpisodeQuery.TITLE);
-        String languageCode = showCursor.getString(ShowQuery.SHOW_LANGUAGE);
+        String showTvdbSlug = showCursor.getString(ShowQuery.SHOW_SLUG);
 
-        ShareUtils.shareEpisode(getActivity(), showTvdbId, seasonTvdbId, currentEpisodeTvdbId,
-                seasonNumber, episodeNumber, showTitle, episodeTitle, languageCode);
+        ShareUtils.shareEpisode(getActivity(), showTvdbSlug, showTvdbId, seasonTvdbId,
+                currentEpisodeTvdbId, seasonNumber, episodeNumber, showTitle, episodeTitle);
 
         Utils.trackAction(getActivity(), TAG, "Share");
     }
@@ -533,7 +533,8 @@ public class OverviewFragment extends Fragment implements
                 Shows.IMDBID,
                 Shows.RUNTIME,
                 Shows.FAVORITE,
-                Shows.LANGUAGE
+                Shows.LANGUAGE,
+                Shows.SLUG
         };
 
         int SHOW_TITLE = 1;
@@ -548,6 +549,7 @@ public class OverviewFragment extends Fragment implements
         int SHOW_RUNTIME = 10;
         int SHOW_FAVORITE = 11;
         int SHOW_LANGUAGE = 12;
+        int SHOW_SLUG = 13;
     }
 
     @Override
@@ -794,7 +796,8 @@ public class OverviewFragment extends Fragment implements
         // TVDb button
         final int episodeTvdbId = currentEpisodeCursor.getInt(EpisodeQuery._ID);
         final int seasonTvdbId = currentEpisodeCursor.getInt(EpisodeQuery.SEASON_ID);
-        String uri = TvdbLinks.episode(showTvdbId, seasonTvdbId, episodeTvdbId, languageCode);
+        String showTvdbSlug = showCursor.getString(ShowQuery.SHOW_SLUG);
+        String uri = TvdbLinks.episode(showTvdbSlug, showTvdbId, seasonTvdbId, episodeTvdbId);
         ViewTools.openUriOnClick(buttonTvdb, uri, TAG, "TVDb");
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.java
@@ -127,6 +127,7 @@ public class ShowFragment extends Fragment {
     private Cursor showCursor;
     private ShowTools showTools;
     private TraktRatingsTask traktTask;
+    @Nullable private String showSlug;
     private String showTitle;
     private String posterPath;
     @Nullable private String languageCode;
@@ -281,7 +282,8 @@ public class ShowFragment extends Fragment {
                 Shows.LASTEDIT,
                 Shows.LANGUAGE,
                 Shows.NOTIFY,
-                Shows.HIDDEN
+                Shows.HIDDEN,
+                Shows.SLUG
         };
 
         int TITLE = 1;
@@ -306,6 +308,7 @@ public class ShowFragment extends Fragment {
         int LANGUAGE = 20;
         int NOTIFY = 21;
         int HIDDEN = 22;
+        int SLUG = 23;
     }
 
     private LoaderCallbacks<Cursor> showLoaderCallbacks = new LoaderCallbacks<Cursor>() {
@@ -336,6 +339,8 @@ public class ShowFragment extends Fragment {
         if (showCursor == null) {
             return;
         }
+
+        showSlug = showCursor.getString(ShowQuery.SLUG);
 
         // title
         showTitle = showCursor.getString(ShowQuery.TITLE);
@@ -481,7 +486,7 @@ public class ShowFragment extends Fragment {
         ServiceUtils.setUpImdbButton(imdbId, buttonImdb, TAG);
 
         // TVDb button
-        String tvdbUri = TvdbLinks.show(getShowTvdbId(), this.languageCode);
+        String tvdbUri = TvdbLinks.show(showSlug, getShowTvdbId());
         ViewTools.openUriOnClick(buttonTvdb, tvdbUri, TAG, "TVDb");
 
         // trakt button
@@ -642,7 +647,7 @@ public class ShowFragment extends Fragment {
 
     private void shareShow() {
         if (showCursor != null) {
-            ShareUtils.shareShow(getActivity(), getShowTvdbId(), showTitle, languageCode);
+            ShareUtils.shareShow(getActivity(), showSlug, getShowTvdbId(), showTitle);
             Utils.trackAction(getActivity(), TAG, "Share");
         }
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ShareUtils.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ShareUtils.java
@@ -21,18 +21,18 @@ public class ShareUtils {
 
     protected static final String TAG = "ShareUtils";
 
-    public static void shareEpisode(Activity activity, int showTvdbId, int seasonTvdbId,
-            int episodeTvdbId, int seasonNumber, int episodeNumber,
-            String showTitle, String episodeTitle, @Nullable String languageCode) {
+    public static void shareEpisode(Activity activity, @Nullable String showTvdbSlug,
+            int showTvdbId, int seasonTvdbId, int episodeTvdbId, int seasonNumber,
+            int episodeNumber, String showTitle, String episodeTitle) {
         String message = showTitle + " - " + TextTools.getNextEpisodeString(activity, seasonNumber,
                 episodeNumber, episodeTitle) + " "
-                + TvdbLinks.episode(showTvdbId, seasonTvdbId, episodeTvdbId, languageCode);
+                + TvdbLinks.episode(showTvdbSlug, showTvdbId, seasonTvdbId, episodeTvdbId);
         startShareIntentChooser(activity, message, R.string.share_episode);
     }
 
-    public static void shareShow(Activity activity, int showTvdbId, String showTitle,
-            @Nullable String languageCode) {
-        String message = showTitle + " " + TvdbLinks.show(showTvdbId, languageCode);
+    public static void shareShow(Activity activity, @Nullable String showTvdbSlug, int showTvdbId,
+            String showTitle) {
+        String message = showTitle + " " + TvdbLinks.show(showTvdbSlug, showTvdbId);
         startShareIntentChooser(activity, message, R.string.share_show);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
             'timber': '4.7.1', // github.com/JakeWharton/timber/blob/master/CHANGELOG.md
 
             'androidUtils': '2.3.1', // github.com/UweTrottmann/AndroidUtils/blob/master/RELEASE_NOTES.md
-            'thetvdb': '1.6.0', // github.com/UweTrottmann/thetvdb-java/blob/master/CHANGELOG.md
+            'thetvdb': '1.6.1', // github.com/UweTrottmann/thetvdb-java/blob/master/CHANGELOG.md
             'tmdb': '1.9.0', // github.com/UweTrottmann/tmdb-java/blob/master/CHANGELOG.md
             'trakt': '5.10.0', // github.com/UweTrottmann/trakt-java/blob/master/CHANGELOG.md
 


### PR DESCRIPTION
Links to TVDB from within the app use the new format. See #545.

However, sharing a TVDB link to SeriesGuide to add a show still won't work as the API has no way to get a TVDB id from a slug. See #546.