### PR TITLE
Migrate to Material Components theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha04'
     implementation 'androidx.palette:palette:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
@@ -200,6 +200,9 @@ dependencies {
     implementation "com.google.android.gms:play-services-auth:16.0.1"
 
     // App Engine
+    // override Guava version to avoid duplicate classes due to listenablefuture extraction
+    // remove once API client depends on Guava 27.0 or newer
+    implementation 'com.google.guava:guava:27.0.1-android'
     // https://github.com/googleapis/google-api-java-client/releases
     implementation('com.google.api-client:google-api-client-android:1.28.0') {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient' // unused

--- a/app/src/main/java/com/battlelancer/seriesguide/extensions/ActionsHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/extensions/ActionsHelper.java
@@ -9,11 +9,9 @@ import android.widget.Button;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.api.Action;
 import com.battlelancer.seriesguide.util.Utils;
-import com.battlelancer.seriesguide.util.ViewTools;
 import com.uwetrottmann.androidutils.AndroidUtils;
 import com.uwetrottmann.androidutils.CheatSheet;
 import java.util.List;
@@ -37,18 +35,12 @@ public class ActionsHelper {
         }
         actionsContainer.removeAllViews();
 
-        // re-use drawable for all buttons
-        VectorDrawableCompat drawable = ViewTools.vectorIconActive(actionsContainer.getContext(),
-                theme, R.drawable.ic_extension_black_24dp);
-
         // add a view per action
         if (data != null) {
             for (Action action : data) {
                 Button actionView = (Button) layoutInflater.inflate(R.layout.item_action,
                         actionsContainer, false);
                 actionView.setText(action.getTitle());
-                ViewTools.setCompoundDrawablesRelativeWithIntrinsicBounds(actionView, drawable,
-                        null, null, null);
 
                 CheatSheet.setup(actionView, action.getTitle());
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
@@ -182,14 +182,6 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         ViewTools.setVectorIconLeft(theme, buttonStreamingSearch,
                 R.drawable.ic_play_arrow_black_24dp);
 
-        // comments button
-        ViewTools.setVectorIconLeft(theme, commentsButton, R.drawable.ic_forum_black_24dp);
-
-        // other bottom buttons
-        ViewTools.setVectorIconLeft(theme, imdbButton, R.drawable.ic_link_black_24dp);
-        ViewTools.setVectorIconLeft(theme, tvdbButton, R.drawable.ic_link_black_24dp);
-        ViewTools.setVectorIconLeft(theme, traktButton, R.drawable.ic_link_black_24dp);
-
         // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
         ClipboardTools.copyTextToClipboardOnLongClick(textViewTitle);
         ClipboardTools.copyTextToClipboardOnLongClick(textViewReleaseTime);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.kt
@@ -191,7 +191,6 @@ class MovieDetailsFragment : Fragment(), MovieActionsContract {
 
         // comments button
         buttonMovieComments.isGone = true
-        ViewTools.setVectorIconLeft(theme, buttonMovieComments, R.drawable.ic_forum_black_24dp)
 
         // cast and crew
         setCastVisibility(false)

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/movies/MovieDetailsFragment.kt
@@ -186,7 +186,6 @@ class MovieDetailsFragment : Fragment(), MovieActionsContract {
 
         // language button
         buttonMovieLanguage.isGone = true
-        ViewTools.setVectorIconLeft(theme, buttonMovieLanguage, R.drawable.ic_language_white_24dp)
         CheatSheet.setup(buttonMovieLanguage, R.string.pref_language)
         buttonMovieLanguage.setOnClickListener { displayLanguageSettings() }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/OverviewFragment.java
@@ -196,14 +196,6 @@ public class OverviewFragment extends Fragment implements
         CheatSheet.setup(containerRatings, R.string.action_rate);
         textRatingRange.setText(getString(R.string.format_rating_range, 10));
 
-        // comments button
-        ViewTools.setVectorIconLeft(theme, buttonComments, R.drawable.ic_forum_black_24dp);
-
-        // other bottom buttons
-        ViewTools.setVectorIconLeft(theme, buttonImdb, R.drawable.ic_link_black_24dp);
-        ViewTools.setVectorIconLeft(theme, buttonTvdb, R.drawable.ic_link_black_24dp);
-        ViewTools.setVectorIconLeft(theme, buttonTrakt, R.drawable.ic_link_black_24dp);
-
         // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
         ClipboardTools.copyTextToClipboardOnLongClick(textDescription);
         ClipboardTools.copyTextToClipboardOnLongClick(textGuestStars);

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.kt
@@ -164,7 +164,6 @@ class ShowFragment : ScopedFragment() {
 
         // language button
         val theme = activity!!.theme
-        ViewTools.setVectorIconLeft(theme, buttonLanguage, R.drawable.ic_language_white_24dp)
         buttonLanguage.setOnClickListener { displayLanguageSettings() }
         CheatSheet.setup(buttonLanguage, R.string.pref_language)
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/overview/ShowFragment.kt
@@ -172,22 +172,10 @@ class ShowFragment : ScopedFragment() {
         CheatSheet.setup(buttonRate, R.string.action_rate)
         textViewRatingRange.text = getString(R.string.format_rating_range, 10)
 
-        // link, search and comments button
-        ViewTools.setVectorIconLeft(theme, buttonImdb, R.drawable.ic_link_black_24dp)
-        ViewTools.setVectorIconLeft(theme, buttonTvdb, R.drawable.ic_link_black_24dp)
-        ViewTools.setVectorIconLeft(theme, buttonTrakt, R.drawable.ic_link_black_24dp)
-        ViewTools.setVectorIconLeft(theme, buttonWebSearch, R.drawable.ic_search_white_24dp)
-        ViewTools.setVectorIconLeft(theme, buttonComments, R.drawable.ic_forum_black_24dp)
-
         // share button
-        ViewTools.setVectorIconLeft(theme, buttonShare, R.drawable.ic_share_white_24dp)
         buttonShare.setOnClickListener { shareShow() }
 
         // shortcut button
-        ViewTools.setVectorIconLeft(
-            theme, buttonShortcut,
-            R.drawable.ic_add_to_home_screen_black_24dp
-        )
         buttonShortcut.setOnClickListener { createShortcut() }
 
         setCastVisibility(false)

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/people/PersonFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/people/PersonFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
-import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -25,7 +24,6 @@ import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.util.ServiceUtils
 import com.battlelancer.seriesguide.util.TextTools
 import com.battlelancer.seriesguide.util.TmdbTools
-import com.battlelancer.seriesguide.util.ViewTools
 import com.battlelancer.seriesguide.util.copyTextToClipboard
 import com.uwetrottmann.androidutils.AndroidUtils
 import com.uwetrottmann.tmdb2.entities.Person
@@ -43,10 +41,6 @@ class PersonFragment : Fragment() {
     lateinit var textViewName: TextView
     @BindView(R.id.textViewPersonBiography)
     lateinit var textViewBiography: TextView
-    @BindView(R.id.buttonPersonTmdbLink)
-    lateinit var buttonTmdbLink: Button
-    @BindView(R.id.buttonPersonWebSearch)
-    lateinit var buttonWebSearch: Button
     private lateinit var unbinder: Unbinder
 
     private var personTmdbId: Int = 0
@@ -62,11 +56,6 @@ class PersonFragment : Fragment() {
             savedInstanceState: Bundle?): View? {
         val rootView = inflater.inflate(R.layout.fragment_person, container, false)
         unbinder = ButterKnife.bind(this, rootView)
-
-        val theme = requireActivity().theme
-        ViewTools.setVectorIconLeft(theme, buttonTmdbLink, R.drawable.ic_link_black_24dp)
-        ViewTools.setVectorIconLeft(theme, buttonWebSearch, R.drawable.ic_search_white_24dp)
-
         return rootView
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/search/AddShowDialogFragment.java
@@ -170,8 +170,6 @@ public class AddShowDialogFragment extends AppCompatDialogFragment {
         final View v = inflater.inflate(R.layout.dialog_addshow, container, false);
         unbinder = ButterKnife.bind(this, v);
 
-        ViewTools.setVectorIconLeft(getActivity().getTheme(), buttonLanguage,
-                R.drawable.ic_language_white_24dp);
         CheatSheet.setup(buttonLanguage, R.string.pref_language);
         ratingRange.setText(getString(R.string.format_rating_range, 10));
 

--- a/app/src/main/res/layout-w1024dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w1024dp/fragment_movie.xml
@@ -182,14 +182,14 @@
                         android:layout_marginTop="@dimen/large_padding"
                         android:background="?attr/sgColorDivider" />
 
-                    <!-- Compound drawable set in code. -->
                     <Button
                         android:id="@+id/buttonMovieComments"
                         style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/dividerMovie2"
-                        android:text="@string/comments" />
+                        android:text="@string/comments"
+                        app:icon="@drawable/ic_forum_black_24dp" />
 
                     <View
                         android:id="@+id/dividerMovie3"

--- a/app/src/main/res/layout-w1024dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w1024dp/fragment_movie.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rootLayoutMovie"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -136,6 +137,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginLeft="@dimen/padding_button"
                         android:layout_marginRight="@dimen/padding_button"
+                        app:icon="@drawable/ic_language_white_24dp"
                         tools:text="Deutsch" />
 
                     <TextView

--- a/app/src/main/res/layout-w590dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w590dp/fragment_movie.xml
@@ -172,13 +172,13 @@
                         android:background="?attr/sgColorDivider"
                         tools:ignore="UnknownIdInLayout" />
 
-                    <!-- Compound drawable set in code. -->
                     <Button
                         android:id="@+id/buttonMovieComments"
                         style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/comments" />
+                        android:text="@string/comments"
+                        app:icon="@drawable/ic_forum_black_24dp" />
 
                     <View
                         android:id="@+id/dividerMovie3"

--- a/app/src/main/res/layout-w590dp/fragment_movie.xml
+++ b/app/src/main/res/layout-w590dp/fragment_movie.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rootLayoutMovie"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -114,6 +115,7 @@
                         android:layout_marginLeft="@dimen/padding_button"
                         android:layout_marginRight="@dimen/padding_button"
                         android:layout_marginTop="@dimen/inline_padding"
+                        app:icon="@drawable/ic_language_white_24dp"
                         tools:text="Deutsch" />
 
                     <TextView

--- a/app/src/main/res/layout/buttons_episode.xml
+++ b/app/src/main/res/layout/buttons_episode.xml
@@ -75,7 +75,6 @@
         android:layout_marginRight="@dimen/padding_button"
         android:contentDescription="@string/checkin"
         android:drawablePadding="8dp"
-        android:gravity="center_vertical|start"
         android:nextFocusUp="@+id/buttonEpisodeWatched"
         android:text="@string/checkin"
         tools:drawableLeft="@drawable/ic_checkin_black_24dp"
@@ -90,7 +89,6 @@
         android:layout_marginRight="@dimen/padding_button"
         android:contentDescription="@string/action_stream"
         android:drawablePadding="8dp"
-        android:gravity="center_vertical|start"
         android:text="@string/action_stream"
         tools:drawableLeft="@drawable/ic_play_arrow_black_24dp"
         tools:drawableTint="?attr/sgColorIcon" />

--- a/app/src/main/res/layout/buttons_episode_more.xml
+++ b/app/src/main/res/layout/buttons_episode_more.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Button
         android:id="@+id/buttonEpisodeImdb"
@@ -9,8 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/imdb"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonEpisodeTvdb"
@@ -18,8 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/tvdb"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonEpisodeTrakt"
@@ -27,8 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/trakt"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonEpisodeComments"
@@ -36,7 +33,6 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/comments"
-        tools:drawableLeft="@drawable/ic_forum_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_forum_black_24dp" />
 
 </merge>

--- a/app/src/main/res/layout/buttons_movie.xml
+++ b/app/src/main/res/layout/buttons_movie.xml
@@ -19,7 +19,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ellipsize="end"
-            android:maxLines="2"
+            android:maxLines="3"
             android:padding="8dp"
             android:text="@string/action_watched"
             tools:drawableTint="?attr/sgColorIcon"
@@ -32,7 +32,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ellipsize="end"
-            android:maxLines="2"
+            android:maxLines="3"
             android:padding="8dp"
             android:text="@string/watchlist_add"
             tools:drawableTint="?attr/sgColorIcon"
@@ -45,7 +45,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:ellipsize="end"
-            android:maxLines="2"
+            android:maxLines="3"
             android:padding="8dp"
             android:text="@string/action_collection_add"
             tools:drawableTint="?attr/sgColorIcon"
@@ -63,7 +63,7 @@
 
     <Button
         android:id="@+id/buttonMovieCheckIn"
-        style="@style/Widget.SeriesGuide.Button.Borderless.Default"
+        style="@style/Widget.SeriesGuide.Button.Borderless.Caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/padding_button"
@@ -75,7 +75,7 @@
 
     <Button
         android:id="@+id/buttonMovieStreamingSearch"
-        style="@style/Widget.SeriesGuide.Button.Borderless.Default"
+        style="@style/Widget.SeriesGuide.Button.Borderless.Caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/padding_button"

--- a/app/src/main/res/layout/buttons_show_bottom.xml
+++ b/app/src/main/res/layout/buttons_show_bottom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Button
         android:id="@+id/buttonShowImdb"
@@ -9,8 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/imdb"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonShowTvdb"
@@ -18,8 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/tvdb"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonShowTrakt"
@@ -27,8 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/trakt"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_link_black_24dp" />
 
     <Button
         android:id="@+id/buttonShowWebSearch"
@@ -36,8 +33,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/web_search"
-        tools:drawableLeft="@drawable/ic_search_white_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_search_white_24dp" />
 
     <Button
         android:id="@+id/buttonShowShare"
@@ -45,8 +41,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/share_show"
-        tools:drawableLeft="@drawable/ic_share_white_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_share_white_24dp" />
 
     <Button
         android:id="@+id/buttonShowShortcut"
@@ -54,8 +49,7 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/add_to_homescreen"
-        tools:drawableLeft="@drawable/ic_link_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_add_to_home_screen_black_24dp" />
 
     <Button
         android:id="@+id/buttonShowComments"
@@ -63,7 +57,6 @@
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:text="@string/comments"
-        tools:drawableLeft="@drawable/ic_forum_black_24dp"
-        tools:drawableTint="?attr/sgColorIcon" />
+        app:icon="@drawable/ic_forum_black_24dp" />
 
 </merge>

--- a/app/src/main/res/layout/dialog_addshow.xml
+++ b/app/src/main/res/layout/dialog_addshow.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <ScrollView
@@ -85,6 +86,7 @@
                 android:layout_marginLeft="@dimen/default_padding"
                 android:layout_marginRight="@dimen/default_padding"
                 android:layout_marginTop="@dimen/default_padding"
+                app:icon="@drawable/ic_language_white_24dp"
                 tools:text="Deutsch" />
 
             <TextView

--- a/app/src/main/res/layout/dialog_buttons.xml
+++ b/app/src/main/res/layout/dialog_buttons.xml
@@ -9,7 +9,7 @@
         android:paddingBottom="@dimen/inline_padding"
         android:paddingLeft="@dimen/default_padding"
         android:paddingRight="@dimen/default_padding"
-        android:paddingTop="@dimen/larger_padding"
+        android:paddingTop="@dimen/inline_padding"
         app:allowStacking="true">
 
         <androidx.legacy.widget.Space

--- a/app/src/main/res/layout/dialog_list_manage.xml
+++ b/app/src/main/res/layout/dialog_list_manage.xml
@@ -5,27 +5,31 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <FrameLayout
+    <LinearLayout
         style="@style/DefaultPadding.DialogContent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:baselineAligned="false"
         android:minWidth="@dimen/dialog_min_width">
 
+        <!-- match_parent is broken, so use LinearLayout that scales this to max width instead -->
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayoutListManageListName"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/list_title_hint">
 
             <!-- Set inputType as it does not default to (single-line) text like EditText. -->
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text"
-                android:hint="@string/list_title_hint" />
+                android:inputType="text" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
-    </FrameLayout>
+    </LinearLayout>
 
     <include layout="@layout/dialog_buttons" />
 

--- a/app/src/main/res/layout/dialog_localization.xml
+++ b/app/src/main/res/layout/dialog_localization.xml
@@ -25,7 +25,7 @@
 
         <Button
             android:id="@+id/buttonLocalizationLanguage"
-            style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
+            style="@style/Widget.SeriesGuide.Button.Borderless.Sheet.Menu"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/inline_padding"
@@ -45,7 +45,7 @@
 
         <Button
             android:id="@+id/buttonLocalizationRegion"
-            style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
+            style="@style/Widget.SeriesGuide.Button.Borderless.Sheet.Menu"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/default_padding"

--- a/app/src/main/res/layout/drawer_item_account.xml
+++ b/app/src/main/res/layout/drawer_item_account.xml
@@ -37,7 +37,7 @@
         android:paddingLeft="@dimen/keyline"
         android:paddingRight="@dimen/keyline"
         android:paddingTop="@dimen/default_padding"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark">
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark">
 
         <TextView
             android:id="@+id/textViewDrawerAccountTrakt"
@@ -70,7 +70,7 @@
         android:paddingLeft="@dimen/keyline"
         android:paddingRight="@dimen/keyline"
         android:paddingTop="@dimen/default_padding"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark">
+        android:theme="@style/ThemeOverlay.MaterialComponents.Dark">
 
         <TextView
             android:id="@+id/textViewDrawerAccountCloud"

--- a/app/src/main/res/layout/fragment_movie.xml
+++ b/app/src/main/res/layout/fragment_movie.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rootLayoutMovie"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -110,6 +111,7 @@
                 android:layout_below="@+id/dividerMovie0"
                 android:layout_marginLeft="@dimen/padding_button"
                 android:layout_marginRight="@dimen/padding_button"
+                app:icon="@drawable/ic_language_white_24dp"
                 tools:text="Deutsch" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_movie.xml
+++ b/app/src/main/res/layout/fragment_movie.xml
@@ -196,14 +196,14 @@
                 android:layout_marginTop="@dimen/inline_padding"
                 android:background="?attr/sgColorDivider" />
 
-            <!-- Compound drawable set in code. -->
             <Button
                 android:id="@+id/buttonMovieComments"
                 style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/dividerMovie3"
-                android:text="@string/comments" />
+                android:text="@string/comments"
+                app:icon="@drawable/ic_forum_black_24dp" />
 
             <View
                 android:id="@+id/dividerMovie4"

--- a/app/src/main/res/layout/fragment_person.xml
+++ b/app/src/main/res/layout/fragment_person.xml
@@ -93,8 +93,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textViewPersonBiography"
-            tools:drawableLeft="@drawable/ic_link_black_24dp"
-            tools:drawableTint="?attr/sgColorIcon" />
+            app:icon="@drawable/ic_link_black_24dp" />
 
         <Button
             android:id="@+id/buttonPersonWebSearch"
@@ -105,8 +104,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/buttonPersonTmdbLink"
-            tools:drawableLeft="@drawable/ic_search_white_24dp"
-            tools:drawableTint="?attr/sgColorIcon" />
+            app:icon="@drawable/ic_search_white_24dp" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_person_wide.xml
+++ b/app/src/main/res/layout/fragment_person_wide.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginRight="@dimen/large_padding"
     android:baselineAligned="false"
     android:orientation="horizontal"
@@ -87,8 +88,7 @@
                 android:layout_height="48dp"
                 android:layout_marginTop="8dp"
                 android:text="@string/tmdb"
-                tools:drawableLeft="@drawable/ic_link_black_24dp"
-                tools:drawableTint="?attr/sgColorIcon" />
+                app:icon="@drawable/ic_link_black_24dp" />
 
             <Button
                 android:id="@+id/buttonPersonWebSearch"
@@ -96,8 +96,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:text="@string/web_search"
-                tools:drawableLeft="@drawable/ic_search_white_24dp"
-                tools:drawableTint="?attr/sgColorIcon" />
+                app:icon="@drawable/ic_search_white_24dp" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_show_meta.xml
+++ b/app/src/main/res/layout/fragment_show_meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Button
         android:id="@+id/buttonShowLanguage"
@@ -9,6 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/padding_button"
         android:layout_marginRight="@dimen/padding_button"
+        app:icon="@drawable/ic_language_white_24dp"
         tools:text="Deutsch" />
 
     <TextView

--- a/app/src/main/res/layout/item_action.xml
+++ b/app/src/main/res/layout/item_action.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Button xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/textViewItemActionTitle"
     style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:ellipsize="end"
-    tools:drawableLeft="@drawable/ic_extension_black_24dp"
-    tools:drawableTint="?attr/sgColorIcon"
+    app:icon="@drawable/ic_extension_black_24dp"
     tools:text="Some Extension Action" />

--- a/app/src/main/res/layout/item_action_add.xml
+++ b/app/src/main/res/layout/item_action_add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/textViewItemActionTitle"
     style="@style/Widget.SeriesGuide.Button.Borderless.Accent"

--- a/app/src/main/res/layout/item_dropdown.xml
+++ b/app/src/main/res/layout/item_dropdown.xml
@@ -7,6 +7,7 @@
     style="@style/Widget.SeriesGuide.TextView.SingleLine"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:ellipsize="end"
     android:gravity="center_vertical"
     android:minHeight="48dp"

--- a/app/src/main/res/layout/item_extension_add.xml
+++ b/app/src/main/res/layout/item_extension_add.xml
@@ -2,7 +2,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="48dp">
+    android:layout_height="48dp"
+    android:background="?attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/textViewItemExtensionAddLabel"

--- a/app/src/main/res/layout/toolbar_transparent.xml
+++ b/app/src/main/res/layout/toolbar_transparent.xml
@@ -7,5 +7,5 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="@color/transparent"
-    android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+    android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar"
     app:layout_scrollFlags="scroll|enterAlways|snap" />

--- a/app/src/main/res/layout/toolbar_transparent_with_spinner.xml
+++ b/app/src/main/res/layout/toolbar_transparent_with_spinner.xml
@@ -7,7 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="@color/transparent"
-    android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+    android:theme="@style/ThemeOverlay.MaterialComponents.ActionBar"
     app:layout_scrollFlags="scroll|enterAlways|snap">
 
     <Spinner

--- a/app/src/main/res/layout/view_filter_shows.xml
+++ b/app/src/main/res/layout/view_filter_shows.xml
@@ -58,7 +58,7 @@
 
     <Button
         android:id="@+id/button_shows_filter_remove"
-        style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
+        style="@style/Widget.SeriesGuide.Button.Borderless.Sheet.Menu"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/empty_filter" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -159,11 +159,14 @@
         <item name="android:insetBottom">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:gravity">center_vertical|start</item>
-        <item name="android:fontFamily" tools:ignore="NewApi">sans-serif</item>
-        <item name="android:textAppearance">@style/TextAppearance.Menu</item>
         <item name="android:paddingLeft">@dimen/large_padding</item>
         <item name="android:paddingRight">@dimen/large_padding</item>
-        <item name="android:drawablePadding">32dp</item>
+        <item name="iconPadding">32dp</item>
+    </style>
+
+    <style name="Widget.SeriesGuide.Button.Borderless.Sheet.Menu">
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textAppearance">@style/TextAppearance.Menu</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Accent">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -147,11 +147,10 @@
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
-    <style name="Widget.SeriesGuide.Button.Borderless.Default">
+    <style name="Widget.SeriesGuide.Button.Borderless.Default" parent="Widget.MaterialComponents.Button.OutlinedButton.Icon">
         <item name="android:textAllCaps">false</item>
-        <item name="android:gravity">center_vertical|start</item>
-        <item name="android:fontFamily">sans-serif</item>
-        <item name="android:drawablePadding">@dimen/default_padding</item>
+        <item name="android:textColor">?android:attr/textColorSecondary</item>
+        <item name="iconTint">?android:attr/textColorSecondary</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Sheet">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -150,8 +150,9 @@
     <style name="Widget.SeriesGuide" parent="Widget" />
 
     <!-- Buttons -->
-    <style name="Widget.SeriesGuide.Button.Borderless" parent="android:Widget.Material.Button.Borderless">
+    <style name="Widget.SeriesGuide.Button.Borderless" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:maxLines">2</item>
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Default">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,23 +16,15 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <style name="TextAppearance.Display3">
-        <item name="android:textColor">?android:attr/textColorSecondary</item>
-        <item name="android:textSize">56sp</item>
-    </style>
+    <style name="TextAppearance.Display3" parent="TextAppearance.MaterialComponents.Headline2" />
 
-    <style name="TextAppearance.Display1">
-        <item name="android:textColor">?android:attr/textColorSecondary</item>
-        <item name="android:textSize">34sp</item>
-    </style>
+    <style name="TextAppearance.Display1" parent="TextAppearance.MaterialComponents.Headline4" />
 
     <style name="TextAppearance.Display1.White">
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="TextAppearance.Headline">
-        <item name="android:textSize">24sp</item>
-    </style>
+    <style name="TextAppearance.Headline" parent="TextAppearance.MaterialComponents.Headline5" />
 
     <style name="TextAppearance.Title">
         <item name="android:textSize">20sp</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -150,12 +150,14 @@
     <style name="Widget.SeriesGuide.Button.Borderless.Default">
         <item name="android:textAllCaps">false</item>
         <item name="android:gravity">center_vertical|start</item>
-        <item name="android:fontFamily" tools:ignore="NewApi">sans-serif</item>
+        <item name="android:fontFamily">sans-serif</item>
         <item name="android:drawablePadding">@dimen/default_padding</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Sheet">
-        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="cornerRadius">0dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:gravity">center_vertical|start</item>
         <item name="android:fontFamily" tools:ignore="NewApi">sans-serif</item>
@@ -173,15 +175,19 @@
         <item name="android:textSize">@dimen/text_size_caption_sg</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">?android:attr/textColorSecondary</item>
+        <item name="android:gravity">center_vertical|start</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Caption.Platform">
+        <item name="android:gravity">center_vertical|center_horizontal</item>
         <item name="android:padding">4dp</item>
-        <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Rating">
-        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="cornerRadius">0dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="rippleColor">@color/sg_ripple_material_dark</item>
         <item name="android:padding">@dimen/default_padding</item>
         <item name="android:textColor">@color/white</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -165,6 +165,7 @@
     </style>
 
     <style name="Widget.SeriesGuide.Button.Borderless.Sheet.Menu">
+        <item name="rippleColor">?attr/colorControlHighlight</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textAppearance">@style/TextAppearance.Menu</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
 
     <style name="Theme" />
 
-    <style name="Theme.BaseSeriesGuide" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.BaseSeriesGuide" parent="Theme.MaterialComponents.NoActionBar">
 
         <!-- All customizations that are SPECIFIC to API-level 21 go here. -->
 
@@ -22,7 +22,7 @@
         <!--   darker variant of colorPrimary (for status bar, contextual app bars) -->
         <item name="colorPrimaryDark">@color/accent_primary_dark</item>
         <!--   theme UI controls like checkboxes and text fields -->
-        <item name="colorAccent">@color/teal_500</item>
+        <item name="colorSecondary">@color/teal_500</item>
 
         <!-- Special attributes -->
         <item name="sgActivatedItemBackgroundDrawer">@drawable/activated_background_drawer_sg</item>
@@ -37,7 +37,7 @@
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background_sg</item>
 
         <!-- Action bar -->
-        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.ActionBar</item>
+        <item name="actionBarTheme">@style/ThemeOverlay.MaterialComponents.ActionBar</item>
 
         <!-- Text -->
         <item name="android:textAppearance">@style/TextAppearance</item>
@@ -62,7 +62,7 @@
 
     </style>
 
-    <style name="Theme.BaseSeriesGuide.DarkBlue" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.BaseSeriesGuide.DarkBlue" parent="Theme.MaterialComponents.NoActionBar">
 
         <!-- All customizations that are SPECIFIC to API-level 21 go here. -->
 
@@ -79,7 +79,7 @@
         <!--   your app's branding color (for the app bar) -->
         <item name="colorPrimary">@android:color/black</item>
         <!--   theme UI controls like checkboxes and text fields -->
-        <item name="colorAccent">@color/teal_500</item>
+        <item name="colorSecondary">@color/teal_500</item>
 
         <!-- Special attributes -->
         <item name="sgActivatedItemBackgroundDrawer">@drawable/activated_background_drawer_sg</item>
@@ -115,7 +115,7 @@
 
     </style>
 
-    <style name="Theme.BaseSeriesGuide.Light" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.BaseSeriesGuide.Light" parent="Theme.MaterialComponents.Light.NoActionBar">
 
         <!-- All customizations that are SPECIFIC to API-level 21 go here. -->
 
@@ -134,7 +134,7 @@
         <!--   darker variant of colorPrimary (for status bar, contextual app bars) -->
         <item name="colorPrimaryDark">@color/accent_primary_dark</item>
         <!--   theme UI controls like checkboxes and text fields -->
-        <item name="colorAccent">@color/teal_500</item>
+        <item name="colorSecondary">@color/teal_500</item>
 
         <!-- Special attributes -->
         <item name="sgActivatedItemBackgroundDrawer">@drawable/activated_background_drawer_sg_light</item>
@@ -152,8 +152,8 @@
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background_sg_light</item>
 
         <!-- Action bar -->
-        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
-        <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="actionBarTheme">@style/ThemeOverlay.MaterialComponents.Dark.ActionBar</item>
+        <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents.Light</item>
 
         <!-- Text -->
         <item name="android:textAppearance">@style/TextAppearance</item>
@@ -182,12 +182,12 @@
     <!-- Special themes -->
     <!-- ####################################### -->
 
-    <style name="Theme.SeriesGuide.Dialog.Distillation" parent="ThemeOverlay.AppCompat.Dialog">
+    <style name="Theme.SeriesGuide.Dialog.Distillation" parent="ThemeOverlay.MaterialComponents.Dialog">
         <item name="android:windowBackground">@drawable/sg_distillation_dialog_background</item>
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="Theme.SeriesGuide.Dialog.CheckIn" parent="ThemeOverlay.AppCompat.Dialog">
+    <style name="Theme.SeriesGuide.Dialog.CheckIn" parent="ThemeOverlay.MaterialComponents.Dialog">
         <item name="android:windowAnimationStyle">@style/Animation.CheckinDialog</item>
     </style>
 
@@ -229,8 +229,8 @@
 
     </style>
 
-    <style name="ThemeOverlay.WhiteAccent" parent="ThemeOverlay.AppCompat.Dark">
-        <item name="colorAccent">@color/white</item>
+    <style name="ThemeOverlay.WhiteAccent" parent="ThemeOverlay.MaterialComponents.Dark">
+        <item name="colorSecondary">@color/white</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -39,6 +39,9 @@
         <!-- Action bar -->
         <item name="actionBarTheme">@style/ThemeOverlay.MaterialComponents.ActionBar</item>
 
+        <!-- Widgets -->
+        <item name="buttonBarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Dialog</item>
+
         <!-- Text -->
         <item name="android:textAppearance">@style/TextAppearance</item>
         <item name="sgTextAppearanceBody1">@style/TextAppearance.SeriesGuide.Body1</item>
@@ -92,6 +95,9 @@
 
         <!-- System widgets -->
         <item name="android:activatedBackgroundIndicator">@drawable/activated_background_sg</item>
+
+        <!-- Widgets -->
+        <item name="buttonBarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Dialog</item>
 
         <!-- Text -->
         <item name="sgTextAppearanceBody1">@style/TextAppearance.SeriesGuide.Body1</item>
@@ -154,6 +160,9 @@
         <!-- Action bar -->
         <item name="actionBarTheme">@style/ThemeOverlay.MaterialComponents.Dark.ActionBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.MaterialComponents.Light</item>
+
+        <!-- Widgets -->
+        <item name="buttonBarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Dialog</item>
 
         <!-- Text -->
         <item name="android:textAppearance">@style/TextAppearance</item>


### PR DESCRIPTION
**Blocked** on AndroidX and Material Components 1.1.0 release.
https://github.com/material-components/material-components-android/releases

- [ ] Figure out 1.1.0 color changes, e.g. change default theme for buttons (look at components docs)
- [ ] Search for `AppCompat` styles and replace them.
- [ ] Check Button themes
- [x] Check ThemeOverlays
- [ ] Update fonts
- [ ] Check text fields
- [ ] Set icons directly on button

Testing
- [ ] Verify **all three** themes