### PR TITLE
Use new artworks.thetvdb.com base for images

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
@@ -15,7 +15,7 @@ import javax.crypto.spec.SecretKeySpec
 
 object TvdbImageTools {
 
-    private const val TVDB_MIRROR_BANNERS = "https://www.thetvdb.com/banners/"
+    private const val TVDB_MIRROR_BANNERS = "https://artworks.thetvdb.com/banners/"
     const val TVDB_CACHE_PREFIX = "_cache/"
     private var sha256_hmac: Mac? = null
 

--- a/app/src/test/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageToolsTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageToolsTest.kt
@@ -13,7 +13,7 @@ class TvdbImageToolsTest {
         val artworkUrl = TvdbImageTools.artworkUrl("example.jpg")
         println("Artwork URL: $artworkUrl")
         assertThat(artworkUrl).isNotEmpty()
-        assertThat(artworkUrl).endsWith("https://www.thetvdb.com/banners/example.jpg")
+        assertThat(artworkUrl).endsWith("https://artworks.thetvdb.com/banners/example.jpg")
     }
 
     @Test


### PR DESCRIPTION
Should save a redirect from www->artworks (theoratically, right now there is none).

However, wait until merging as this new subdomain does not seem capable of serving the old `_cache` subpath for thumbnails, but only the new `_t` suffix on poster file names.