### PR TITLE
Drop default language setting, default to English

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/settings/DisplaySettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/DisplaySettings.java
@@ -18,14 +18,13 @@ public class DisplaySettings {
 
     public static final String KEY_THEME = "com.battlelancer.seriesguide.theme";
 
+    @Deprecated // language is stored per show or defined by place of usage
     public static final String KEY_LANGUAGE_PREFERRED = "language";
     public static final String KEY_LANGUAGE_FALLBACK = "com.battlelancer.seriesguide.languageFallback";
+    public static final String KEY_LANGUAGE_SEARCH = "com.battlelancer.seriesguide.languagesearch";
 
     public static final String KEY_MOVIES_LANGUAGE = "com.battlelancer.seriesguide.languagemovies";
-
     public static final String KEY_MOVIES_REGION = "com.battlelancer.seriesguide.regionmovies";
-
-    public static final String KEY_LANGUAGE_SEARCH = "com.battlelancer.seriesguide.languagesearch";
 
     public static final String KEY_NUMBERFORMAT = "numberformat";
 
@@ -74,15 +73,6 @@ public class DisplaySettings {
     }
 
     /**
-     * Returns two letter ISO 639-1 language code of the show language preferred by the user.
-     * Defaults to 'en'.
-     */
-    public static String getShowsLanguage(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context)
-                .getString(KEY_LANGUAGE_PREFERRED, LANGUAGE_EN);
-    }
-
-    /**
      * Returns two letter ISO 639-1 language code of the fallback show language preferred by the
      * user. Defaults to 'en'.
      */
@@ -118,11 +108,11 @@ public class DisplaySettings {
 
     /**
      * @return Two letter ISO 639-1 language code of the language the user prefers when searching or
-     * 'xx' if all languages should be searched. Defaults to {@link #getShowsLanguage(Context)}.
+     * 'xx' if all languages should be searched. Defaults to all languages.
      */
     public static String getSearchLanguage(Context context) {
         String languageCode = PreferenceManager.getDefaultSharedPreferences(context)
-                .getString(KEY_LANGUAGE_SEARCH, getShowsLanguage(context));
+                .getString(KEY_LANGUAGE_SEARCH, context.getString(R.string.language_code_any));
         return TextUtils.isEmpty(languageCode)
                 ? context.getString(R.string.language_code_any)
                 : languageCode;

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/DisplaySettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/DisplaySettings.java
@@ -118,6 +118,19 @@ public class DisplaySettings {
                 : languageCode;
     }
 
+    /**
+     * @return Two letter ISO 639-1 language code of the language the user prefers when searching or
+     * {@link #getShowsLanguageFallback(Context)} if all languages is selected. Defaults to
+     * {@link #getShowsLanguageFallback(Context)}.
+     */
+    public static String getSearchLanguageOrFallbackIfAny(Context context) {
+        String languageCode = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(KEY_LANGUAGE_SEARCH, null);
+        return TextUtils.isEmpty(languageCode)
+                ? getShowsLanguageFallback(context)
+                : languageCode;
+    }
+
     public static String getNumberFormat(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context)
                 .getString(KEY_NUMBERFORMAT, NUMBERFORMAT_DEFAULT);

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.java
@@ -56,17 +56,6 @@ public class TvdbImageTools {
     }
 
     /**
-     * @see #smallSizeOrResolveUrl(String, int, String)
-     */
-    @Nullable
-    public static String smallSizeOrResolveUrl(@Nullable String imagePath, int showTvdbId) {
-        if (TextUtils.isEmpty(imagePath)) {
-            return SgPicassoRequestHandler.SCHEME_SHOW_TVDB + "://" + showTvdbId;
-        }
-        return smallSizeUrl(imagePath);
-    }
-
-    /**
      * Builds a full url for a TVDb show poster using the given image path.
      *
      * @param imagePath If empty, will return an URL that will be resolved to the highest rated

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
@@ -415,8 +415,7 @@ public class TvdbTools {
      * information from trakt.
      *
      * @param language A TVDb language code (ISO 639-1 two-letter format, see <a
-     * href="http://www.thetvdb.com/wiki/index.php/API:languages.xml">TVDb wiki</a>). If not
-     * supplied, TVDb falls back to English.
+     * href="http://www.thetvdb.com/wiki/index.php/API:languages.xml">TVDb wiki</a>).
      * @throws TvdbException If a request fails or a response appears to be corrupted.
      */
     @NonNull
@@ -492,10 +491,10 @@ public class TvdbTools {
     }
 
     /**
-     * Get a show from TVDb. Tries to fetch in the desired language, but will fall back to the
-     * default entry if no translation exists. The returned entity will still have its <b>language
-     * property set to the desired language</b>, which might not be the language of the actual
-     * content.
+     * Get a show from TVDb. Tries to fetch in the desired language, but will use
+     * {@link DisplaySettings#getShowsLanguageFallback(Context)} if no translation or poster in that
+     * language exists. The returned entity will still have its <b>language property set to the
+     * desired language</b>, which might not be the language of the actual content.
      */
     @NonNull
     private Show downloadAndParseShow(int showTvdbId, @NonNull String desiredLanguage)
@@ -504,8 +503,8 @@ public class TvdbTools {
         // title is null if no translation exists
         boolean noTranslation = TextUtils.isEmpty(series.seriesName);
         if (noTranslation) {
-            // try to fetch default entry
-            series = getSeries(showTvdbId, null);
+            // try to fetch using fall back language
+            series = getSeries(showTvdbId, DisplaySettings.getShowsLanguageFallback(context));
         }
 
         Show result = new Show();
@@ -552,8 +551,9 @@ public class TvdbTools {
         retrofit2.Response<SeriesImageQueryResultResponse> posterResponse;
         posterResponse = getSeriesPosters(showTvdbId, desiredLanguage);
         if (posterResponse.code() == 404) {
-            // no posters for this language, fall back to default
-            posterResponse = getSeriesPosters(showTvdbId, null);
+            // no posters for this language, try fall back language
+            posterResponse = getSeriesPosters(showTvdbId,
+                    DisplaySettings.getShowsLanguageFallback(context));
         }
 
         if (posterResponse.isSuccessful()) {

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
@@ -208,7 +208,10 @@ public class TvdbTools {
         getEpisodesAndUpdateDatabase(batch, show, show.language);
     }
 
-    public static String getShowLanguage(Context context, int showTvdbId) {
+    /**
+     * @return {@code null} if the query failed, should try again later.
+     */
+    private static String getShowLanguage(Context context, int showTvdbId) {
         Cursor languageQuery = context.getContentResolver()
                 .query(Shows.buildShowUri(showTvdbId), LANGUAGE_QUERY_PROJECTION, null, null, null);
         if (languageQuery == null) {
@@ -221,9 +224,11 @@ public class TvdbTools {
         }
         languageQuery.close();
 
+        // handle legacy records
         if (TextUtils.isEmpty(language)) {
-            // use fall back language
-            language = DisplaySettings.getShowsLanguageFallback(context);
+            // default to 'en' for consistent behavior across devices
+            // and to encourage users to set language
+            language = DisplaySettings.LANGUAGE_EN;
         }
 
         return language;
@@ -379,9 +384,11 @@ public class TvdbTools {
         if (language == null && hexagonShow != null) {
             language = hexagonShow.getLanguage();
         }
-        // if we still have no language, use the users fall back language
-        if (TextUtils.isEmpty(language)) {
-            language = DisplaySettings.getShowsLanguageFallback(context);
+        // handle legacy records without language
+        if (language == null || language.length() == 0) {
+            // default to 'en' to ensure consistency across devices,
+            // and to encourage users to set a language
+            language = DisplaySettings.LANGUAGE_EN;
         }
 
         // get show info from TVDb and trakt

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbTools.java
@@ -222,8 +222,8 @@ public class TvdbTools {
         languageQuery.close();
 
         if (TextUtils.isEmpty(language)) {
-            // fall back to preferred language
-            language = DisplaySettings.getShowsLanguage(context);
+            // use fall back language
+            language = DisplaySettings.getShowsLanguageFallback(context);
         }
 
         return language;
@@ -379,9 +379,9 @@ public class TvdbTools {
         if (language == null && hexagonShow != null) {
             language = hexagonShow.getLanguage();
         }
-        // if we still have no language, use the users default language
+        // if we still have no language, use the users fall back language
         if (TextUtils.isEmpty(language)) {
-            language = DisplaySettings.getShowsLanguage(context);
+            language = DisplaySettings.getShowsLanguageFallback(context);
         }
 
         // get show info from TVDb and trakt

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/SearchActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/SearchActivity.java
@@ -256,7 +256,7 @@ public class SearchActivity extends BaseNavDrawerActivity implements
         }
 
         // display add dialog
-        AddShowDialogFragment.showAddDialog(showTvdbId, getSupportFragmentManager());
+        AddShowDialogFragment.showAddDialog(this, getSupportFragmentManager(), showTvdbId);
         Utils.trackCustomEvent(this, "Beam", "Success", null);
     }
 
@@ -322,7 +322,7 @@ public class SearchActivity extends BaseNavDrawerActivity implements
 
         if (showTvdbId > 0) {
             // found an id, display the add dialog
-            AddShowDialogFragment.showAddDialog(showTvdbId, getSupportFragmentManager());
+            AddShowDialogFragment.showAddDialog(this, getSupportFragmentManager(), showTvdbId);
         } else {
             // no id, populate the search field instead
             viewPager.setCurrentItem(TAB_POSITION_SEARCH);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/SeriesGuidePreferences.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/SeriesGuidePreferences.java
@@ -373,7 +373,6 @@ public class SeriesGuidePreferences extends AppCompatActivity {
 
             // show currently set values for some prefs
             updateStreamSearchServiceSummary(findPreference(StreamingSearch.KEY_SETTING_SERVICE));
-            setListPreferenceSummary((ListPreference) findPreference(DisplaySettings.KEY_LANGUAGE_PREFERRED));
             setListPreferenceSummary((ListPreference) findPreference(DisplaySettings.KEY_LANGUAGE_FALLBACK));
             updateTimeOffsetSummary(findPreference(DisplaySettings.KEY_SHOWS_TIME_OFFSET));
         }
@@ -565,8 +564,7 @@ public class SeriesGuidePreferences extends AppCompatActivity {
                 new BackupManager(pref.getContext()).dataChanged();
 
                 // update pref summary text
-                if (DisplaySettings.KEY_LANGUAGE_PREFERRED.equals(key)
-                        || DisplaySettings.KEY_LANGUAGE_FALLBACK.equals(key)
+                if (DisplaySettings.KEY_LANGUAGE_FALLBACK.equals(key)
                         || DisplaySettings.KEY_NUMBERFORMAT.equals(key)
                         || DisplaySettings.KEY_THEME.equals(key)) {
                     setListPreferenceSummary((ListPreference) pref);
@@ -606,8 +604,7 @@ public class SeriesGuidePreferences extends AppCompatActivity {
                 ListWidgetProvider.notifyDataChanged(getActivity());
             }
 
-            if (DisplaySettings.KEY_LANGUAGE_PREFERRED.equals(key)
-                    || DisplaySettings.KEY_LANGUAGE_FALLBACK.equals(key)) {
+            if (DisplaySettings.KEY_LANGUAGE_FALLBACK.equals(key)) {
                 // reset last edit date of all episodes so they will get updated
                 new Thread(new Runnable() {
                     public void run() {

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/ShowsActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/ShowsActivity.java
@@ -147,7 +147,8 @@ public class ShowsActivity extends BaseTopActivity implements
                 // no such episode, offer to add show
                 int showTvdbId = intent.getIntExtra(Intents.EXTRA_SHOW_TVDBID, 0);
                 if (showTvdbId > 0) {
-                    AddShowDialogFragment.showAddDialog(showTvdbId, getSupportFragmentManager());
+                    AddShowDialogFragment.showAddDialog(this, getSupportFragmentManager(),
+                            showTvdbId);
                 }
             }
         }
@@ -162,7 +163,8 @@ public class ShowsActivity extends BaseTopActivity implements
                 viewIntent = OverviewActivity.intentShow(this, showTvdbId);
             } else {
                 // no such show, offer to add it
-                AddShowDialogFragment.showAddDialog(showTvdbId, getSupportFragmentManager());
+                AddShowDialogFragment.showAddDialog(this, getSupportFragmentManager(),
+                        showTvdbId);
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/dialogs/LanguageChoiceDialogFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/dialogs/LanguageChoiceDialogFragment.java
@@ -19,11 +19,16 @@ import timber.log.Timber;
  */
 public class LanguageChoiceDialogFragment extends AppCompatDialogFragment {
 
+    public static final String TAG_ADD_DIALOG = "languageDialogAdd";
+    public static final String TAG_DISCOVER = "languageDialogDiscover";
+
     public static class LanguageChangedEvent {
         @NonNull public final String selectedLanguageCode;
+        @Nullable public final String tag;
 
-        public LanguageChangedEvent(@NonNull String selectedLanguageCode) {
+        public LanguageChangedEvent(@NonNull String selectedLanguageCode, @Nullable String tag) {
             this.selectedLanguageCode = selectedLanguageCode;
+            this.tag = tag;
         }
     }
 
@@ -99,7 +104,7 @@ public class LanguageChoiceDialogFragment extends AppCompatDialogFragment {
         }
 
         EventBus.getDefault()
-                .post(new LanguageChangedEvent(languageCodes[selectedLanguagePosition]));
+                .post(new LanguageChangedEvent(languageCodes[selectedLanguagePosition], getTag()));
         dismiss();
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
@@ -52,8 +52,8 @@ public class AddShowDialogFragment extends AppCompatDialogFragment {
     private static final String KEY_SHOW_LANGUAGE = "show_language";
 
     /**
-     * Display a {@link AddShowDialogFragment} for the given
-     * show.
+     * Display a {@link AddShowDialogFragment} for the given show. The language of the show should
+     * be set.
      */
     public static void showAddDialog(SearchResult show, FragmentManager fm) {
         // DialogFragment.show() will take care of adding the fragment
@@ -72,10 +72,10 @@ public class AddShowDialogFragment extends AppCompatDialogFragment {
     }
 
     /**
-     * Display a {@link AddShowDialogFragment} for the given
-     * show.
+     * Display a {@link AddShowDialogFragment} for the given show.
      *
-     * <p> Use if there is no actual search result, but just a TheTVDB id available.
+     * <p> Use if there is no actual search result, but just a TheTVDB id available. Uses the search
+     * or fall back language.
      */
     public static void showAddDialog(int showTvdbId, FragmentManager fm) {
         SearchResult fakeResult = new SearchResult();

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
@@ -247,12 +247,17 @@ public class AddShowDialogFragment extends AppCompatDialogFragment {
     @OnClick(R.id.buttonAddLanguage)
     public void onClickButtonLanguage() {
         DialogFragment dialog = LanguageChoiceDialogFragment.newInstance(
-                R.array.languageCodesShows, displayedShow.getLanguage());
-        dialog.show(getFragmentManager(), "dialog-language");
+                R.array.languageCodesShows, displayedShow.getLanguage()
+        );
+        dialog.show(getFragmentManager(), LanguageChoiceDialogFragment.TAG_ADD_DIALOG);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(LanguageChoiceDialogFragment.LanguageChangedEvent event) {
+        if (!LanguageChoiceDialogFragment.TAG_ADD_DIALOG.equals(event.tag)) {
+            return;
+        }
+
         showProgressBar(true);
         overview.setVisibility(View.INVISIBLE);
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowsDiscoverFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowsDiscoverFragment.kt
@@ -240,7 +240,7 @@ class ShowsDiscoverFragment : Fragment() {
             fragmentManager?.let {
                 val dialogFragment = LanguageChoiceDialogFragment.newInstance(
                         R.array.languageCodesShowsWithAny, languageCode)
-                dialogFragment.show(fragmentManager, "dialog-language")
+                dialogFragment.show(fragmentManager, LanguageChoiceDialogFragment.TAG_DISCOVER)
             }
         }
     }
@@ -270,6 +270,9 @@ class ShowsDiscoverFragment : Fragment() {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: LanguageChoiceDialogFragment.LanguageChangedEvent) {
+        if (LanguageChoiceDialogFragment.TAG_DISCOVER != event.tag) {
+            return
+        }
         changeLanguage(event.selectedLanguageCode)
         loadResults()
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowsDiscoverFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowsDiscoverFragment.kt
@@ -147,7 +147,7 @@ class ShowsDiscoverFragment : Fragment() {
                     // onSaveInstanceState might already be called
                     if (isResumed) {
                         // display more details in a dialog
-                        AddShowDialogFragment.showAddDialog(item, fragmentManager)
+                        AddShowDialogFragment.showAddDialog(context, fragmentManager, item)
                     }
                 }
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/TraktAddFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/TraktAddFragment.java
@@ -103,7 +103,8 @@ public class TraktAddFragment extends AddFragment {
                     // onSaveInstanceState might already be called
                     if (isResumed()) {
                         // display more details in a dialog
-                        AddShowDialogFragment.showAddDialog(item, getFragmentManager());
+                        AddShowDialogFragment
+                                .showAddDialog(getContext(), getFragmentManager(), item);
                     }
                 }
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/TraktAddLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/TraktAddLoader.java
@@ -8,6 +8,7 @@ import android.support.v4.util.SparseArrayCompat;
 import android.text.TextUtils;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.SgApp;
+import com.battlelancer.seriesguide.settings.DisplaySettings;
 import com.battlelancer.seriesguide.traktapi.SgTrakt;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
 import com.uwetrottmann.androidutils.AndroidUtils;
@@ -123,7 +124,8 @@ public class TraktAddLoader extends GenericSimpleLoader<TraktAddLoader.Result> {
             return buildResultSuccess(new LinkedList<SearchResult>());
         }
 
-        return buildResultSuccess(parseTraktShowsToSearchResults(getContext(), shows));
+        return buildResultSuccess(parseTraktShowsToSearchResults(getContext(), shows,
+                DisplaySettings.getSearchLanguageOrFallbackIfAny(getContext())));
     }
 
     private void extractShows(List<BaseShow> watchedShows, List<Show> shows) {
@@ -148,11 +150,6 @@ public class TraktAddLoader extends GenericSimpleLoader<TraktAddLoader.Result> {
 
     private Result buildResultFailure(@StringRes int errorResId) {
         return new Result(new LinkedList<SearchResult>(), getContext(), errorResId);
-    }
-
-    private static List<SearchResult> parseTraktShowsToSearchResults(Context context,
-            @NonNull List<Show> traktShows) {
-        return parseTraktShowsToSearchResults(context, traktShows, null);
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
@@ -1,11 +1,9 @@
 package com.battlelancer.seriesguide.ui.search;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.text.TextUtils;
+import android.support.annotation.NonNull;
 import com.battlelancer.seriesguide.SgApp;
 import com.battlelancer.seriesguide.dataliberation.model.Show;
-import com.battlelancer.seriesguide.settings.DisplaySettings;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbException;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbTools;
 import com.battlelancer.seriesguide.util.DBUtils;
@@ -24,9 +22,9 @@ class TvdbShowLoader extends GenericSimpleLoader<TvdbShowLoader.Result> {
     }
 
     private final int showTvdbId;
-    private String language;
+    @NonNull private String language;
 
-    TvdbShowLoader(Context context, int showTvdbId, @Nullable String language) {
+    TvdbShowLoader(Context context, int showTvdbId, @NonNull String language) {
         super(context);
         this.showTvdbId = showTvdbId;
         this.language = language;
@@ -38,10 +36,6 @@ class TvdbShowLoader extends GenericSimpleLoader<TvdbShowLoader.Result> {
 
         result.isAdded = DBUtils.isShowExists(getContext(), showTvdbId);
         try {
-            if (TextUtils.isEmpty(language)) {
-                // use search or fall back language
-                language = DisplaySettings.getSearchLanguageOrFallbackIfAny(getContext());
-            }
             TvdbTools tvdbTools = SgApp.getServicesComponent(getContext()).tvdbTools();
             result.show = tvdbTools.getShowDetails(showTvdbId, language);
         } catch (TvdbException e) {

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
@@ -39,8 +39,8 @@ class TvdbShowLoader extends GenericSimpleLoader<TvdbShowLoader.Result> {
         result.isAdded = DBUtils.isShowExists(getContext(), showTvdbId);
         try {
             if (TextUtils.isEmpty(language)) {
-                // fall back to user preferred language
-                language = DisplaySettings.getShowsLanguage(getContext());
+                // use fall back language
+                language = DisplaySettings.getShowsLanguageFallback(getContext());
             }
             TvdbTools tvdbTools = SgApp.getServicesComponent(getContext()).tvdbTools();
             result.show = tvdbTools.getShowDetails(showTvdbId, language);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/TvdbShowLoader.java
@@ -39,8 +39,8 @@ class TvdbShowLoader extends GenericSimpleLoader<TvdbShowLoader.Result> {
         result.isAdded = DBUtils.isShowExists(getContext(), showTvdbId);
         try {
             if (TextUtils.isEmpty(language)) {
-                // use fall back language
-                language = DisplaySettings.getShowsLanguageFallback(getContext());
+                // use search or fall back language
+                language = DisplaySettings.getSearchLanguageOrFallbackIfAny(getContext());
             }
             TvdbTools tvdbTools = SgApp.getServicesComponent(getContext()).tvdbTools();
             result.show = tvdbTools.getShowDetails(showTvdbId, language);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/shows/ShowsNowFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/shows/ShowsNowFragment.java
@@ -30,10 +30,10 @@ import com.battlelancer.seriesguide.jobs.episodes.EpisodeWatchedJob;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract;
 import com.battlelancer.seriesguide.traktapi.TraktCredentials;
 import com.battlelancer.seriesguide.ui.BaseNavDrawerActivity;
-import com.battlelancer.seriesguide.ui.streams.HistoryActivity;
 import com.battlelancer.seriesguide.ui.ShowsActivity;
-import com.battlelancer.seriesguide.ui.search.AddShowDialogFragment;
 import com.battlelancer.seriesguide.ui.episodes.EpisodesActivity;
+import com.battlelancer.seriesguide.ui.search.AddShowDialogFragment;
+import com.battlelancer.seriesguide.ui.streams.HistoryActivity;
 import com.battlelancer.seriesguide.util.TabClickEvent;
 import com.battlelancer.seriesguide.util.ViewTools;
 import com.battlelancer.seriesguide.widgets.EmptyViewSwipeRefreshLayout;
@@ -361,7 +361,8 @@ public class ShowsNowFragment extends Fragment {
                 showDetails(view, item.episodeTvdbId);
             } else if (item.showTvdbId != null) {
                 // episode missing: show likely not in database, suggest adding it
-                AddShowDialogFragment.showAddDialog(item.showTvdbId, getFragmentManager());
+                AddShowDialogFragment
+                        .showAddDialog(getContext(), getFragmentManager(), item.showTvdbId);
             }
             query.close();
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/shows/TraktFriendsEpisodeHistoryLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/shows/TraktFriendsEpisodeHistoryLoader.java
@@ -93,7 +93,7 @@ class TraktFriendsEpisodeHistoryLoader extends GenericSimpleLoader<List<NowAdapt
             if (showTvdbId != null && localShows != null) {
                 // prefer poster of already added show, fall back to first uploaded poster
                 posterUrl = TvdbImageTools.smallSizeOrResolveUrl(localShows.get(showTvdbId),
-                        showTvdbId);
+                        showTvdbId, DisplaySettings.LANGUAGE_EN);
             } else {
                 posterUrl = null;
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/shows/TraktRecentEpisodeHistoryLoader.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/shows/TraktRecentEpisodeHistoryLoader.java
@@ -9,6 +9,7 @@ import android.support.v4.util.SparseArrayCompat;
 import android.text.format.DateUtils;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.SgApp;
+import com.battlelancer.seriesguide.settings.DisplaySettings;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
 import com.battlelancer.seriesguide.traktapi.SgTrakt;
 import com.battlelancer.seriesguide.traktapi.TraktCredentials;
@@ -117,7 +118,7 @@ public class TraktRecentEpisodeHistoryLoader
             if (showTvdbId != null && localShows != null) {
                 // prefer poster of already added show, fall back to first uploaded poster
                 posterUrl = TvdbImageTools.smallSizeOrResolveUrl(localShows.get(showTvdbId),
-                        showTvdbId);
+                        showTvdbId, DisplaySettings.LANGUAGE_EN);
             } else {
                 posterUrl = null;
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/streams/EpisodeHistoryAdapter.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/streams/EpisodeHistoryAdapter.java
@@ -3,6 +3,7 @@ package com.battlelancer.seriesguide.ui.streams;
 import android.content.Context;
 import android.support.v4.util.SparseArrayCompat;
 import android.text.format.DateUtils;
+import com.battlelancer.seriesguide.settings.DisplaySettings;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
 import com.battlelancer.seriesguide.util.TextTools;
@@ -37,7 +38,7 @@ class EpisodeHistoryAdapter extends SectionedHistoryAdapter {
         if (localShowPosters != null && showTvdbId != null) {
             // prefer poster of already added show, fall back to first uploaded poster
             posterUrl = TvdbImageTools.smallSizeOrResolveUrl(localShowPosters.get(showTvdbId),
-                    showTvdbId);
+                    showTvdbId, DisplaySettings.LANGUAGE_EN);
         } else {
             posterUrl = null;
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/streams/UserEpisodeStreamFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/streams/UserEpisodeStreamFragment.java
@@ -69,7 +69,8 @@ public class UserEpisodeStreamFragment extends StreamFragment {
                 showDetails(view, episodeQuery.getInt(0));
             } else {
                 // offer to add the show if it's not in the show database yet
-                AddShowDialogFragment.showAddDialog(item.show.ids.tvdb, getFragmentManager());
+                AddShowDialogFragment.showAddDialog(getContext(), getFragmentManager(),
+                        item.show.ids.tvdb);
             }
 
             episodeQuery.close();

--- a/app/src/main/java/com/battlelancer/seriesguide/util/LanguageTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/LanguageTools.java
@@ -18,12 +18,13 @@ public class LanguageTools {
      * Returns the string representation of the given two letter ISO 639-1 language code if it is
      * supported by SeriesGuide ({@link SeriesGuideContract.Shows#LANGUAGE}).
      *
-     * <p>If the given language code is {@code null}, uses {@link DisplaySettings#getShowsLanguage(Context)}.
+     * <p>If the given language code is {@code null}, uses
+     * {@link DisplaySettings#getShowsLanguageFallback(Context)}.
      */
     public static String getShowLanguageStringFor(Context context, @Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
-            // fall back to default language
-            languageCode = DisplaySettings.getShowsLanguage(context);
+            // use fall back language
+            languageCode = DisplaySettings.getShowsLanguageFallback(context);
         }
 
         return getLanguageStringFor(context, languageCode, R.array.languageCodesShows);
@@ -33,7 +34,7 @@ public class LanguageTools {
      * Returns the string representation of the given two letter ISO 639-1 language code if it is
      * supported by SeriesGuide ({@link SeriesGuideContract.Shows#LANGUAGE}).
      *
-     * <p>If the given language code is {@code null}, uses {@link DisplaySettings#getShowsLanguage(Context)}.
+     * <p>If the given language code is {@code null}, uses {@link DisplaySettings#getMoviesLanguage(Context)}.
      */
     public static String getMovieLanguageStringFor(Context context, @Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
@@ -70,14 +71,15 @@ public class LanguageTools {
      * Returns the string representation and index of the given two letter ISO 639-1 language code
      * if it is supported by SeriesGuide ({@link SeriesGuideContract.Shows#LANGUAGE}).
      *
-     * <p>If the given language code is {@code null}, uses {@link DisplaySettings#getShowsLanguage(Context)}.
+     * <p>If the given language code is {@code null}, uses
+     * {@link DisplaySettings#getShowsLanguageFallback(Context)}.
      */
     @Nullable
     public static LanguageData getShowLanguageDataFor(Context context,
             @Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
-            // fall back to default language
-            languageCode = DisplaySettings.getShowsLanguage(context);
+            // use fall back language
+            languageCode = DisplaySettings.getShowsLanguageFallback(context);
         }
 
         String[] languageCodes = context.getResources().getStringArray(R.array.languageCodesShows);

--- a/app/src/main/java/com/battlelancer/seriesguide/util/LanguageTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/LanguageTools.java
@@ -18,13 +18,13 @@ public class LanguageTools {
      * Returns the string representation of the given two letter ISO 639-1 language code if it is
      * supported by SeriesGuide ({@link SeriesGuideContract.Shows#LANGUAGE}).
      *
-     * <p>If the given language code is {@code null}, uses
-     * {@link DisplaySettings#getShowsLanguageFallback(Context)}.
+     * <p>If the given language code is {@code null} uses 'en' to ensure consistent behavior across
+     * devices.
      */
     public static String getShowLanguageStringFor(Context context, @Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
-            // use fall back language
-            languageCode = DisplaySettings.getShowsLanguageFallback(context);
+            // default to 'en'
+            languageCode = DisplaySettings.LANGUAGE_EN;
         }
 
         return getLanguageStringFor(context, languageCode, R.array.languageCodesShows);
@@ -71,15 +71,15 @@ public class LanguageTools {
      * Returns the string representation and index of the given two letter ISO 639-1 language code
      * if it is supported by SeriesGuide ({@link SeriesGuideContract.Shows#LANGUAGE}).
      *
-     * <p>If the given language code is {@code null}, uses
-     * {@link DisplaySettings#getShowsLanguageFallback(Context)}.
+     * <p>If the given language code is {@code null} uses 'en' to ensure consistent behavior across
+     * devices.
      */
     @Nullable
     public static LanguageData getShowLanguageDataFor(Context context,
             @Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
-            // use fall back language
-            languageCode = DisplaySettings.getShowsLanguageFallback(context);
+            // default to 'en'
+            languageCode = DisplaySettings.LANGUAGE_EN;
         }
 
         String[] languageCodes = context.getResources().getStringArray(R.array.languageCodesShows);

--- a/app/src/main/java/com/battlelancer/seriesguide/util/SgPicassoRequestHandler.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/SgPicassoRequestHandler.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import com.battlelancer.seriesguide.SgApp;
-import com.battlelancer.seriesguide.settings.DisplaySettings;
 import com.battlelancer.seriesguide.settings.TmdbSettings;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbException;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
@@ -52,14 +51,14 @@ public class SgPicassoRequestHandler extends RequestHandler {
 
             String language = request.uri.getQueryParameter(QUERY_LANGUAGE);
             if (TextUtils.isEmpty(language)) {
-                language = DisplaySettings.getShowsLanguage(context);
+                language = null;
             }
 
             TvdbTools tvdbTools = SgApp.getServicesComponent(context).tvdbTools();
             try {
                 retrofit2.Response<SeriesImageQueryResultResponse> posterResponse
                         = tvdbTools.getSeriesPosters(showTvdbId, language);
-                if (posterResponse.code() == 404) {
+                if (language != null && posterResponse.code() == 404) {
                     // no posters for this language, fall back to default
                     posterResponse = tvdbTools.getSeriesPosters(showTvdbId, null);
                 }

--- a/app/src/main/res/layout/dialog_addshow.xml
+++ b/app/src/main/res/layout/dialog_addshow.xml
@@ -76,15 +76,25 @@
 
             </RelativeLayout>
 
+            <Button
+                android:id="@+id/buttonAddLanguage"
+                style="@style/Widget.SeriesGuide.Button.Borderless.Default"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/containerShowInfo"
+                android:layout_marginLeft="@dimen/default_padding"
+                android:layout_marginRight="@dimen/default_padding"
+                android:layout_marginTop="@dimen/default_padding"
+                tools:text="Deutsch" />
+
             <TextView
                 android:id="@+id/textViewAddDescription"
                 style="@style/Block.FlowText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/containerShowInfo"
+                android:layout_below="@+id/buttonAddLanguage"
                 android:layout_marginLeft="@dimen/large_padding"
                 android:layout_marginRight="@dimen/large_padding"
-                android:layout_marginTop="@dimen/large_padding"
                 android:background="?attr/selectableItemBackground"
                 android:focusable="true"
                 android:maxWidth="@dimen/max_width_text_size_body"

--- a/app/src/main/res/xml/settings_basic.xml
+++ b/app/src/main/res/xml/settings_basic.xml
@@ -25,13 +25,6 @@
             android:defaultValue="@string/show_default_language"
             android:entries="@array/languagesShows"
             android:entryValues="@array/languageCodesShows"
-            android:key="language"
-            android:title="@string/pref_language" />
-
-        <ListPreference
-            android:defaultValue="@string/show_default_language"
-            android:entries="@array/languagesShows"
-            android:entryValues="@array/languageCodesShows"
             android:key="com.battlelancer.seriesguide.languageFallback"
             android:title="@string/pref_language_fallback" />
 


### PR DESCRIPTION
- Ensures consistent behavior across devices and encourages users to set a language.
- Use search or fallback language in any case a show is added.