### PR TITLE
Fix for issue #520 - Local search only works with exact title

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowSearchFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/ShowSearchFragment.kt
@@ -82,7 +82,7 @@ class ShowSearchFragment : BaseSearchFragment() {
     private val searchLoaderCallbacks = object : LoaderManager.LoaderCallbacks<Cursor> {
         override fun onCreateLoader(id: Int, args: Bundle?): Loader<Cursor> {
             loaderArgs = args
-            val query = args?.getString(SearchManager.QUERY)
+            var query = args?.getString(SearchManager.QUERY)
             return if (query.isNullOrEmpty()) {
                 // empty query selects shows with next episodes before this point in time
                 CursorLoader(requireContext(), Shows.CONTENT_URI,
@@ -92,6 +92,7 @@ class ShowSearchFragment : BaseSearchFragment() {
                                 requireContext()) + DateUtils.HOUR_IN_MILLIS).toString()),
                         Shows.SORT_LATEST_EPISODE)
             } else {
+                query = query.replace("\\s".toRegex(), "%");
                 Shows.CONTENT_URI_FILTER.buildUpon().appendPath(query).build().let {
                     CursorLoader(requireActivity(), it, ShowResultsAdapter.Query.PROJECTION,
                             null, null, null)


### PR DESCRIPTION
This commit modifies the query to make it as a pattern rather than the raw string.
Eg: "Mr Robot" gets modified as "Mr%Robot"
As per SQLite documentation, A percent symbol ("%") in the LIKE pattern matches any sequence of zero or more characters in the string.