### PR TITLE
Potential fix for JobIntentService SecurityException de-queuing work

### DIFF
--- a/api/src/main/java/android/support/v4/app/SafeJobIntentService.java
+++ b/api/src/main/java/android/support/v4/app/SafeJobIntentService.java
@@ -1,0 +1,106 @@
+package android.support.v4.app;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+/**
+ * Improved version of {@link JobIntentService} which actually stops de-queuing work after the
+ * associated job was stopped by using {@link SafeCommandProcessor}.
+ *
+ * Potential fix for {@link SecurityException} when de-queuing work, assuming they are caused by
+ * the processor trying to dequeue work after the job was already stopped by the system.
+ *
+ * https://issuetracker.google.com/issues/63622293
+ */
+public abstract class SafeJobIntentService extends JobIntentService {
+
+    private SafeCommandProcessor curProcessor;
+
+    @Override
+    boolean doStopCurrentWork() {
+        if (curProcessor != null) {
+            curProcessor.cancel(mInterruptIfStopped);
+        }
+        mStopped = true;
+        return onStopCurrentWork();
+    }
+
+    @Override
+    void ensureProcessorRunningLocked(boolean reportStarted) {
+        if (curProcessor == null) {
+            curProcessor = new SafeCommandProcessor();
+            if (mCompatWorkEnqueuer != null && reportStarted) {
+                mCompatWorkEnqueuer.serviceProcessingStarted();
+            }
+            if (DEBUG) {
+                Log.d(TAG, "Starting processor: " + curProcessor);
+            }
+            curProcessor.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    void processorFinished() {
+        if (mCompatQueue != null) {
+            synchronized (mCompatQueue) {
+                curProcessor = null;
+                // The async task has finished, but we may have gotten more work scheduled in the
+                // meantime.  If so, we need to restart the new processor to execute it.  If there
+                // is no more work at this point, either the service is in the process of being
+                // destroyed (because we called stopSelf on the last intent started for it), or
+                // someone has already called startService with a new Intent that will be
+                // arriving shortly.  In either case, we want to just leave the service
+                // waiting -- either to get destroyed, or get a new onStartCommand() callback
+                // which will then kick off a new processor.
+                if (mCompatQueue != null && mCompatQueue.size() > 0) {
+                    ensureProcessorRunningLocked(false);
+                } else if (!mDestroyed) {
+                    mCompatWorkEnqueuer.serviceProcessingFinished();
+                }
+            }
+        }
+    }
+
+    /**
+     * Copy of {@link android.support.v4.app.JobIntentService.CommandProcessor} which actually
+     * checks for {@link AsyncTask#isCancelled()} as suggested by the example implementation at
+     * https://android.googlesource.com/platform/development/+/master/samples/ApiDemos/src/com/example/android/apis/app/JobWorkService.java
+     */
+    final class SafeCommandProcessor extends AsyncTask<Void, Void, Void> {
+        @Override
+        protected Void doInBackground(Void... params) {
+            GenericWorkItem work;
+
+            if (DEBUG) {
+                Log.d(TAG, "Starting to dequeue work...");
+            }
+
+            // stop de-queuing work if the processor was cancelled
+            while (!isCancelled() && (work = dequeueWork()) != null) {
+                if (DEBUG) {
+                    Log.d(TAG, "Processing next work: " + work);
+                }
+                onHandleWork(work.getIntent());
+                if (DEBUG) {
+                    Log.d(TAG, "Completing work: " + work);
+                }
+                work.complete();
+            }
+
+            if (DEBUG) {
+                Log.d(TAG, "Done processing work!");
+            }
+
+            return null;
+        }
+
+        @Override
+        protected void onCancelled(Void aVoid) {
+            processorFinished();
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            processorFinished();
+        }
+    }
+}

--- a/api/src/main/java/com/battlelancer/seriesguide/api/SeriesGuideExtension.java
+++ b/api/src/main/java/com/battlelancer/seriesguide/api/SeriesGuideExtension.java
@@ -1,27 +1,5 @@
 package com.battlelancer.seriesguide.api;
 
-import android.annotation.SuppressLint;
-import android.app.job.JobService;
-import android.content.ComponentName;
-import android.content.Context;
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
-import android.os.Build;
-import android.os.Bundle;
-import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.v4.app.JobIntentService;
-import android.text.TextUtils;
-import android.util.Log;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONTokener;
-
 import static com.battlelancer.seriesguide.api.constants.IncomingConstants.ACTION_SUBSCRIBE;
 import static com.battlelancer.seriesguide.api.constants.IncomingConstants.ACTION_UPDATE;
 import static com.battlelancer.seriesguide.api.constants.IncomingConstants.EXTRA_ENTITY_IDENTIFIER;
@@ -35,6 +13,29 @@ import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.ACTIO
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.ACTION_TYPE_MOVIE;
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.EXTRA_ACTION;
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.EXTRA_ACTION_TYPE;
+
+import android.annotation.SuppressLint;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
+import android.support.v4.app.SafeJobIntentService;
+import android.text.TextUtils;
+import android.util.Log;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 
 /**
  * Base class for a SeriesGuide extension. Extensions are a way for other apps to
@@ -167,7 +168,7 @@ import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.EXTRA
  * <p> Based on code from <a href="https://github.com/romannurik/muzei">Muzei</a>, an awesome Live
  * Wallpaper by Roman Nurik.
  */
-public abstract class SeriesGuideExtension extends JobIntentService {
+public abstract class SeriesGuideExtension extends SafeJobIntentService {
 
     private static final String TAG = "SeriesGuideExtension";
 

--- a/app/src/main/java/com/battlelancer/seriesguide/extensions/ExtensionActionService.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/extensions/ExtensionActionService.java
@@ -1,22 +1,22 @@
 package com.battlelancer.seriesguide.extensions;
 
-import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.v4.app.JobIntentService;
-import com.battlelancer.seriesguide.SgApp;
-import com.battlelancer.seriesguide.api.Action;
-
 import static com.battlelancer.seriesguide.api.constants.IncomingConstants.EXTRA_TOKEN;
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.ACTION_TYPE_EPISODE;
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.EXTRA_ACTION;
 import static com.battlelancer.seriesguide.api.constants.OutgoingConstants.EXTRA_ACTION_TYPE;
 
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.SafeJobIntentService;
+import com.battlelancer.seriesguide.SgApp;
+import com.battlelancer.seriesguide.api.Action;
+
 /**
  * Processes actions published by enabled extensions.
  */
-public class ExtensionActionService extends JobIntentService {
+public class ExtensionActionService extends SafeJobIntentService {
 
     public static void enqueue(Context context, Intent actionIntent) {
         enqueueWork(context, ExtensionActionService.class, SgApp.JOB_ID_EXTENSION_ACTIONS_SERVICE,

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/UnwatchedUpdaterService.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/UnwatchedUpdaterService.java
@@ -6,6 +6,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.JobIntentService;
+import android.support.v4.app.SafeJobIntentService;
 import com.battlelancer.seriesguide.SgApp;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract;
 import com.battlelancer.seriesguide.util.DBUtils;
@@ -16,7 +17,7 @@ import timber.log.Timber;
  * JobIntentService} so only one runs at a time. Not using an IntentService as it ran into
  * O background restrictions on some devices (even though it was started during onStart).
  */
-public class UnwatchedUpdaterService extends JobIntentService {
+public class UnwatchedUpdaterService extends SafeJobIntentService {
 
     public static final String EXTRA_SHOW_TVDB_ID = "showTvdbId";
     public static final String EXTRA_OPTIONAL_SEASON_TVDB_ID = "seasonTvdbId";


### PR DESCRIPTION
Add SafeJobIntentService which actually stops de-queuing work after the
associated job was stopped by using SafeCommandProcessor
following the example implementation of Dianne Hackborn.

https://android.googlesource.com/platform/development/+/master/samples/ApiDemos/src/com/example/android/apis/app/JobWorkService.java

https://issuetracker.google.com/issues/63622293