### PR TITLE
Support image URLs with legacy cache path

### DIFF
--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -164,7 +164,7 @@ public class MigrationTest {
         SgRoomDatabase database = getMigratedRoomDatabase();
         assertTestData(database);
         SgShow dbShow = database.showHelper().getShow();
-        assertThat(dbShow.posterSmall).isEqualTo(TvdbImageTools.TVDB_CACHE_PREFIX + dbShow.poster);
+        assertThat(dbShow.posterSmall).isEqualTo(TvdbImageTools.TVDB_LEGACY_CACHE_PREFIX + dbShow.poster);
     }
 
     private void assertTestData(SgRoomDatabase database) {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
@@ -360,7 +360,8 @@ public class JsonImportTask extends AsyncTask<Void, Integer, Integer> {
         // Construct missing small poster URL if there is a poster URL.
         if ((show.poster_small == null || show.poster_small.length() == 0)
                 && show.poster != null && show.poster.length() > 0) {
-            show.poster_small = TvdbImageTools.TVDB_CACHE_PREFIX + show.poster;
+            show.poster_small = show.poster
+                    .replace(".jpg", TvdbImageTools.TVDB_THUMBNAIL_POSTFIX);
         }
         // ensure a show will be updated (last_updated might be far into the future)
         if (show.last_updated > System.currentTimeMillis()) {

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
@@ -16,6 +16,7 @@ import javax.crypto.spec.SecretKeySpec
 object TvdbImageTools {
 
     private const val TVDB_MIRROR_BANNERS = "https://artworks.thetvdb.com/banners/"
+    private const val TVDB_LEGACY_MIRROR_BANNERS = "https://www.thetvdb.com/banners/"
     const val TVDB_THUMBNAIL_POSTFIX = "_t.jpg"
     const val TVDB_LEGACY_CACHE_PREFIX = "_cache/"
     private var sha256_hmac: Mac? = null
@@ -28,7 +29,17 @@ object TvdbImageTools {
         return if (imagePath.isNullOrEmpty()) {
             null
         } else {
-            buildImageCacheUrl("$TVDB_MIRROR_BANNERS$imagePath")
+            // If the path contains the legacy cache prefix, use the www subdomain as it has
+            // a redirect to the new thumbnail URL set up (artworks subdomain + file name postfix).
+            // E.g. https://www.thetvdb.com/banners/_cache/posters/example.jpg redirects to
+            // https://artworks.thetvdb.com/banners/posters/example_t.jpg
+            // Using the artworks subdomain with the legacy cache prefix is not supported.
+            val imageUrl = if (imagePath.contains(TVDB_LEGACY_CACHE_PREFIX, false)) {
+                "$TVDB_LEGACY_MIRROR_BANNERS$imagePath"
+            } else {
+                "$TVDB_MIRROR_BANNERS$imagePath"
+            }
+            buildImageCacheUrl(imageUrl)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
@@ -16,6 +16,7 @@ import javax.crypto.spec.SecretKeySpec
 object TvdbImageTools {
 
     private const val TVDB_MIRROR_BANNERS = "https://artworks.thetvdb.com/banners/"
+    const val TVDB_THUMBNAIL_POSTFIX = "_t.jpg"
     const val TVDB_CACHE_PREFIX = "_cache/"
     private var sha256_hmac: Mac? = null
 

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageTools.kt
@@ -17,7 +17,7 @@ object TvdbImageTools {
 
     private const val TVDB_MIRROR_BANNERS = "https://artworks.thetvdb.com/banners/"
     const val TVDB_THUMBNAIL_POSTFIX = "_t.jpg"
-    const val TVDB_CACHE_PREFIX = "_cache/"
+    const val TVDB_LEGACY_CACHE_PREFIX = "_cache/"
     private var sha256_hmac: Mac? = null
 
     /**

--- a/app/src/test/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageToolsTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/thetvdbapi/TvdbImageToolsTest.kt
@@ -17,6 +17,14 @@ class TvdbImageToolsTest {
     }
 
     @Test
+    fun artworkUrl_withLegacyCachePath() {
+        val url = TvdbImageTools.artworkUrl("_cache/posters/example.jpg")
+        println("Artwork URL: $url")
+        assertThat(url).isNotEmpty()
+        assertThat(url).endsWith("https://www.thetvdb.com/banners/_cache/posters/example.jpg")
+    }
+
+    @Test
     fun posterUrlOrResolve() {
         val url = TvdbImageTools.posterUrlOrResolve(null, 42, null)
         assertThat(url).isNotEmpty()


### PR DESCRIPTION
Using the new artworks URL with a legacy cache path directly does not work.

So use the www subdomain if a poster path uses the legacy `_cache` path. TVDB has redirects set up that correctly rewrite the URL to the artworks subdomain and `_t` file name suffix.

E.g. `https://www.thetvdb.com/banners/_cache/posters/example.jpg` redirects to `https://artworks.thetvdb.com/banners/posters/example_t.jpg`.

Also update JSON importer to create missing poster thumbnail paths using new file name postfix instead of legacy cache path.