### PR TITLE
Always sync trakt basics

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.java
@@ -16,15 +16,15 @@ import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.SgApp;
 import com.battlelancer.seriesguide.backend.HexagonTools;
 import com.battlelancer.seriesguide.backend.settings.HexagonSettings;
-import com.battlelancer.seriesguide.ui.search.SearchResult;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
 import com.battlelancer.seriesguide.service.NotificationService;
 import com.battlelancer.seriesguide.settings.UpdateSettings;
 import com.battlelancer.seriesguide.sync.SyncOptions.SyncType;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbTools;
-import com.battlelancer.seriesguide.util.DBUtils;
 import com.battlelancer.seriesguide.ui.movies.MovieTools;
+import com.battlelancer.seriesguide.ui.search.SearchResult;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
+import com.battlelancer.seriesguide.util.DBUtils;
 import com.battlelancer.seriesguide.util.TaskManager;
 import com.uwetrottmann.androidutils.AndroidUtils;
 import com.uwetrottmann.tmdb2.services.ConfigurationService;
@@ -149,22 +149,28 @@ public class SgSyncAdapter extends AbstractThreadedSyncAdapter {
             if (existingShows == null) {
                 resultCode = UpdateResult.INCOMPLETE;
             } else {
-                UpdateResult resultSync;
-                if (HexagonSettings.isEnabled(getContext())) {
-                    // sync with hexagon...
-                    resultSync = new HexagonSync(getContext(), hexagonTools.get(), movieTools.get(),
-                            progress).sync(existingShows, newShows);
+                // sync with hexagon
+                boolean isHexagonEnabled = HexagonSettings.isEnabled(getContext());
+                if (isHexagonEnabled) {
+                    UpdateResult resultHexagonSync = new HexagonSync(getContext(),
+                            hexagonTools.get(), movieTools.get(), progress)
+                            .sync(existingShows, newShows);
+                    // don't overwrite failure
+                    if (resultCode == UpdateResult.SUCCESS) {
+                        resultCode = resultHexagonSync;
+                    }
                     Timber.d("Syncing: Hexagon...DONE");
-                } else {
-                    // ...OR sync with trakt
-                    resultSync = new TraktSync(getContext(), movieTools.get(),
-                            traktSync.get(), progress).sync(existingShows, currentTime);
-                    Timber.d("Syncing: trakt...DONE");
                 }
+
+                // sync with trakt (only watched movies + ratings if hexagon is enabled)
+                UpdateResult resultTraktSync = new TraktSync(getContext(), movieTools.get(),
+                        traktSync.get(), progress)
+                        .sync(existingShows, currentTime, isHexagonEnabled);
                 // don't overwrite failure
                 if (resultCode == UpdateResult.SUCCESS) {
-                    resultCode = resultSync;
+                    resultCode = resultTraktSync;
                 }
+                Timber.d("Syncing: trakt...DONE");
 
                 // make sure other loaders (activity, overview, details) are notified of changes
                 getContext().getContentResolver().notifyChange(Episodes.CONTENT_URI_WITHSHOW, null);

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/TraktSync.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/TraktSync.java
@@ -38,18 +38,12 @@ public class TraktSync {
      */
     public SgSyncAdapter.UpdateResult sync(HashSet<Integer> localShows, long currentTime,
             boolean onlyRatingsAndWatchedMovies) {
+        // get last activity timestamps
         progress.publish(SyncProgress.Step.TRAKT);
-        if (!TraktCredentials.get(context).hasCredentials()) {
-            progress.recordError();
-            Timber.d("performTraktSync: no auth, skip");
-            return SgSyncAdapter.UpdateResult.SUCCESS;
-        }
         if (!AndroidUtils.isNetworkConnected(context)) {
             progress.recordError();
             return SgSyncAdapter.UpdateResult.INCOMPLETE;
         }
-
-        // get last activity timestamps
         LastActivities lastActivity = getLastActivity();
         if (lastActivity == null) {
             // trakt is likely offline or busy, try later


### PR DESCRIPTION
When Cloud and trakt are connected, also sync trakt ratings (shows, episodes and movies) and watched movies as they do not conflict with Cloud sync. Also cleans up movie database items not watched or in any list.

Also skip trakt sync instead of showing error if there are no credentials.