### PR TITLE
Use Room transactions in Content Provider

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
@@ -74,6 +74,7 @@ abstract class SgRoomDatabase : RoomDatabase() {
                                     MIGRATION_38_43
                             )
                             .addCallback(CALLBACK)
+                            .allowMainThreadQueries()
                             .build()
                     instance = newInstance
                     newInstance


### PR DESCRIPTION
The Room invalidation tracker requires transactions to be handled
through the RoomDatabase API (this is also suggested by [the Content
Provider example](https://github.com/googlesamples/android-architecture-components/blob/master/PersistenceContentProviderSample/app/src/main/java/com/example/android/contentprovidersample/provider/SampleContentProvider.java)). Also temporarily disable yielding as not sure if that
throws of the invalidation tracking.

And temporarily allow main thread queries.
Some ContentProvider ops in SeriesGuide do run on the main thread.
Allow them until they are moved to background threads.