### PR TITLE
Create auto backups that can be backed up by Android

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -194,12 +194,15 @@ public class AutoBackupFragment extends Fragment implements JsonExportTask.OnTas
                 || requestCode == REQUEST_CODE_LISTS_EXPORT_URI
                 || requestCode == REQUEST_CODE_MOVIES_EXPORT_URI) {
             Uri uri = data.getData();
+            if (uri == null) return;
 
             // persist read and write permission for this URI across device reboots
             try {
-                getContext().getContentResolver()
-                        .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
-                                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                requireContext().getContentResolver().takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                );
             } catch (SecurityException e) {
                 Timber.e(e, "Could not persist r/w permission for backup file URI.");
             }
@@ -214,6 +217,7 @@ public class AutoBackupFragment extends Fragment implements JsonExportTask.OnTas
                 BackupSettings.storeFileUri(getContext(),
                         BackupSettings.KEY_AUTO_BACKUP_MOVIES_EXPORT_URI, uri);
             }
+
             updateFileViews();
         }
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -1,5 +1,6 @@
 package com.battlelancer.seriesguide.dataliberation;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
@@ -116,6 +117,7 @@ public class AutoBackupFragment extends Fragment {
                 });
     }
 
+    @SuppressLint("SetTextI18n")
     @Override
     public void onStart() {
         super.onStart();
@@ -124,6 +126,19 @@ public class AutoBackupFragment extends Fragment {
         boolean autoBackupEnabled = BackupSettings.isAutoBackupEnabled(getContext());
         setContainerSettingsVisible(autoBackupEnabled);
         binding.switchAutoBackup.setChecked(autoBackupEnabled);
+
+        // Update state.
+        String errorOrNull = BackupSettings.getAutoBackupErrorOrNull(requireContext());
+        if (errorOrNull == null) {
+            binding.imageViewBackupStatus.setImageResource(
+                    R.drawable.ic_check_circle_green_24dp);
+            binding.textViewBackupStatus.setText(R.string.backup_success);
+        } else {
+            binding.imageViewBackupStatus.setImageResource(
+                    R.drawable.ic_cancel_red_24dp);
+            binding.textViewBackupStatus.setText(
+                    getString(R.string.backup_failed) + " " + errorOrNull);
+        }
 
         // Update auto-backup availability.
         viewModel.updateAvailableBackupData();

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.widget.TextViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 import com.battlelancer.seriesguide.R;
@@ -261,6 +262,11 @@ public class AutoBackupFragment extends Fragment implements JsonExportTask.OnTas
     }
 
     private void setUriOrPlaceholder(TextView textView, Uri uri) {
-        textView.setText(uri == null ? getString(R.string.no_file_selected) : uri.toString());
+        textView.setText(uri == null
+                ? getString(R.string.no_file_selected)
+                : uri.toString());
+        TextViewCompat.setTextAppearance(textView, uri == null
+                ? R.style.TextAppearance_SeriesGuide_Body2_Error
+                : R.style.TextAppearance_SeriesGuide_Body2_Dim);
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.databinding.FragmentAutoBackupBinding;
+import com.battlelancer.seriesguide.util.TaskManager;
 import com.battlelancer.seriesguide.util.Utils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -67,7 +68,16 @@ public class AutoBackupFragment extends Fragment {
             }
         });
 
-        binding.buttonAutoBackupImport.setOnClickListener(view -> runAutoBackupImport());
+        binding.buttonAutoBackupNow.setOnClickListener(
+                view -> {
+                    if (TaskManager.getInstance().tryBackupTask(requireContext())) {
+                        setProgressLock(true);
+                    }
+                }
+        );
+        binding.buttonAutoBackupImport.setOnClickListener(
+                view -> runAutoBackupImport()
+        );
 
         binding.checkBoxAutoBackupCreateCopy.setChecked(
                 BackupSettings.isCreateCopyOfAutoBackup(getContext()));
@@ -181,6 +191,7 @@ public class AutoBackupFragment extends Fragment {
             // don't touch views if fragment is not added to activity any longer
             return;
         }
+        viewModel.updateAvailableBackupData();
         updateFileViews();
         setProgressLock(false);
     }
@@ -243,6 +254,7 @@ public class AutoBackupFragment extends Fragment {
     }
 
     private void setProgressLock(boolean isLocked) {
+        binding.buttonAutoBackupNow.setEnabled(!isLocked);
         if (!isBackupAvailableForImport || isLocked) {
             binding.buttonAutoBackupImport.setEnabled(false);
         } else {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -16,8 +16,6 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.databinding.FragmentAutoBackupBinding;
-import com.battlelancer.seriesguide.settings.AdvancedSettings;
-import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.util.Utils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -60,10 +58,10 @@ public class AutoBackupFragment extends Fragment {
         // setup listeners
         binding.switchAutoBackup.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
-                DataLiberationTools.setAutoBackupEnabled(getContext());
+                BackupSettings.setAutoBackupEnabled(getContext());
                 setContainerSettingsVisible(true);
             } else {
-                DataLiberationTools.setAutoBackupDisabled(getContext());
+                BackupSettings.setAutoBackupDisabled(getContext());
                 setContainerSettingsVisible(false);
             }
         });
@@ -123,7 +121,7 @@ public class AutoBackupFragment extends Fragment {
         super.onStart();
 
         // update enabled state
-        boolean autoBackupEnabled = AdvancedSettings.isAutoBackupEnabled(getContext());
+        boolean autoBackupEnabled = BackupSettings.isAutoBackupEnabled(getContext());
         setContainerSettingsVisible(autoBackupEnabled);
         binding.switchAutoBackup.setChecked(autoBackupEnabled);
 

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupFragment.java
@@ -28,7 +28,7 @@ import timber.log.Timber;
  * Configuration of auto backup, creation of optional copies
  * and ability to import the last auto backup.
  */
-public class AutoBackupFragment extends Fragment implements JsonExportTask.OnTaskProgressListener {
+public class AutoBackupFragment extends Fragment {
 
     private static final int REQUEST_CODE_SHOWS_EXPORT_URI = 3;
     private static final int REQUEST_CODE_LISTS_EXPORT_URI = 4;
@@ -154,16 +154,6 @@ public class AutoBackupFragment extends Fragment implements JsonExportTask.OnTas
         importTask = null;
 
         super.onDestroy();
-    }
-
-    @Override
-    public void onProgressUpdate(Integer... values) {
-        if (binding.progressBarAutoBackup == null) {
-            return;
-        }
-        binding.progressBarAutoBackup.setIndeterminate(values[0].equals(values[1]));
-        binding.progressBarAutoBackup.setMax(values[0]);
-        binding.progressBarAutoBackup.setProgress(values[1]);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -1,0 +1,127 @@
+package com.battlelancer.seriesguide.dataliberation
+
+import android.content.Context
+import android.os.Environment
+import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_LISTS
+import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_MOVIES
+import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_SHOWS
+import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BackupType
+import com.battlelancer.seriesguide.settings.AdvancedSettings
+import timber.log.Timber
+import java.io.Closeable
+import java.io.File
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Backs up shows, lists and movies to timestamped files
+ * in a [Context.getExternalFilesDir] subdirectory.
+ * This directory is included in Google's full auto backup.
+ *
+ * Failures are silent.
+ *
+ * If the user has specified auto backup files, copies the latest backups to them.
+ * If the user specified files are not writable, will trigger a user notification.
+ */
+class AutoBackupTask(
+    private val jsonExportTask: JsonExportTask,
+    private val context: Context
+) {
+
+    sealed class Result {
+        object Success : Result()
+        data class Error(val reason: String) : Result()
+    }
+
+    sealed class Backup(val name: String, @BackupType val type: Int) {
+        object Shows : Backup("shows", BACKUP_SHOWS)
+        object Lists : Backup("lists", BACKUP_LISTS)
+        object Movies : Backup("movies", BACKUP_MOVIES)
+    }
+
+    fun run(): Result {
+        val storage = context.getExternalFilesDir(null)
+            ?: return Result.Error("Storage not available.")
+
+        if (Environment.getExternalStorageState(storage) != Environment.MEDIA_MOUNTED) {
+            return Result.Error("Storage not mounted.")
+        }
+
+        val backupDirectory = File(storage, "Backups")
+
+        if (!backupDirectory.exists()) {
+            if (!backupDirectory.mkdirs()) {
+                return Result.Error("Unable to create backup directory.")
+            }
+        }
+
+        val timestamp = SimpleDateFormat("yyyy-MM-dd-HH-mm-ss", Locale.US).format(Date())
+
+        backup(Backup.Shows, backupDirectory, timestamp).let {
+            if (it is Result.Error) return it
+        }
+        backup(Backup.Lists, backupDirectory, timestamp).let {
+            if (it is Result.Error) return it
+        }
+        backup(Backup.Movies, backupDirectory, timestamp).let {
+            if (it is Result.Error) return it
+        }
+
+        // TODO Copy to user backup files.
+
+        // TODO Clean up old backups.
+
+        AdvancedSettings.setLastAutoBackupTimeToNow(context)
+
+        return Result.Success
+    }
+
+    private fun backup(
+        backup: Backup,
+        backupDirectory: File,
+        timestamp: String
+    ): Result {
+        val dataCursor = jsonExportTask.getDataCursor(backup.type)
+            ?: return Result.Error("Querying for data failed.")
+
+        // If there is no data, do nothing.
+        if (dataCursor.count == 0) return Result.Success
+
+        val fileName = "backup-${backup.name}-$timestamp.json"
+        val backupFile = File(backupDirectory, fileName)
+        val out = FileOutputStream(backupFile)
+
+        try {
+            when (backup) {
+                Backup.Shows -> jsonExportTask.writeJsonStreamShows(out, dataCursor)
+                Backup.Lists -> jsonExportTask.writeJsonStreamLists(out, dataCursor)
+                Backup.Movies -> jsonExportTask.writeJsonStreamMovies(out, dataCursor)
+            }
+        } catch (e: Exception) {
+            if (backupFile.delete()) {
+                Timber.e(e, "Backup failed, deleted backup file.")
+            } else {
+                Timber.e(e, "Backup failed, failed to delete backup file.")
+            }
+            return Result.Error(e.message ?: "Backup failed for unknown reason.")
+        } finally {
+            out.closeFinally()
+            dataCursor.closeFinally()
+        }
+
+        return Result.Success
+    }
+
+    private fun Closeable.closeFinally() {
+        try {
+            close()
+        } catch (runtimeException: RuntimeException) {
+            throw runtimeException
+        } catch (checkedException: Exception) {
+            // Ignored.
+        }
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -87,7 +87,10 @@ class AutoBackupTask(
             ?: return Result.Error("Querying for data failed.")
 
         // If there is no data, do nothing.
-        if (dataCursor.count == 0) return Result.Success
+        if (dataCursor.count == 0) {
+            dataCursor.close()
+            return Result.Success
+        }
 
         val fileName = "backup-${backup.name}-$timestamp.json"
         val backupFile = File(backupDirectory, fileName)

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -2,7 +2,6 @@ package com.battlelancer.seriesguide.dataliberation
 
 import android.content.Context
 import android.net.Uri
-import android.os.Environment
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_LISTS
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_MOVIES
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_SHOWS
@@ -16,9 +15,10 @@ import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+
+class AutoBackupException(message: String) : IOException(message)
 
 /**
  * Backs up shows, lists and movies to timestamped files
@@ -35,24 +35,10 @@ class AutoBackupTask(
     private val context: Context
 ) {
 
-    class AutoBackupException(message: String) : IOException(message)
-
     sealed class Backup(val name: String, @BackupType val type: Int) {
         object Shows : Backup("seriesguide-shows", BACKUP_SHOWS)
         object Lists : Backup("seriesguide-lists", BACKUP_LISTS)
         object Movies : Backup("seriesguide-movies", BACKUP_MOVIES)
-    }
-
-    @Throws(AutoBackupException::class)
-    private fun getBackupDirectory(): File {
-        val storage = context.getExternalFilesDir(null)
-            ?: throw AutoBackupException("Storage not available.")
-
-        if (Environment.getExternalStorageState(storage) != Environment.MEDIA_MOUNTED) {
-            throw AutoBackupException("Storage not mounted.")
-        }
-
-        return File(storage, "Backups")
     }
 
     private fun getBackupFile(backup: Backup, timestamp: String, backupDirectory: File): File {
@@ -64,7 +50,7 @@ class AutoBackupTask(
     fun run() {
         Timber.i("Creating auto backup.")
 
-        val backupDirectory = getBackupDirectory()
+        val backupDirectory = AutoBackupTools.getBackupDirectory(context)
 
         if (!backupDirectory.exists()) {
             if (!backupDirectory.mkdirs()) {
@@ -95,7 +81,7 @@ class AutoBackupTask(
         copyBackupToUserFile(Backup.Lists, backupFileLists)
         copyBackupToUserFile(Backup.Movies, backupFileMovies)
 
-        deleteOldBackups()
+        AutoBackupTools.deleteOldBackups(context)
 
         AdvancedSettings.setLastAutoBackupTimeToNow(context)
     }
@@ -173,77 +159,6 @@ class AutoBackupTask(
                     throw e
                 }
             }
-    }
-
-    private fun deleteOldBackups() {
-        Timber.i("Deleting old backups.")
-        deleteOldBackups(Backup.Shows)
-        deleteOldBackups(Backup.Lists)
-        deleteOldBackups(Backup.Movies)
-    }
-
-    private fun deleteOldBackups(backup: Backup) {
-        val backups = try {
-            getAllBackupsNewestFirst(backup)
-        } catch (e: IOException) {
-            Timber.e(e, "Unable to delete old backups")
-            return
-        }
-
-        // Keep last 2 backups.
-        backups
-            .drop(2)
-            .forEach {
-                if (!it.file.delete()) {
-                    Timber.e("Unable to delete old backup file ${it.file}")
-                }
-            }
-    }
-
-    data class BackupFile(val file: File, val timestamp: Long)
-
-    private fun getAllBackupsNewestFirst(backup: Backup): List<BackupFile> {
-        val backupDirectory = getBackupDirectory()
-        val files = backupDirectory.listFiles()
-
-        val backups = files.mapNotNull { file ->
-            if (file.isFile && file.name.startsWith(backup.name)) {
-                getBackupTimestamp(file)
-                    ?.let { return@mapNotNull BackupFile(file, it) }
-            }
-            return@mapNotNull null
-        }
-
-        return backups.sortedByDescending { it.timestamp }
-    }
-
-    private fun getBackupTimestamp(file: File): Long? {
-        val nameAndExtension = file.name.split(".")
-
-        // <something>.json
-        if (nameAndExtension.size == 2) {
-            val nameParts = nameAndExtension[0].split("-")
-
-            // seriesguide-<type>-yyyy-MM-dd-HH-mm-ss
-            if (nameParts.size == 8) {
-                val cal = Calendar.getInstance()
-                try {
-                    cal.set(Calendar.YEAR, nameParts[2].toInt())
-                    cal.set(Calendar.MONTH, nameParts[3].toInt())
-                    cal.set(Calendar.DAY_OF_MONTH, nameParts[4].toInt())
-                    cal.set(Calendar.HOUR_OF_DAY, nameParts[5].toInt())
-                    cal.set(Calendar.MINUTE, nameParts[6].toInt())
-                    cal.set(Calendar.SECOND, nameParts[7].toInt())
-                    cal.set(Calendar.MILLISECOND, 0)
-
-                    return cal.timeInMillis
-                } catch (e: NumberFormatException) {
-                    // Return default value end of method.
-                }
-            }
-        }
-
-        return null
     }
 
     private fun Closeable.closeFinally() {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -143,6 +143,8 @@ class AutoBackupTask(
         val outFileUri: Uri = jsonExportTask.getDataBackupFile(backup.type)
             ?: return
 
+        Timber.i("Copying ${backup.name} backup to user file.")
+
         // Do not guard against FileNotFoundException, backup file should exist.
         FileInputStream(sourceFile)
             .use { source ->
@@ -157,6 +159,10 @@ class AutoBackupTask(
                     }
                 } catch (e: FileNotFoundException) {
                     Timber.e("Backup file not found, removing from prefs.")
+                    jsonExportTask.removeBackupFileUri(backup.type)
+                    throw e
+                } catch (e: SecurityException) {
+                    Timber.e("Backup file not writable, removing from prefs.")
                     jsonExportTask.removeBackupFileUri(backup.type)
                     throw e
                 }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -22,9 +22,9 @@ class AutoBackupException(message: String) : IOException(message)
 /**
  * Backs up shows, lists and movies to timestamped files
  * in a [Context.getExternalFilesDir] subdirectory.
- * This directory is included in Google's full auto backup.
+ * This directory is included in Android's full auto backup (app data backup).
  *
- * Failures are silent.
+ * If the last backup attempt failed an error is recorded that can be shown in UI.
  *
  * If the user has specified auto backup files, copies the latest backups to them.
  * If the user specified files do not exist, their URI is purged from prefs.

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -7,6 +7,7 @@ import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_MOVIES
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_SHOWS
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BackupType
 import com.battlelancer.seriesguide.settings.AdvancedSettings
+import com.battlelancer.seriesguide.settings.BackupSettings
 import timber.log.Timber
 import java.io.Closeable
 import java.io.File
@@ -76,10 +77,12 @@ class AutoBackupTask(
                 .also { backup(type, it) }
         }
 
-        // Copy to user files.
-        copyBackupToUserFile(Backup.Shows, backupFileShows)
-        copyBackupToUserFile(Backup.Lists, backupFileLists)
-        copyBackupToUserFile(Backup.Movies, backupFileMovies)
+        if (BackupSettings.isCreateCopyOfAutoBackup(context)) {
+            // Copy to user files.
+            copyBackupToUserFile(Backup.Shows, backupFileShows)
+            copyBackupToUserFile(Backup.Lists, backupFileLists)
+            copyBackupToUserFile(Backup.Movies, backupFileMovies)
+        }
 
         AutoBackupTools.deleteOldBackups(context)
 

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -6,8 +6,6 @@ import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_LISTS
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_MOVIES
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BACKUP_SHOWS
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BackupType
-import com.battlelancer.seriesguide.settings.AdvancedSettings
-import com.battlelancer.seriesguide.settings.BackupSettings
 import timber.log.Timber
 import java.io.Closeable
 import java.io.File
@@ -86,7 +84,7 @@ class AutoBackupTask(
 
         AutoBackupTools.deleteOldBackups(context)
 
-        AdvancedSettings.setLastAutoBackupTimeToNow(context)
+        BackupSettings.setLastAutoBackupTimeToNow(context)
     }
 
     @Throws(AutoBackupException::class)

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
@@ -66,13 +66,13 @@ object AutoBackupTools {
         val backupDirectory = getBackupDirectory(context)
         val files = backupDirectory.listFiles()
 
-        val backups = files.mapNotNull { file ->
+        val backups = files?.mapNotNull { file ->
             if (file.isFile && file.name.startsWith(backup.name)) {
                 getBackupTimestamp(file)
                     ?.let { return@mapNotNull BackupFile(file, it) }
             }
             return@mapNotNull null
-        }
+        } ?: emptyList()
 
         return backups.sortedByDescending { it.timestamp }
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
@@ -50,6 +50,13 @@ object AutoBackupTools {
 
     data class BackupFile(val file: File, val timestamp: Long)
 
+    /**
+     * Only checks if an auto backup file for shows is available, likely others are then, too.
+     */
+    fun isAutoBackupMaybeAvailable(context: Context): Boolean {
+        return getLatestBackupOrNull(JsonExportTask.BACKUP_SHOWS, context) != null
+    }
+
     @JvmStatic
     fun getLatestBackupOrNull(@BackupType type: Int, context: Context): BackupFile? {
         val backup = when (type) {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
@@ -1,0 +1,109 @@
+package com.battlelancer.seriesguide.dataliberation
+
+import android.content.Context
+import android.os.Environment
+import com.battlelancer.seriesguide.dataliberation.AutoBackupTask.Backup
+import com.battlelancer.seriesguide.dataliberation.JsonExportTask.BackupType
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+import java.util.Calendar
+
+object AutoBackupTools {
+
+    @Throws(AutoBackupException::class)
+    fun getBackupDirectory(context: Context): File {
+        val storage = context.getExternalFilesDir(null)
+            ?: throw AutoBackupException("Storage not available.")
+
+        if (Environment.getExternalStorageState(storage) != Environment.MEDIA_MOUNTED) {
+            throw AutoBackupException("Storage not mounted.")
+        }
+
+        return File(storage, "Backups")
+    }
+
+    fun deleteOldBackups(context: Context) {
+        Timber.i("Deleting old backups.")
+        deleteOldBackups(Backup.Shows, context)
+        deleteOldBackups(Backup.Lists, context)
+        deleteOldBackups(Backup.Movies, context)
+    }
+
+    private fun deleteOldBackups(backup: Backup, context: Context) {
+        val backups = try {
+            getAllBackupsNewestFirst(backup, context)
+        } catch (e: IOException) {
+            Timber.e(e, "Unable to delete old backups")
+            return
+        }
+
+        // Keep last 2 backups.
+        backups
+            .drop(2)
+            .forEach {
+                if (!it.file.delete()) {
+                    Timber.e("Unable to delete old backup file ${it.file}")
+                }
+            }
+    }
+
+    data class BackupFile(val file: File, val timestamp: Long)
+
+    @JvmStatic
+    fun getLatestBackupOrNull(@BackupType type: Int, context: Context): BackupFile? {
+        val backup = when (type) {
+            Backup.Shows.type -> Backup.Shows
+            Backup.Lists.type -> Backup.Lists
+            Backup.Movies.type -> Backup.Movies
+            else -> throw IllegalArgumentException("Unknown backup type $type")
+        }
+        getAllBackupsNewestFirst(backup, context)
+            .let { return if (it.isNotEmpty()) it[0] else null }
+    }
+
+    private fun getAllBackupsNewestFirst(backup: Backup, context: Context): List<BackupFile> {
+        val backupDirectory = getBackupDirectory(context)
+        val files = backupDirectory.listFiles()
+
+        val backups = files.mapNotNull { file ->
+            if (file.isFile && file.name.startsWith(backup.name)) {
+                getBackupTimestamp(file)
+                    ?.let { return@mapNotNull BackupFile(file, it) }
+            }
+            return@mapNotNull null
+        }
+
+        return backups.sortedByDescending { it.timestamp }
+    }
+
+    private fun getBackupTimestamp(file: File): Long? {
+        val nameAndExtension = file.name.split(".")
+
+        // <something>.json
+        if (nameAndExtension.size == 2) {
+            val nameParts = nameAndExtension[0].split("-")
+
+            // seriesguide-<type>-yyyy-MM-dd-HH-mm-ss
+            if (nameParts.size == 8) {
+                val cal = Calendar.getInstance()
+                try {
+                    cal.set(Calendar.YEAR, nameParts[2].toInt())
+                    cal.set(Calendar.MONTH, nameParts[3].toInt())
+                    cal.set(Calendar.DAY_OF_MONTH, nameParts[4].toInt())
+                    cal.set(Calendar.HOUR_OF_DAY, nameParts[5].toInt())
+                    cal.set(Calendar.MINUTE, nameParts[6].toInt())
+                    cal.set(Calendar.SECOND, nameParts[7].toInt())
+                    cal.set(Calendar.MILLISECOND, 0)
+
+                    return cal.timeInMillis
+                } catch (e: NumberFormatException) {
+                    // Return default value end of method.
+                }
+            }
+        }
+
+        return null
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTools.kt
@@ -48,8 +48,6 @@ object AutoBackupTools {
             }
     }
 
-    data class BackupFile(val file: File, val timestamp: Long)
-
     /**
      * Only checks if an auto backup file for shows is available, likely others are then, too.
      */
@@ -68,6 +66,8 @@ object AutoBackupTools {
         getAllBackupsNewestFirst(backup, context)
             .let { return if (it.isNotEmpty()) it[0] else null }
     }
+
+    data class BackupFile(val file: File, val timestamp: Long)
 
     private fun getAllBackupsNewestFirst(backup: Backup, context: Context): List<BackupFile> {
         val backupDirectory = getBackupDirectory(context)

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
@@ -19,16 +19,13 @@ class AutoBackupViewModel(application: Application) : AndroidViewModel(applicati
 
     fun updateAvailableBackupData() = viewModelScope.launch(Dispatchers.IO) {
         val backupShows = AutoBackupTools.getLatestBackupOrNull(
-            JsonExportTask.BACKUP_SHOWS,
-            getApplication()
+            JsonExportTask.BACKUP_SHOWS, getApplication()
         )
         val backupLists = AutoBackupTools.getLatestBackupOrNull(
-            JsonExportTask.BACKUP_LISTS,
-            getApplication()
+            JsonExportTask.BACKUP_LISTS, getApplication()
         )
         val backupMovies = AutoBackupTools.getLatestBackupOrNull(
-            JsonExportTask.BACKUP_MOVIES,
-            getApplication()
+            JsonExportTask.BACKUP_MOVIES, getApplication()
         )
 
         // All three files required.

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
@@ -1,0 +1,57 @@
+package com.battlelancer.seriesguide.dataliberation
+
+import android.app.Application
+import android.text.format.DateUtils
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+/**
+ * View model that checks for available backup files.
+ */
+class AutoBackupViewModel(application: Application) : AndroidViewModel(application) {
+
+    /** Time string of the available backup, or null if no backup is available. */
+    val availableBackupLiveData = MutableLiveData<String?>()
+
+    fun updateAvailableBackupData() = GlobalScope.launch(Dispatchers.IO) {
+        val backupShows = AutoBackupTools.getLatestBackupOrNull(
+            JsonExportTask.BACKUP_SHOWS,
+            getApplication()
+        )
+        val backupLists = AutoBackupTools.getLatestBackupOrNull(
+            JsonExportTask.BACKUP_LISTS,
+            getApplication()
+        )
+        val backupMovies = AutoBackupTools.getLatestBackupOrNull(
+            JsonExportTask.BACKUP_MOVIES,
+            getApplication()
+        )
+
+        // All three files required.
+        if (backupShows == null || backupLists == null || backupMovies == null) {
+            availableBackupLiveData.postValue(null)
+            return@launch
+        }
+
+        // All three files must have same time stamp.
+        if (backupShows.timestamp != backupLists.timestamp
+            || backupShows.timestamp != backupMovies.timestamp) {
+            availableBackupLiveData.postValue(null)
+            return@launch
+        }
+
+        val availableBackupTimeString = DateUtils.getRelativeDateTimeString(
+            getApplication(),
+            backupShows.timestamp,
+            DateUtils.SECOND_IN_MILLIS,
+            DateUtils.DAY_IN_MILLIS,
+            0
+        )
+
+        availableBackupLiveData.postValue(availableBackupTimeString.toString())
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.text.format.DateUtils
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -16,7 +17,7 @@ class AutoBackupViewModel(application: Application) : AndroidViewModel(applicati
     /** Time string of the available backup, or null if no backup is available. */
     val availableBackupLiveData = MutableLiveData<String?>()
 
-    fun updateAvailableBackupData() = GlobalScope.launch(Dispatchers.IO) {
+    fun updateAvailableBackupData() = viewModelScope.launch(Dispatchers.IO) {
         val backupShows = AutoBackupTools.getLatestBackupOrNull(
             JsonExportTask.BACKUP_SHOWS,
             getApplication()

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
@@ -48,6 +48,8 @@ public class BackupSettings {
     private static final String PREFS_AUTOBACKUP = "autobackup";
     private static final String KEY_AUTOBACKUP_LAST_TIME
             = "com.battlelancer.seriesguide.lastbackup";
+    private static final String KEY_AUTOBACKUP_LAST_ERROR
+            = "com.uwetrottmann.seriesguide.autobackup.lasterror";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -111,6 +113,19 @@ public class BackupSettings {
     public static boolean isCreateCopyOfAutoBackup(Context context) {
         return !PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(KEY_AUTO_BACKUP_USE_DEFAULT_FILES, true);
+    }
+
+    @Nullable
+    public static String getAutoBackupErrorOrNull(Context context) {
+        return context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+                .getString(KEY_AUTOBACKUP_LAST_ERROR, null);
+    }
+
+    public static void setAutoBackupErrorOrNull(Context context, String errorOrNull) {
+        context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_AUTOBACKUP_LAST_ERROR, errorOrNull)
+                .apply();
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
@@ -46,9 +46,10 @@ public class BackupSettings {
             = "com.battlelancer.seriesguide.autobackup.moviesExport";
 
     // Store some auto backup prefs in separate preference file
-    // that is not backed up by Android auto backup.
+    // that is not backed up by Android app data backup.
     private static final String KEY_AUTOBACKUP_LAST_TIME = "last_backup";
     private static final String KEY_AUTOBACKUP_LAST_ERROR = "last_error";
+    private static final String KEY_AUTOBACKUP_LAST_ERROR_WARN = "last_error.warn";
 
     public static boolean isAutoBackupEnabled(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(KEY_AUTOBACKUP,
@@ -123,10 +124,30 @@ public class BackupSettings {
                 .getString(KEY_AUTOBACKUP_LAST_ERROR, null);
     }
 
+    /**
+     * If error is not null, {@link #isWarnLastAutoBackupFailed(Context)}
+     * will return true afterwards. If it is null, it will return false.
+     */
     static void setAutoBackupErrorOrNull(Context context, String errorOrNull) {
         getAutoBackupPrefs(context)
                 .edit()
                 .putString(KEY_AUTOBACKUP_LAST_ERROR, errorOrNull)
+                .putBoolean(KEY_AUTOBACKUP_LAST_ERROR_WARN, errorOrNull != null)
+                .apply();
+    }
+
+    public static boolean isWarnLastAutoBackupFailed(Context context) {
+        return getAutoBackupPrefs(context)
+                .getBoolean(KEY_AUTOBACKUP_LAST_ERROR_WARN, false);
+    }
+
+    /**
+     * Afterwards {@link #isWarnLastAutoBackupFailed(Context)} returns false.
+     */
+    public static void setHasSeenLastAutoBackupFailed(Context context) {
+        getAutoBackupPrefs(context)
+                .edit()
+                .putBoolean(KEY_AUTOBACKUP_LAST_ERROR_WARN, false)
                 .apply();
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
@@ -28,8 +28,14 @@ public class BackupSettings {
             = "com.battlelancer.seriesguide.backup.moviesImport";
 
     // auto backup
+    // Previous auto backup preference key.
+    // Renamed (= reset) so on upgrade the new auto backup is turned on,
+    // as users might have dismissed the setup notification which
+    // turned off the old auto backup.
+//    private static final String KEY_AUTOBACKUP
+//            = "com.battlelancer.seriesguide.autobackup";
     private static final String KEY_AUTOBACKUP
-            = "com.battlelancer.seriesguide.autobackup";
+            = "autobackup";
     private static final String KEY_AUTO_BACKUP_USE_DEFAULT_FILES
             = "com.battlelancer.seriesguide.autobackup.defaultFiles";
     private static final String KEY_AUTOBACKUP_SHOWS_EXPORT_URI

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
@@ -41,15 +41,10 @@ public class BackupSettings {
     public static final String KEY_AUTO_BACKUP_MOVIES_EXPORT_URI
             = "com.battlelancer.seriesguide.autobackup.moviesExport";
 
-    /**
-     * Store some auto backup prefs in separate preference file
-     * that is not backed up by Android auto backup.
-     */
-    private static final String PREFS_AUTOBACKUP = "autobackup";
-    private static final String KEY_AUTOBACKUP_LAST_TIME
-            = "com.battlelancer.seriesguide.lastbackup";
-    private static final String KEY_AUTOBACKUP_LAST_ERROR
-            = "com.uwetrottmann.seriesguide.autobackup.lasterror";
+    // Store some auto backup prefs in separate preference file
+    // that is not backed up by Android auto backup.
+    private static final String KEY_AUTOBACKUP_LAST_TIME = "last_backup";
+    private static final String KEY_AUTOBACKUP_LAST_ERROR = "last_error";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -89,9 +84,15 @@ public class BackupSettings {
         return (now - previousBackupTime) > 7 * DateUtils.DAY_IN_MILLIS;
     }
 
+    private static SharedPreferences getAutoBackupPrefs(Context context) {
+        return context.getSharedPreferences(
+                context.getPackageName() + "_autobackup",
+                Context.MODE_PRIVATE
+        );
+    }
+
     private static long getLastAutoBackupTime(Context context) {
-        SharedPreferences prefs = context
-                .getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE);
+        SharedPreferences prefs = getAutoBackupPrefs(context);
 
         long time = prefs.getLong(KEY_AUTOBACKUP_LAST_TIME, 0);
         if (time == 0) {
@@ -104,7 +105,7 @@ public class BackupSettings {
     }
 
     public static void setLastAutoBackupTimeToNow(Context context) {
-        context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+        getAutoBackupPrefs(context)
                 .edit()
                 .putLong(KEY_AUTOBACKUP_LAST_TIME, System.currentTimeMillis())
                 .apply();
@@ -116,13 +117,13 @@ public class BackupSettings {
     }
 
     @Nullable
-    public static String getAutoBackupErrorOrNull(Context context) {
-        return context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+    static String getAutoBackupErrorOrNull(Context context) {
+        return getAutoBackupPrefs(context)
                 .getString(KEY_AUTOBACKUP_LAST_ERROR, null);
     }
 
-    public static void setAutoBackupErrorOrNull(Context context, String errorOrNull) {
-        context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+    static void setAutoBackupErrorOrNull(Context context, String errorOrNull) {
+        getAutoBackupPrefs(context)
                 .edit()
                 .putString(KEY_AUTOBACKUP_LAST_ERROR, errorOrNull)
                 .apply();

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/BackupSettings.java
@@ -30,14 +30,8 @@ public class BackupSettings {
             = "com.battlelancer.seriesguide.backup.moviesImport";
 
     // auto backup
-    /**
-     * Store last auto backup timestamp in separate settings file
-     * that is not backed up by Android auto backup.
-     */
-    private static final String PREFS_AUTOBACKUP = "autobackup";
-    public static final String KEY_AUTOBACKUP = "com.battlelancer.seriesguide.autobackup";
-    public static final String KEY_LASTBACKUP = "com.battlelancer.seriesguide.lastbackup";
-
+    public static final String KEY_AUTOBACKUP
+            = "com.battlelancer.seriesguide.autobackup";
     public static final String KEY_AUTO_BACKUP_USE_DEFAULT_FILES
             = "com.battlelancer.seriesguide.autobackup.defaultFiles";
     public static final String KEY_AUTO_BACKUP_SHOWS_EXPORT_URI
@@ -46,6 +40,14 @@ public class BackupSettings {
             = "com.battlelancer.seriesguide.autobackup.listsExport";
     public static final String KEY_AUTO_BACKUP_MOVIES_EXPORT_URI
             = "com.battlelancer.seriesguide.autobackup.moviesExport";
+
+    /**
+     * Store some auto backup prefs in separate preference file
+     * that is not backed up by Android auto backup.
+     */
+    private static final String PREFS_AUTOBACKUP = "autobackup";
+    private static final String KEY_AUTOBACKUP_LAST_TIME
+            = "com.battlelancer.seriesguide.lastbackup";
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
@@ -89,11 +91,11 @@ public class BackupSettings {
         SharedPreferences prefs = context
                 .getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE);
 
-        long time = prefs.getLong(KEY_LASTBACKUP, 0);
+        long time = prefs.getLong(KEY_AUTOBACKUP_LAST_TIME, 0);
         if (time == 0) {
             // For new installs set last time to now so backup will not run right away.
             time = System.currentTimeMillis();
-            prefs.edit().putLong(KEY_LASTBACKUP, time).apply();
+            prefs.edit().putLong(KEY_AUTOBACKUP_LAST_TIME, time).apply();
         }
 
         return time;
@@ -102,7 +104,7 @@ public class BackupSettings {
     public static void setLastAutoBackupTimeToNow(Context context) {
         context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
                 .edit()
-                .putLong(KEY_LASTBACKUP, System.currentTimeMillis())
+                .putLong(KEY_AUTOBACKUP_LAST_TIME, System.currentTimeMillis())
                 .apply();
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationActivity.kt
@@ -1,5 +1,7 @@
 package com.battlelancer.seriesguide.dataliberation
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.fragment.app.Fragment
@@ -51,7 +53,13 @@ class DataLiberationActivity : BaseActivity() {
     }
 
     companion object {
-        const val EXTRA_SHOW_AUTOBACKUP = "EXTRA_SHOW_AUTOBACKUP"
+        private const val EXTRA_SHOW_AUTOBACKUP = "EXTRA_SHOW_AUTOBACKUP"
+
+        @JvmStatic
+        fun intentToShowAutoBackup(context: Context): Intent {
+            return Intent(context, DataLiberationActivity::class.java)
+                .putExtra(EXTRA_SHOW_AUTOBACKUP, true)
+        }
     }
 
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
@@ -21,7 +21,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 import com.battlelancer.seriesguide.R;
-import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.util.Utils;
 import com.google.android.material.snackbar.Snackbar;
 import org.greenrobot.eventbus.EventBus;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
@@ -291,44 +291,59 @@ public class DataLiberationFragment extends Fragment implements
                 Timber.e(e, "Could not persist r/w permission for backup file URI.");
             }
 
-            if (requestCode == REQUEST_CODE_SHOWS_EXPORT_URI) {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_SHOWS_EXPORT_URI, uri);
-                type = JsonExportTask.BACKUP_SHOWS;
-                doDataLiberationAction(REQUEST_CODE_EXPORT);
-            } else if (requestCode == REQUEST_CODE_LISTS_EXPORT_URI) {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_LISTS_EXPORT_URI, uri);
-                type = JsonExportTask.BACKUP_LISTS;
-                doDataLiberationAction(REQUEST_CODE_EXPORT);
-            } else if (requestCode == REQUEST_CODE_MOVIES_EXPORT_URI) {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_MOVIES_EXPORT_URI,
-                        uri);
-                type = JsonExportTask.BACKUP_MOVIES;
-                doDataLiberationAction(REQUEST_CODE_EXPORT);
-            } else if (requestCode == REQUEST_CODE_SHOWS_IMPORT_URI) {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_SHOWS_IMPORT_URI, uri);
-            } else if (requestCode == REQUEST_CODE_LISTS_IMPORT_URI) {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_LISTS_IMPORT_URI, uri);
-            } else {
-                BackupSettings.storeFileUri(getContext(), BackupSettings.KEY_MOVIES_IMPORT_URI,
-                        uri);
+            switch (requestCode) {
+                case REQUEST_CODE_SHOWS_EXPORT_URI:
+                    type = JsonExportTask.BACKUP_SHOWS;
+                    BackupSettings.storeExportFileUri(getContext(), type, uri, false);
+                    doDataLiberationAction(REQUEST_CODE_EXPORT);
+                    break;
+                case REQUEST_CODE_LISTS_EXPORT_URI:
+                    type = JsonExportTask.BACKUP_LISTS;
+                    BackupSettings.storeExportFileUri(getContext(), type, uri, false);
+                    doDataLiberationAction(REQUEST_CODE_EXPORT);
+                    break;
+                case REQUEST_CODE_MOVIES_EXPORT_URI:
+                    type = JsonExportTask.BACKUP_MOVIES;
+                    BackupSettings.storeExportFileUri(getContext(), type, uri, false);
+                    doDataLiberationAction(REQUEST_CODE_EXPORT);
+                    break;
+                case REQUEST_CODE_SHOWS_IMPORT_URI:
+                    BackupSettings.storeImportFileUri(getContext(),
+                            JsonExportTask.BACKUP_SHOWS, uri);
+                    break;
+                case REQUEST_CODE_LISTS_IMPORT_URI:
+                    BackupSettings.storeImportFileUri(getContext(),
+                            JsonExportTask.BACKUP_LISTS, uri);
+                    break;
+                default:
+                    BackupSettings.storeImportFileUri(getContext(),
+                            JsonExportTask.BACKUP_MOVIES, uri);
+                    break;
             }
             updateFileViews();
         }
     }
 
     private void updateFileViews() {
-        setUriOrPlaceholder(textShowsExportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_SHOWS_EXPORT_URI));
-        setUriOrPlaceholder(textShowsImportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_SHOWS_IMPORT_URI));
-        setUriOrPlaceholder(textListsExportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_LISTS_EXPORT_URI));
-        setUriOrPlaceholder(textListsImportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_LISTS_IMPORT_URI));
-        setUriOrPlaceholder(textMoviesExportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_MOVIES_EXPORT_URI));
-        setUriOrPlaceholder(textMoviesImportFile, BackupSettings.getFileUri(getContext(),
-                BackupSettings.KEY_MOVIES_IMPORT_URI));
+        setUriOrPlaceholder(textShowsExportFile,
+                BackupSettings.getExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_SHOWS, false));
+        setUriOrPlaceholder(textListsExportFile,
+                BackupSettings.getExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_LISTS, false));
+        setUriOrPlaceholder(textMoviesExportFile,
+                BackupSettings.getExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_MOVIES, false));
+
+        setUriOrPlaceholder(textShowsImportFile,
+                BackupSettings.getImportFileUriOrExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_SHOWS));
+        setUriOrPlaceholder(textListsImportFile,
+                BackupSettings.getImportFileUriOrExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_LISTS));
+        setUriOrPlaceholder(textMoviesImportFile,
+                BackupSettings.getImportFileUriOrExportFileUri(
+                        getContext(), JsonExportTask.BACKUP_MOVIES));
     }
 
     private void setUriOrPlaceholder(TextView textView, Uri uri) {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationTools.java
@@ -1,29 +1,14 @@
 package com.battlelancer.seriesguide.dataliberation;
 
 import android.annotation.TargetApi;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.preference.PreferenceManager;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import com.battlelancer.seriesguide.settings.AdvancedSettings;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
 import com.battlelancer.seriesguide.util.Utils;
 
 public class DataLiberationTools {
-
-    public static void setAutoBackupEnabled(Context context) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                .putBoolean(AdvancedSettings.KEY_AUTOBACKUP, true)
-                .apply();
-    }
-
-    public static void setAutoBackupDisabled(Context context) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                .putBoolean(AdvancedSettings.KEY_AUTOBACKUP, false)
-                .apply();
-    }
 
     /**
      * Transform a string representation of {@link com.battlelancer.seriesguide.dataliberation.JsonExportTask.ShowStatusExport}

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationTools.java
@@ -1,39 +1,17 @@
 package com.battlelancer.seriesguide.dataliberation;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import com.battlelancer.seriesguide.settings.AdvancedSettings;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
 import com.battlelancer.seriesguide.util.Utils;
-import java.io.File;
 
 public class DataLiberationTools {
-
-    /**
-     * Returns if at least one auto backup file in the default folder exists and is readable.
-     */
-    public static boolean isAutoBackupDefaultFilesAvailable() {
-        File pathAutoBackup = JsonExportTask.getExportPath(true);
-        File backupShows = new File(pathAutoBackup, JsonExportTask.EXPORT_JSON_FILE_SHOWS);
-        File backupLists = new File(pathAutoBackup, JsonExportTask.EXPORT_JSON_FILE_LISTS);
-        File backupMovies = new File(pathAutoBackup, JsonExportTask.EXPORT_JSON_FILE_MOVIES);
-        return (backupShows.exists() && backupShows.canRead())
-                || (backupLists.exists() && backupLists.canRead()
-                || (backupMovies.exists() && backupMovies.canRead()));
-    }
-
-    public static boolean isAutoBackupPermissionMissing(Context context) {
-        return ContextCompat.checkSelfPermission(context,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED;
-    }
 
     public static void setAutoBackupEnabled(Context context) {
         PreferenceManager.getDefaultSharedPreferences(context).edit()

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -51,9 +51,9 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         void onProgressUpdate(Integer... values);
     }
 
-    public static final String EXPORT_JSON_FILE_SHOWS = "sg-shows-export.json";
-    public static final String EXPORT_JSON_FILE_LISTS = "sg-lists-export.json";
-    public static final String EXPORT_JSON_FILE_MOVIES = "sg-movies-export.json";
+    public static final String EXPORT_JSON_FILE_SHOWS = "seriesguide-shows-backup.json";
+    public static final String EXPORT_JSON_FILE_LISTS = "seriesguide-lists-backup.json";
+    public static final String EXPORT_JSON_FILE_MOVIES = "seriesguide-movies-backup.json";
 
     public static final int BACKUP_SHOWS = 1;
     public static final int BACKUP_LISTS = 2;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -298,7 +298,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     }
 
     @Nullable
-    private Uri getDataBackupFile(@BackupType int type) {
+    Uri getDataBackupFile(@BackupType int type) {
         if (type == BACKUP_SHOWS) {
             return BackupSettings.getFileUri(context,
                     isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_SHOWS_EXPORT_URI
@@ -317,7 +317,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         return null;
     }
 
-    private void removeBackupFileUri(@BackupType int type) {
+    void removeBackupFileUri(@BackupType int type) {
         if (type == BACKUP_SHOWS) {
             BackupSettings.storeFileUri(context,
                     isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_SHOWS_EXPORT_URI

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -116,9 +116,12 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
             // Auto backup mode.
             try {
                 new AutoBackupTask(this, context).run();
+                BackupSettings.setAutoBackupErrorOrNull(context, null);
                 return SUCCESS;
             } catch (Exception e) {
                 Timber.e(e, "Unable to auto backup.");
+                BackupSettings.setAutoBackupErrorOrNull(context,
+                        e.getClass().getSimpleName() + ": " + e.getMessage());
                 return ERROR;
             }
         } else {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -125,13 +125,12 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     protected Integer doInBackground(Void... params) {
         if (isAutoBackupMode) {
             // Auto backup mode.
-
-            AutoBackupTask.Result backupResult = new AutoBackupTask(this, context).run();
-            if (backupResult instanceof AutoBackupTask.Result.Error) {
-                Timber.e(((AutoBackupTask.Result.Error) backupResult).getReason());
-                return ERROR;
-            } else {
+            try {
+                new AutoBackupTask(this, context).run();
                 return SUCCESS;
+            } catch (Exception e) {
+                Timber.e(e, "Unable to auto backup.");
+                return ERROR;
             }
         } else {
             // Manual backup mode.

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -36,6 +36,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.greenrobot.eventbus.EventBus;
 import timber.log.Timber;
@@ -329,7 +330,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         int numExported = 0;
 
         Gson gson = new Gson();
-        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
+        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         writer.beginArray();
 
         while (shows.moveToNext()) {
@@ -455,7 +456,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         int numExported = 0;
 
         Gson gson = new Gson();
-        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
+        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         writer.beginArray();
 
         while (lists.moveToNext()) {
@@ -519,7 +520,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         int numExported = 0;
 
         Gson gson = new Gson();
-        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"));
+        JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
         writer.beginArray();
 
         while (movies.moveToNext()) {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -291,38 +291,11 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
 
     @Nullable
     Uri getDataBackupFile(@BackupType int type) {
-        if (type == BACKUP_SHOWS) {
-            return BackupSettings.getFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_SHOWS_EXPORT_URI
-                            : BackupSettings.KEY_SHOWS_EXPORT_URI);
-        }
-        if (type == BACKUP_LISTS) {
-            return BackupSettings.getFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_LISTS_EXPORT_URI
-                            : BackupSettings.KEY_LISTS_EXPORT_URI);
-        }
-        if (type == BACKUP_MOVIES) {
-            return BackupSettings.getFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_MOVIES_EXPORT_URI
-                            : BackupSettings.KEY_MOVIES_EXPORT_URI);
-        }
-        return null;
+        return BackupSettings.getExportFileUri(context, type, isAutoBackupMode);
     }
 
     void removeBackupFileUri(@BackupType int type) {
-        if (type == BACKUP_SHOWS) {
-            BackupSettings.storeFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_SHOWS_EXPORT_URI
-                            : BackupSettings.KEY_SHOWS_EXPORT_URI, null);
-        } else if (type == BACKUP_LISTS) {
-            BackupSettings.storeFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_LISTS_EXPORT_URI
-                            : BackupSettings.KEY_LISTS_EXPORT_URI, null);
-        } else if (type == BACKUP_MOVIES) {
-            BackupSettings.storeFileUri(context,
-                    isAutoBackupMode ? BackupSettings.KEY_AUTO_BACKUP_MOVIES_EXPORT_URI
-                            : BackupSettings.KEY_MOVIES_EXPORT_URI, null);
-        }
+        BackupSettings.storeExportFileUri(context, type, null, isAutoBackupMode);
     }
 
     void writeJsonStreamShows(OutputStream out, Cursor shows) throws IOException {

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -23,7 +23,6 @@ import com.battlelancer.seriesguide.provider.SeriesGuideContract.ListItemTypes;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.ListItems;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
-import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.ui.episodes.EpisodeTools;
 import com.battlelancer.seriesguide.ui.shows.ShowTools;
 import com.battlelancer.seriesguide.util.TaskManager;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -31,7 +30,6 @@ import com.battlelancer.seriesguide.util.TaskManager;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.stream.JsonWriter;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -53,8 +51,6 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
         void onProgressUpdate(Integer... values);
     }
 
-    public static final String EXPORT_FOLDER = "SeriesGuide";
-    public static final String EXPORT_FOLDER_AUTO = "SeriesGuide" + File.separator + "AutoBackup";
     public static final String EXPORT_JSON_FILE_SHOWS = "sg-shows-export.json";
     public static final String EXPORT_JSON_FILE_LISTS = "sg-lists-export.json";
     public static final String EXPORT_JSON_FILE_MOVIES = "sg-movies-export.json";
@@ -98,12 +94,6 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
     private boolean isAutoBackupMode;
     @Nullable private final Integer type;
     @Nullable private String errorCause;
-
-    public static File getExportPath(boolean isAutoBackupMode) {
-        return new File(
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-                isAutoBackupMode ? EXPORT_FOLDER_AUTO : EXPORT_FOLDER);
-    }
 
     /**
      * Same as {@link JsonExportTask} but allows to set parameters.

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
@@ -27,7 +27,6 @@ import com.battlelancer.seriesguide.provider.SeriesGuideContract.ListItems;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Lists;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
-import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.sync.SgSyncAdapter;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
 import com.battlelancer.seriesguide.util.DBUtils;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
@@ -294,6 +294,12 @@ public class JsonImportTask extends AsyncTask<Void, Integer, Integer> {
 
     private void importFromJson(@JsonExportTask.BackupType int type, FileInputStream in)
             throws JsonParseException, IOException, IllegalArgumentException {
+        if (in.getChannel().size() == 0) {
+            Timber.i("Backup file is empty, nothing to import.");
+            in.close();
+            return; // File is empty, nothing to import.
+        }
+
         Gson gson = new Gson();
         JsonReader reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
         reader.beginArray();

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonImportTask.java
@@ -242,25 +242,7 @@ public class JsonImportTask extends AsyncTask<Void, Integer, Integer> {
 
     @Nullable
     private Uri getDataBackupFile(@JsonExportTask.BackupType int type) {
-        // use import URIs
-        // if they are not set getFileUri will fall back to the export URI
-        // for auto backup always use the URI data is configured to be exported to
-        if (type == JsonExportTask.BACKUP_SHOWS) {
-            return BackupSettings.getFileUri(context,
-                    isImportingAutoBackup ? BackupSettings.KEY_AUTO_BACKUP_SHOWS_EXPORT_URI
-                            : BackupSettings.KEY_SHOWS_IMPORT_URI);
-        }
-        if (type == JsonExportTask.BACKUP_LISTS) {
-            return BackupSettings.getFileUri(context,
-                    isImportingAutoBackup ? BackupSettings.KEY_AUTO_BACKUP_LISTS_EXPORT_URI
-                            : BackupSettings.KEY_LISTS_IMPORT_URI);
-        }
-        if (type == JsonExportTask.BACKUP_MOVIES) {
-            return BackupSettings.getFileUri(context,
-                    isImportingAutoBackup ? BackupSettings.KEY_AUTO_BACKUP_MOVIES_EXPORT_URI
-                            : BackupSettings.KEY_MOVIES_IMPORT_URI);
-        }
-        return null;
+        return BackupSettings.getImportFileUriOrExportFileUri(context, type);
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
@@ -10,6 +10,12 @@ import android.preference.PreferenceManager;
  */
 public class AdvancedSettings {
 
+    /**
+     * Store last auto backup timestamp in separate settings file
+     * that is not backed up by Android auto backup.
+     */
+    public static final String PREFS_AUTOBACKUP = "autobackup";
+
     public static final String KEY_AUTOBACKUP = "com.battlelancer.seriesguide.autobackup";
 
     public static final String KEY_LASTBACKUP = "com.battlelancer.seriesguide.lastbackup";
@@ -25,17 +31,24 @@ public class AdvancedSettings {
     }
 
     public static long getLastAutoBackupTime(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences prefs = context
+                .getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE);
 
         long time = prefs.getLong(KEY_LASTBACKUP, 0);
         if (time == 0) {
-            // use now as default value, so a re-install won't overwrite the old
-            // auto-backup right away
+            // For new installs set last time to now so backup will not run right away.
             time = System.currentTimeMillis();
             prefs.edit().putLong(KEY_LASTBACKUP, time).apply();
         }
 
         return time;
+    }
+
+    public static void setLastAutoBackupTimeToNow(Context context) {
+        context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
+                .edit()
+                .putLong(KEY_LASTBACKUP, System.currentTimeMillis())
+                .apply();
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
@@ -4,6 +4,7 @@ package com.battlelancer.seriesguide.settings;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.text.format.DateUtils;
 
 /**
  * Access advanced settings for auto backup and auto update.
@@ -28,6 +29,12 @@ public class AdvancedSettings {
     public static boolean isAutoBackupEnabled(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(KEY_AUTOBACKUP,
                 true);
+    }
+
+    public static boolean isTimeForAutoBackup(Context context) {
+        long now = System.currentTimeMillis();
+        long previousBackupTime = AdvancedSettings.getLastAutoBackupTime(context);
+        return (now - previousBackupTime) > 7 * DateUtils.DAY_IN_MILLIS;
     }
 
     public static long getLastAutoBackupTime(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/AdvancedSettings.java
@@ -2,61 +2,17 @@
 package com.battlelancer.seriesguide.settings;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.text.format.DateUtils;
 
 /**
  * Access advanced settings for auto backup and auto update.
  */
 public class AdvancedSettings {
 
-    /**
-     * Store last auto backup timestamp in separate settings file
-     * that is not backed up by Android auto backup.
-     */
-    public static final String PREFS_AUTOBACKUP = "autobackup";
-
-    public static final String KEY_AUTOBACKUP = "com.battlelancer.seriesguide.autobackup";
-
-    public static final String KEY_LASTBACKUP = "com.battlelancer.seriesguide.lastbackup";
-
     private static final String KEY_LAST_SUPPORTER_STATE
             = "com.battlelancer.seriesguide.lastupgradestate";
 
     public static final String KEY_UPCOMING_LIMIT = "com.battlelancer.seriesguide.upcominglimit";
-
-    public static boolean isAutoBackupEnabled(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(KEY_AUTOBACKUP,
-                true);
-    }
-
-    public static boolean isTimeForAutoBackup(Context context) {
-        long now = System.currentTimeMillis();
-        long previousBackupTime = AdvancedSettings.getLastAutoBackupTime(context);
-        return (now - previousBackupTime) > 7 * DateUtils.DAY_IN_MILLIS;
-    }
-
-    public static long getLastAutoBackupTime(Context context) {
-        SharedPreferences prefs = context
-                .getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE);
-
-        long time = prefs.getLong(KEY_LASTBACKUP, 0);
-        if (time == 0) {
-            // For new installs set last time to now so backup will not run right away.
-            time = System.currentTimeMillis();
-            prefs.edit().putLong(KEY_LASTBACKUP, time).apply();
-        }
-
-        return time;
-    }
-
-    public static void setLastAutoBackupTimeToNow(Context context) {
-        context.getSharedPreferences(PREFS_AUTOBACKUP, Context.MODE_PRIVATE)
-                .edit()
-                .putLong(KEY_LASTBACKUP, System.currentTimeMillis())
-                .apply();
-    }
 
     /**
      * (Only Amazon version) Returns if the user was a supporter through an in-app purchase

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/BackupSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/BackupSettings.java
@@ -52,8 +52,8 @@ public class BackupSettings {
     public @interface FileUriSettingsKey {
     }
 
-    public static boolean isUseAutoBackupDefaultFiles(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context)
+    public static boolean isCreateCopyOfAutoBackup(Context context) {
+        return !PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(KEY_AUTO_BACKUP_USE_DEFAULT_FILES, true);
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
@@ -11,13 +11,10 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 import com.battlelancer.seriesguide.R;
-import com.battlelancer.seriesguide.dataliberation.DataLiberationTools;
 import com.battlelancer.seriesguide.settings.AdvancedSettings;
-import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.sync.SgSyncAdapter;
 import com.battlelancer.seriesguide.traktapi.TraktTask;
 import com.battlelancer.seriesguide.ui.search.AddShowTask;
-import com.battlelancer.seriesguide.ui.shows.FirstRunView;
 import com.battlelancer.seriesguide.util.DBUtils;
 import com.battlelancer.seriesguide.util.TaskManager;
 import org.greenrobot.eventbus.EventBus;
@@ -144,26 +141,23 @@ public abstract class BaseActivity extends AppCompatActivity {
             return false;
         }
 
-        if (DataLiberationTools.isAutoBackupPermissionMissing(this)) {
-            // only show warning if the user is done with first run
-            if (FirstRunView.hasSeenFirstRunFragment(this)) {
-                onShowAutoBackupPermissionWarning();
-            }
-            return false;
-        }
+        // TODO Only if user has specified custom files.
+//        // If user specified files are invalid, show a warning,
+//        // but only once first run is dismissed.
+//        if (FirstRunView.hasSeenFirstRunFragment(this)
+//                && DataLiberationTools.isAutoBackupPermissionMissing(this)) {
+//            onShowAutoBackupPermissionWarning();
+//        }
 
-        long now = System.currentTimeMillis();
-        long previousBackupTime = AdvancedSettings.getLastAutoBackupTime(this);
-        final boolean isTime = (now - previousBackupTime) > 7 * DateUtils.DAY_IN_MILLIS;
-
-        if (isTime) {
-            // if custom files are enabled, make sure they are configured
-            // note: backup task clears backup file setting if there was an issue with the file
-            if (!BackupSettings.isUseAutoBackupDefaultFiles(this)
-                    && BackupSettings.isMissingAutoBackupFile(this)) {
-                onShowAutoBackupMissingFilesWarning();
-                return false;
-            }
+        if (AdvancedSettings.isTimeForAutoBackup(this)) {
+            // FIXME
+//            // if custom files are enabled, make sure they are configured
+//            // note: backup task clears backup file setting if there was an issue with the file
+//            if (!BackupSettings.isUseAutoBackupDefaultFiles(this)
+//                    && BackupSettings.isMissingAutoBackupFile(this)) {
+//                onShowAutoBackupMissingFilesWarning();
+//                return false;
+//            }
 
             TaskManager.getInstance().tryBackupTask(this);
             return true;

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
@@ -12,6 +12,7 @@ import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 import com.battlelancer.seriesguide.R;
 import com.battlelancer.seriesguide.settings.AdvancedSettings;
+import com.battlelancer.seriesguide.settings.BackupSettings;
 import com.battlelancer.seriesguide.sync.SgSyncAdapter;
 import com.battlelancer.seriesguide.traktapi.TraktTask;
 import com.battlelancer.seriesguide.ui.search.AddShowTask;
@@ -141,29 +142,19 @@ public abstract class BaseActivity extends AppCompatActivity {
             return false;
         }
 
-        // TODO Only if user has specified custom files.
-//        // If user specified files are invalid, show a warning,
-//        // but only once first run is dismissed.
-//        if (FirstRunView.hasSeenFirstRunFragment(this)
-//                && DataLiberationTools.isAutoBackupPermissionMissing(this)) {
-//            onShowAutoBackupPermissionWarning();
-//        }
+        // If copies should be made, but the specified files are invalid,
+        // show a warning but run auto backup anyhow.
+        if (BackupSettings.isCreateCopyOfAutoBackup(this)
+                && BackupSettings.isMissingAutoBackupFile(this)) {
+            onShowAutoBackupMissingFilesWarning();
+        }
 
-        if (AdvancedSettings.isTimeForAutoBackup(this)) {
-            // FIXME
-//            // if custom files are enabled, make sure they are configured
-//            // note: backup task clears backup file setting if there was an issue with the file
-//            if (!BackupSettings.isUseAutoBackupDefaultFiles(this)
-//                    && BackupSettings.isMissingAutoBackupFile(this)) {
-//                onShowAutoBackupMissingFilesWarning();
-//                return false;
-//            }
-
-            TaskManager.getInstance().tryBackupTask(this);
-            return true;
-        } else {
+        if (!AdvancedSettings.isTimeForAutoBackup(this)) {
             return false;
         }
+
+        TaskManager.getInstance().tryBackupTask(this);
+        return true;
     }
 
     /**
@@ -171,14 +162,6 @@ public abstract class BaseActivity extends AppCompatActivity {
      * custom backup files are configured.
      */
     protected void onShowAutoBackupMissingFilesWarning() {
-        // do nothing
-    }
-
-    /**
-     * Implementers may choose to show a warning that auto backup can not complete because of
-     * missing permissions.
-     */
-    protected void onShowAutoBackupPermissionWarning() {
         // do nothing
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
@@ -11,8 +11,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 import com.battlelancer.seriesguide.R;
-import com.battlelancer.seriesguide.settings.AdvancedSettings;
-import com.battlelancer.seriesguide.settings.BackupSettings;
+import com.battlelancer.seriesguide.dataliberation.BackupSettings;
 import com.battlelancer.seriesguide.sync.SgSyncAdapter;
 import com.battlelancer.seriesguide.traktapi.TraktTask;
 import com.battlelancer.seriesguide.ui.search.AddShowTask;
@@ -138,7 +137,7 @@ public abstract class BaseActivity extends AppCompatActivity {
      * Periodically do an automatic backup of the show database.
      */
     private boolean onAutoBackup() {
-        if (!AdvancedSettings.isAutoBackupEnabled(this)) {
+        if (!BackupSettings.isAutoBackupEnabled(this)) {
             return false;
         }
 
@@ -149,7 +148,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             onShowAutoBackupMissingFilesWarning();
         }
 
-        if (!AdvancedSettings.isTimeForAutoBackup(this)) {
+        if (!BackupSettings.isTimeForAutoBackup(this)) {
             return false;
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseActivity.java
@@ -141,11 +141,15 @@ public abstract class BaseActivity extends AppCompatActivity {
             return false;
         }
 
+        // If last auto backup failed, show a warning, but run it (if it's time) anyhow.
+        if (BackupSettings.isWarnLastAutoBackupFailed(this)) {
+            onLastAutoBackupFailed();
+        }
         // If copies should be made, but the specified files are invalid,
-        // show a warning but run auto backup anyhow.
-        if (BackupSettings.isCreateCopyOfAutoBackup(this)
+        // show a warning but run auto backup (if it's time) anyhow.
+        else if (BackupSettings.isCreateCopyOfAutoBackup(this)
                 && BackupSettings.isMissingAutoBackupFile(this)) {
-            onShowAutoBackupMissingFilesWarning();
+            onAutoBackupMissingFiles();
         }
 
         if (!BackupSettings.isTimeForAutoBackup(this)) {
@@ -157,11 +161,18 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     /**
+     * Implementers may choose to show a warning that the last auto backup has failed.
+     */
+    protected void onLastAutoBackupFailed() {
+        // Do nothing.
+    }
+
+    /**
      * Implementers may choose to show a warning that auto backup can not complete because not all
      * custom backup files are configured.
      */
-    protected void onShowAutoBackupMissingFilesWarning() {
-        // do nothing
+    protected void onAutoBackupMissingFiles() {
+        // Do nothing.
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
@@ -19,7 +19,6 @@ import com.battlelancer.seriesguide.SgApp;
 import com.battlelancer.seriesguide.backend.CloudSetupActivity;
 import com.battlelancer.seriesguide.backend.HexagonTools;
 import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity;
-import com.battlelancer.seriesguide.dataliberation.DataLiberationTools;
 import com.battlelancer.seriesguide.sync.AccountUtils;
 import com.google.android.material.snackbar.Snackbar;
 import timber.log.Timber;
@@ -140,48 +139,23 @@ public abstract class BaseTopActivity extends BaseNavDrawerActivity {
             return;
         }
 
-        Snackbar newSnackbar = Snackbar
-                .make(getSnackbarParentView(),
-                        R.string.autobackup_files_missing, Snackbar.LENGTH_LONG);
-        setUpAutoBackupSnackbar(newSnackbar);
-        newSnackbar.show();
-
-        snackbar = newSnackbar;
-    }
-
-    @Override
-    protected void onShowAutoBackupPermissionWarning() {
-        if (snackbar != null && snackbar.isShown()) {
-            Timber.d("NOT showing backup permission warning: existing snackbar.");
-            return;
-        }
-
-        Snackbar newSnackbar = Snackbar
-                .make(getSnackbarParentView(),
-                        R.string.autobackup_permission_missing, Snackbar.LENGTH_INDEFINITE);
-        setUpAutoBackupSnackbar(newSnackbar);
-        newSnackbar.show();
-
-        snackbar = newSnackbar;
-    }
-
-    private void setUpAutoBackupSnackbar(Snackbar snackbar) {
-        TextView textView = snackbar.getView().findViewById(
-                com.google.android.material.R.id.snackbar_text);
-        textView.setMaxLines(5);
-        snackbar.addCallback(new Snackbar.Callback() {
-            @Override
-            public void onDismissed(Snackbar snackbar, int event) {
-                if (event == Snackbar.Callback.DISMISS_EVENT_SWIPE) {
-                    // user has acknowledged warning
-                    // disable auto backup so warning is not shown again
-                    DataLiberationTools.setAutoBackupDisabled(BaseTopActivity.this);
-                }
-            }
-        }).setAction(R.string.preferences,
-                v -> startActivity(new Intent(BaseTopActivity.this, DataLiberationActivity.class)
-                        .putExtra(DataLiberationActivity.EXTRA_SHOW_AUTOBACKUP, true))
+        Snackbar newSnackbar = Snackbar.make(
+                getSnackbarParentView(),
+                R.string.autobackup_files_missing,
+                Snackbar.LENGTH_INDEFINITE
         );
+
+        // Manually increase max lines.
+        TextView textView = newSnackbar.getView()
+                .findViewById(com.google.android.material.R.id.snackbar_text);
+        textView.setMaxLines(5);
+
+        newSnackbar.setAction(R.string.preferences, v -> startActivity(
+                new Intent(this, DataLiberationActivity.class)
+                        .putExtra(DataLiberationActivity.EXTRA_SHOW_AUTOBACKUP, true)));
+        newSnackbar.show();
+
+        snackbar = newSnackbar;
     }
 
     @Override

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
@@ -150,9 +150,8 @@ public abstract class BaseTopActivity extends BaseNavDrawerActivity {
                 .findViewById(com.google.android.material.R.id.snackbar_text);
         textView.setMaxLines(5);
 
-        newSnackbar.setAction(R.string.preferences, v -> startActivity(
-                new Intent(this, DataLiberationActivity.class)
-                        .putExtra(DataLiberationActivity.EXTRA_SHOW_AUTOBACKUP, true)));
+        newSnackbar.setAction(R.string.preferences, v ->
+                startActivity(DataLiberationActivity.intentToShowAutoBackup(this)));
         newSnackbar.show();
 
         snackbar = newSnackbar;

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/preferences/SgPreferencesFragment.kt
@@ -301,11 +301,7 @@ class SgPreferencesFragment : PreferenceFragmentCompat(),
                 return true
             }
             LINK_KEY_AUTOBACKUP -> {
-                startActivity(
-                    Intent(activity, DataLiberationActivity::class.java).putExtra(
-                        DataLiberationActivity.EXTRA_SHOW_AUTOBACKUP, true
-                    )
-                )
+                startActivity(DataLiberationActivity.intentToShowAutoBackup(requireActivity()))
                 return true
             }
             LINK_KEY_DATALIBERATION -> {

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/shows/FirstRunView.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/shows/FirstRunView.kt
@@ -4,14 +4,10 @@ import android.content.Context
 import android.preference.PreferenceManager
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.ViewGroup
-import android.widget.Button
-import android.widget.CheckBox
 import android.widget.FrameLayout
-import android.widget.ImageButton
-import android.widget.TextView
 import androidx.core.content.edit
 import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.databinding.ViewFirstRunBinding
 import com.battlelancer.seriesguide.settings.DisplaySettings
 import com.battlelancer.seriesguide.settings.UpdateSettings
 import com.battlelancer.seriesguide.util.TaskManager
@@ -30,28 +26,15 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
 
     class ButtonEvent(val type: ButtonType)
 
-    init {
-        LayoutInflater.from(context).inflate(R.layout.view_first_run, this)
-    }
+    private val binding: ViewFirstRunBinding =
+        ViewFirstRunBinding.inflate(LayoutInflater.from(context), this, true)
 
     override fun onFinishInflate() {
         super.onFinishInflate()
 
-        val noSpoilerView = findViewById<ViewGroup>(R.id.containerFirstRunNoSpoilers)
-        val noSpoilerCheckBox = noSpoilerView.findViewById<CheckBox>(
-            R.id.checkboxFirstRunNoSpoilers
-        )
-        val dataSaverContainer = findViewById<ViewGroup>(R.id.containerFirstRunDataSaver)
-        val dataSaverCheckBox = findViewById<CheckBox>(R.id.checkboxFirstRunDataSaver)
-        val buttonAddShow = findViewById<Button>(R.id.buttonFirstRunAddShow)
-        val buttonSignIn = findViewById<Button>(R.id.buttonFirstRunSignIn)
-        val buttonRestoreBackup = findViewById<Button>(R.id.buttonFirstRunRestore)
-        val textViewPrivacyPolicy = findViewById<TextView>(R.id.textViewFirstRunPrivacyLink)
-        val buttonDismiss = findViewById<ImageButton>(R.id.buttonFirstRunDismiss)
-
-        noSpoilerView.setOnClickListener { v ->
+        binding.containerNoSpoilers.setOnClickListener { v ->
             // new state is inversion of current state
-            val noSpoilers = !noSpoilerCheckBox.isChecked
+            val noSpoilers = !binding.checkboxNoSpoilers.isChecked
             // save
             PreferenceManager.getDefaultSharedPreferences(v.context).edit {
                 putBoolean(DisplaySettings.KEY_PREVENT_SPOILERS, noSpoilers)
@@ -59,34 +42,34 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
             // update next episode strings right away
             TaskManager.getInstance().tryNextEpisodeUpdateTask(v.context)
             // show
-            noSpoilerCheckBox.isChecked = noSpoilers
+            binding.checkboxNoSpoilers.isChecked = noSpoilers
         }
-        noSpoilerCheckBox.isChecked = DisplaySettings.preventSpoilers(context)
-        dataSaverContainer.setOnClickListener {
-            val isSaveData = !dataSaverCheckBox.isChecked
+        binding.checkboxNoSpoilers.isChecked = DisplaySettings.preventSpoilers(context)
+
+        binding.containerDataSaver.setOnClickListener {
+            val isSaveData = !binding.checkboxDataSaver.isChecked
             PreferenceManager.getDefaultSharedPreferences(it.context).edit {
                 putBoolean(UpdateSettings.KEY_ONLYWIFI, isSaveData)
             }
-            dataSaverCheckBox.isChecked = isSaveData
+            binding.checkboxDataSaver.isChecked = isSaveData
         }
-        dataSaverCheckBox.isChecked = UpdateSettings.isLargeDataOverWifiOnly(context)
-        buttonAddShow.setOnClickListener {
-            EventBus.getDefault()
-                .post(ButtonEvent(ButtonType.ADD_SHOW))
+        binding.checkboxDataSaver.isChecked = UpdateSettings.isLargeDataOverWifiOnly(context)
+
+        binding.buttonAddShow.setOnClickListener {
+            EventBus.getDefault().post(ButtonEvent(ButtonType.ADD_SHOW))
         }
-        buttonSignIn.setOnClickListener {
-            EventBus.getDefault()
-                .post(ButtonEvent(ButtonType.SIGN_IN))
+        binding.buttonSignIn.setOnClickListener {
+            EventBus.getDefault().post(ButtonEvent(ButtonType.SIGN_IN))
         }
-        buttonRestoreBackup.setOnClickListener {
-            EventBus.getDefault()
-                .post(ButtonEvent(ButtonType.RESTORE_BACKUP))
+        binding.buttonRestoreBackup.setOnClickListener {
+            EventBus.getDefault().post(ButtonEvent(ButtonType.RESTORE_BACKUP))
         }
-        buttonDismiss.setOnClickListener {
+        binding.buttonDismiss.setOnClickListener {
             setFirstRunDismissed()
             EventBus.getDefault().post(ButtonEvent(ButtonType.DISMISS))
         }
-        textViewPrivacyPolicy.setOnClickListener { v ->
+
+        binding.textViewPolicyLink.setOnClickListener { v ->
             val context = v.context
             Utils.launchWebsite(context, context.getString(R.string.url_privacy))
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/shows/FirstRunView.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/shows/FirstRunView.kt
@@ -6,8 +6,11 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.content.edit
+import androidx.core.view.isGone
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.ViewFirstRunBinding
+import com.battlelancer.seriesguide.dataliberation.AutoBackupTools
+import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity
 import com.battlelancer.seriesguide.settings.DisplaySettings
 import com.battlelancer.seriesguide.settings.UpdateSettings
 import com.battlelancer.seriesguide.util.TaskManager
@@ -31,6 +34,12 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+
+        binding.groupAutoBackupDetected.isGone =
+            !AutoBackupTools.isAutoBackupMaybeAvailable(context)
+        binding.buttonRestoreAutoBackup.setOnClickListener {
+            context.startActivity(DataLiberationActivity.intentToShowAutoBackup(context))
+        }
 
         binding.containerNoSpoilers.setOnClickListener { v ->
             // new state is inversion of current state

--- a/app/src/main/java/com/battlelancer/seriesguide/util/TaskManager.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/TaskManager.java
@@ -84,12 +84,14 @@ public class TaskManager {
      * {@link JsonExportTask} is scheduled in silent mode.
      */
     @MainThread
-    public synchronized void tryBackupTask(Context context) {
+    public synchronized boolean tryBackupTask(Context context) {
         if (!isAddTaskRunning()
                 && (backupTask == null || backupTask.getStatus() == AsyncTask.Status.FINISHED)) {
             backupTask = new JsonExportTask(context, null, false, true, null);
             backupTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            return true;
         }
+        return false;
     }
 
     public synchronized void releaseBackupTaskRef() {

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -21,13 +21,13 @@
                 android:layout_height="wrap_content"
                 android:minHeight="48dp"
                 android:text="@string/pref_autobackup"
-                android:textAppearance="@style/TextAppearance.Title" />
+                android:textAppearance="@style/TextAppearance.SeriesGuide.Headline6" />
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/pref_autobackupsummary"
-                android:textAppearance="@style/TextAppearance.Body.Secondary" />
+                android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/containerAutoBackupSettings"
@@ -101,7 +101,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/shows"
-                    android:textAppearance="@style/TextAppearance.Body.Bold"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Bold"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/checkBoxAutoBackupCreateCopy" />
 
@@ -119,7 +119,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:textAppearance="@style/TextAppearance.Body.Secondary"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupShowsExportFile"
@@ -131,7 +131,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/large_padding"
                     android:text="@string/lists"
-                    android:textAppearance="@style/TextAppearance.Body.Bold"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Bold"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupShowsExportFile" />
 
@@ -149,7 +149,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:textAppearance="@style/TextAppearance.Body.Secondary"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupListsExportFile"
@@ -161,7 +161,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/large_padding"
                     android:text="@string/movies"
-                    android:textAppearance="@style/TextAppearance.Body.Bold"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Bold"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupListsExportFile" />
 
@@ -179,7 +179,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:textAppearance="@style/TextAppearance.Body.Secondary"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupMoviesExportFile"
@@ -205,7 +205,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/restore_auto_backup"
-                    android:textAppearance="@style/TextAppearance.Body.Bold.Accent"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Bold.Accent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
@@ -217,6 +217,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/last_auto_backup"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupLabelImport" />
@@ -227,7 +228,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/import_warning"
-                    android:textAppearance="@style/TextAppearance.Body.Bold"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Bold"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -36,6 +36,16 @@
                 android:layout_marginTop="@dimen/large_padding"
                 android:animateLayoutChanges="true">
 
+                <TextView
+                    android:id="@+id/textViewDetails"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/autobackup_details"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary" />
+
                 <ImageView
                     android:id="@+id/imageViewBackupStatus"
                     android:layout_width="24dp"
@@ -52,10 +62,11 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="4dp"
+                    android:layout_marginTop="16dp"
                     android:textAppearance="@style/TextAppearance.SeriesGuide.Body2"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@+id/imageViewBackupStatus"
-                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textViewDetails"
                     tools:text="AutoBackupException: something has gone terribly wrong" />
 
                 <androidx.constraintlayout.widget.Group

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -41,10 +41,10 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/autobackup_details"
-                    app:layout_constraintStart_toStartOf="parent"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageView
                     android:id="@+id/imageViewBackupStatus"
@@ -75,6 +75,15 @@
                     android:layout_height="wrap_content"
                     app:constraint_referenced_ids="imageViewBackupStatus,textViewBackupStatus" />
 
+                <Button
+                    android:id="@+id/buttonAutoBackupNow"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/backup_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textViewBackupStatus" />
+
                 <CheckBox
                     android:id="@+id/checkBoxAutoBackupCreateCopy"
                     android:layout_width="wrap_content"
@@ -84,7 +93,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/textViewBackupStatus" />
+                    app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupNow" />
 
                 <TextView
                     android:id="@+id/textViewAutoBackupShows"

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -58,6 +58,12 @@
                     app:layout_constraintTop_toTopOf="parent"
                     tools:text="AutoBackupException: something has gone terribly wrong" />
 
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/groupState"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:constraint_referenced_ids="imageViewBackupStatus,textViewBackupStatus" />
+
                 <CheckBox
                     android:id="@+id/checkBoxAutoBackupCreateCopy"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -37,10 +37,10 @@
                 android:animateLayoutChanges="true">
 
                 <CheckBox
-                    android:id="@+id/checkBoxAutoBackupDefaultFiles"
+                    android:id="@+id/checkBoxAutoBackupCreateCopy"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/backup_use_default_files"
+                    android:text="@string/autobackup_create_user_copy"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
@@ -54,7 +54,7 @@
                     android:text="@string/shows"
                     android:textAppearance="@style/TextAppearance.Body.Bold"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/checkBoxAutoBackupDefaultFiles" />
+                    app:layout_constraintTop_toBottomOf="@id/checkBoxAutoBackupCreateCopy" />
 
                 <Button
                     android:id="@+id/buttonAutoBackupShowsExportFile"
@@ -138,6 +138,12 @@
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupMoviesExportFile"
                     tools:text="content://some.path.on.storage/sg-movies-export.json" />
+
+                <androidx.constraintlayout.widget.Group
+                    android:id="@+id/groupUserFiles"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:constraint_referenced_ids="textViewAutoBackupShows,buttonAutoBackupShowsExportFile,textViewAutoBackupShowsExportFile,textViewAutoBackupLists,buttonAutoBackupListsExportFile,textViewAutoBackupListsExportFile,textViewAutoBackupMovies,buttonAutoBackupMoviesExportFile,textViewAutoBackupMoviesExportFile" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_auto_backup.xml
+++ b/app/src/main/res/layout/fragment_auto_backup.xml
@@ -36,15 +36,38 @@
                 android:layout_marginTop="@dimen/large_padding"
                 android:animateLayoutChanges="true">
 
+                <ImageView
+                    android:id="@+id/imageViewBackupStatus"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="4dp"
+                    android:contentDescription="@null"
+                    app:layout_constraintBottom_toBottomOf="@+id/textViewBackupStatus"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/textViewBackupStatus"
+                    tools:src="@drawable/ic_cancel_red_24dp" />
+
+                <TextView
+                    android:id="@+id/textViewBackupStatus"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@+id/imageViewBackupStatus"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="AutoBackupException: something has gone terribly wrong" />
+
                 <CheckBox
                     android:id="@+id/checkBoxAutoBackupCreateCopy"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
                     android:text="@string/autobackup_create_user_copy"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textViewBackupStatus" />
 
                 <TextView
                     android:id="@+id/textViewAutoBackupShows"
@@ -53,7 +76,7 @@
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/shows"
                     android:textAppearance="@style/TextAppearance.Body.Bold"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/checkBoxAutoBackupCreateCopy" />
 
                 <Button
@@ -62,7 +85,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/action_select_file"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupShows" />
 
                 <TextView
@@ -70,10 +93,9 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:layout_marginLeft="8dp"
                     android:textAppearance="@style/TextAppearance.Body.Secondary"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupShowsExportFile"
                     tools:text="content://some.path.on.storage/sg-shows-export.json" />
 
@@ -84,7 +106,7 @@
                     android:layout_marginTop="@dimen/large_padding"
                     android:text="@string/lists"
                     android:textAppearance="@style/TextAppearance.Body.Bold"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupShowsExportFile" />
 
                 <Button
@@ -93,7 +115,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/action_select_file"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupLists" />
 
                 <TextView
@@ -101,10 +123,9 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:layout_marginLeft="8dp"
                     android:textAppearance="@style/TextAppearance.Body.Secondary"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupListsExportFile"
                     tools:text="content://sg-lists-export.json" />
 
@@ -115,7 +136,7 @@
                     android:layout_marginTop="@dimen/large_padding"
                     android:text="@string/movies"
                     android:textAppearance="@style/TextAppearance.Body.Bold"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupListsExportFile" />
 
                 <Button
@@ -124,7 +145,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/action_select_file"
-                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupMovies" />
 
                 <TextView
@@ -132,10 +153,9 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:layout_marginLeft="8dp"
                     android:textAppearance="@style/TextAppearance.Body.Secondary"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/buttonAutoBackupMoviesExportFile"
                     tools:text="content://some.path.on.storage/sg-movies-export.json" />
 
@@ -160,9 +180,9 @@
                     android:layout_height="wrap_content"
                     android:text="@string/restore_auto_backup"
                     android:textAppearance="@style/TextAppearance.Body.Bold.Accent"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
@@ -171,8 +191,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/last_auto_backup"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupLabelImport" />
 
                 <TextView
@@ -182,9 +202,9 @@
                     android:layout_marginTop="@dimen/default_padding"
                     android:text="@string/import_warning"
                     android:textAppearance="@style/TextAppearance.Body.Bold"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupLastTime" />
 
                 <Button
@@ -194,9 +214,9 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/restore_auto_backup"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupImportWarning" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_first_run.xml
+++ b/app/src/main/res/layout/item_first_run.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.battlelancer.seriesguide.ui.shows.FirstRunView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/view_first_run.xml
+++ b/app/src/main/res/layout/view_first_run.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cardView"
     style="@style/FirstRunColumn"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/default_padding"
     app:cardPreventCornerOverlap="false">
 
-    <RelativeLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/containerCard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -14,32 +16,37 @@
             android:id="@+id/buttonDismiss"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:layout_alignParentEnd="true"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/dismiss"
-            android:src="@drawable/ic_clear_24dp" />
+            android:src="@drawable/ic_clear_24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/textViewTitle"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/large_padding"
             android:layout_marginTop="@dimen/large_padding"
-            android:layout_marginEnd="@dimen/large_padding"
             android:text="@string/get_started"
-            android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5" />
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5"
+            app:layout_constraintEnd_toStartOf="@+id/buttonDismiss"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/containerNoSpoilers"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/textViewTitle"
             android:layout_marginTop="@dimen/large_padding"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:minHeight="?android:attr/listPreferredItemHeight"
             android:paddingStart="@dimen/large_padding"
-            android:paddingEnd="@dimen/large_padding">
+            android:paddingEnd="@dimen/large_padding"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textViewTitle">
 
             <CheckBox
                 android:id="@+id/checkboxNoSpoilers"
@@ -76,14 +83,16 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/containerDataSaver"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/containerNoSpoilers"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:minHeight="?android:attr/listPreferredItemHeight"
             android:paddingStart="@dimen/large_padding"
-            android:paddingEnd="@dimen/large_padding">
+            android:paddingEnd="@dimen/large_padding"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/containerNoSpoilers">
 
             <CheckBox
                 android:id="@+id/checkboxDataSaver"
@@ -118,53 +127,59 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <LinearLayout
-            android:id="@+id/containerButtons"
-            android:layout_width="match_parent"
+        <Button
+            android:id="@+id/buttonAddShow"
+            style="@style/Widget.SeriesGuide.Button"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/containerDataSaver"
-            android:gravity="end"
-            android:orientation="vertical"
-            android:paddingStart="@dimen/default_padding"
-            android:paddingTop="@dimen/large_padding"
-            android:paddingEnd="@dimen/default_padding"
-            android:paddingBottom="@dimen/inline_padding">
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/action_shows_add"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/containerDataSaver" />
 
-            <Button
-                android:id="@+id/buttonAddShow"
-                style="@style/Widget.SeriesGuide.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_shows_add" />
+        <Button
+            android:id="@+id/buttonSignIn"
+            style="@style/Widget.SeriesGuide.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/hexagon_signin"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonAddShow" />
 
-            <Button
-                android:id="@+id/buttonSignIn"
-                style="@style/Widget.SeriesGuide.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hexagon_signin" />
-
-            <Button
-                android:id="@+id/buttonRestoreBackup"
-                style="@style/Widget.SeriesGuide.Button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/import_button" />
-
-        </LinearLayout>
+        <Button
+            android:id="@+id/buttonRestoreBackup"
+            style="@style/Widget.SeriesGuide.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/import_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonSignIn" />
 
         <include
             android:id="@+id/dividerBottom"
             layout="@layout/divider_horizontal"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_below="@id/containerButtons" />
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonRestoreBackup" />
 
         <TextView
             android:id="@+id/textViewPolicyLink"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/dividerBottom"
             android:layout_marginStart="@dimen/large_padding"
             android:layout_marginEnd="@dimen/large_padding"
             android:background="?attr/selectableItemBackground"
@@ -172,8 +187,10 @@
             android:paddingTop="@dimen/default_padding"
             android:paddingBottom="@dimen/default_padding"
             android:text="@string/privacy_policy"
-            android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent" />
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/dividerBottom" />
 
-    </RelativeLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/view_first_run.xml
+++ b/app/src/main/res/layout/view_first_run.xml
@@ -11,38 +11,38 @@
         android:layout_height="wrap_content">
 
         <ImageButton
-            android:id="@+id/buttonFirstRunDismiss"
+            android:id="@+id/buttonDismiss"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/dismiss"
             android:src="@drawable/ic_clear_24dp" />
 
         <TextView
-            android:id="@+id/textViewFirstRunTitle"
+            android:id="@+id/textViewTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/large_padding"
+            android:layout_marginStart="@dimen/large_padding"
             android:layout_marginTop="@dimen/large_padding"
-            android:layout_marginRight="@dimen/large_padding"
+            android:layout_marginEnd="@dimen/large_padding"
             android:text="@string/get_started"
             android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/containerFirstRunNoSpoilers"
+            android:id="@+id/containerNoSpoilers"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/textViewFirstRunTitle"
+            android:layout_below="@+id/textViewTitle"
             android:layout_marginTop="@dimen/large_padding"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:minHeight="?android:attr/listPreferredItemHeight"
-            android:paddingLeft="@dimen/large_padding"
-            android:paddingRight="@dimen/large_padding">
+            android:paddingStart="@dimen/large_padding"
+            android:paddingEnd="@dimen/large_padding">
 
             <CheckBox
-                android:id="@+id/checkboxFirstRunNoSpoilers"
+                android:id="@+id/checkboxNoSpoilers"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
@@ -52,41 +52,41 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/textViewFirstRunNoSpoilerText"
+                android:id="@+id/textViewNoSpoilers"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/pref_nospoilers"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Subtitle1"
-                app:layout_constraintBaseline_toBaselineOf="@id/checkboxFirstRunNoSpoilers"
+                app:layout_constraintBaseline_toBaselineOf="@id/checkboxNoSpoilers"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/checkboxFirstRunNoSpoilers" />
+                app:layout_constraintStart_toEndOf="@+id/checkboxNoSpoilers" />
 
             <TextView
-                android:id="@+id/textViewFirstRunNoSpoilerSummary"
+                android:id="@+id/textViewNoSpoilersSummary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/inline_padding"
                 android:text="@string/pref_nospoilers_summary"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textViewFirstRunNoSpoilerText"
-                app:layout_constraintTop_toBottomOf="@id/textViewFirstRunNoSpoilerText" />
+                app:layout_constraintStart_toStartOf="@+id/textViewNoSpoilers"
+                app:layout_constraintTop_toBottomOf="@id/textViewNoSpoilers" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/containerFirstRunDataSaver"
+            android:id="@+id/containerDataSaver"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/containerFirstRunNoSpoilers"
+            android:layout_below="@+id/containerNoSpoilers"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:minHeight="?android:attr/listPreferredItemHeight"
-            android:paddingLeft="@dimen/large_padding"
-            android:paddingRight="@dimen/large_padding">
+            android:paddingStart="@dimen/large_padding"
+            android:paddingEnd="@dimen/large_padding">
 
             <CheckBox
-                android:id="@+id/checkboxFirstRunDataSaver"
+                android:id="@+id/checkboxDataSaver"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
@@ -96,56 +96,56 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/textViewFirstRunDataSaverText"
+                android:id="@+id/textViewDataSaver"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/pref_updatewifionly"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Subtitle1"
-                app:layout_constraintBaseline_toBaselineOf="@id/checkboxFirstRunDataSaver"
+                app:layout_constraintBaseline_toBaselineOf="@id/checkboxDataSaver"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/checkboxFirstRunDataSaver" />
+                app:layout_constraintStart_toEndOf="@+id/checkboxDataSaver" />
 
             <TextView
-                android:id="@+id/textViewFirstRunDataSaverSummary"
+                android:id="@+id/textViewDataSaverSummary"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/inline_padding"
                 android:text="@string/pref_updatewifionlysummary"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Secondary"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textViewFirstRunDataSaverText"
-                app:layout_constraintTop_toBottomOf="@id/textViewFirstRunDataSaverText" />
+                app:layout_constraintStart_toStartOf="@+id/textViewDataSaver"
+                app:layout_constraintTop_toBottomOf="@id/textViewDataSaver" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout
-            android:id="@+id/containerFirstRunButtons"
+            android:id="@+id/containerButtons"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/containerFirstRunDataSaver"
+            android:layout_below="@id/containerDataSaver"
             android:gravity="end"
             android:orientation="vertical"
-            android:paddingLeft="@dimen/default_padding"
+            android:paddingStart="@dimen/default_padding"
             android:paddingTop="@dimen/large_padding"
-            android:paddingRight="@dimen/default_padding"
+            android:paddingEnd="@dimen/default_padding"
             android:paddingBottom="@dimen/inline_padding">
 
             <Button
-                android:id="@+id/buttonFirstRunAddShow"
+                android:id="@+id/buttonAddShow"
                 style="@style/Widget.SeriesGuide.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/action_shows_add" />
 
             <Button
-                android:id="@+id/buttonFirstRunSignIn"
+                android:id="@+id/buttonSignIn"
                 style="@style/Widget.SeriesGuide.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/hexagon_signin" />
 
             <Button
-                android:id="@+id/buttonFirstRunRestore"
+                android:id="@+id/buttonRestoreBackup"
                 style="@style/Widget.SeriesGuide.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -154,19 +154,19 @@
         </LinearLayout>
 
         <include
-            android:id="@+id/dividerFirstRun"
+            android:id="@+id/dividerBottom"
             layout="@layout/divider_horizontal"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_below="@id/containerFirstRunButtons" />
+            android:layout_below="@id/containerButtons" />
 
         <TextView
-            android:id="@+id/textViewFirstRunPrivacyLink"
+            android:id="@+id/textViewPolicyLink"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/dividerFirstRun"
-            android:layout_marginLeft="@dimen/large_padding"
-            android:layout_marginRight="@dimen/large_padding"
+            android:layout_below="@+id/dividerBottom"
+            android:layout_marginStart="@dimen/large_padding"
+            android:layout_marginEnd="@dimen/large_padding"
             android:background="?attr/selectableItemBackground"
             android:focusable="true"
             android:paddingTop="@dimen/default_padding"

--- a/app/src/main/res/layout/view_first_run.xml
+++ b/app/src/main/res/layout/view_first_run.xml
@@ -34,6 +34,31 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <TextView
+            android:id="@+id/textViewAutoBackupDetected"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="center"
+            android:text="@string/autobackup_restore_available"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textViewTitle" />
+
+        <Button
+            android:id="@+id/buttonRestoreAutoBackup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/restore_auto_backup"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textViewAutoBackupDetected" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/containerNoSpoilers"
             android:layout_width="0dp"
@@ -46,7 +71,7 @@
             android:paddingEnd="@dimen/large_padding"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textViewTitle">
+            app:layout_constraintTop_toBottomOf="@+id/buttonRestoreAutoBackup">
 
             <CheckBox
                 android:id="@+id/checkboxNoSpoilers"
@@ -190,6 +215,12 @@
             android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/dividerBottom" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/groupAutoBackupDetected"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="textViewAutoBackupDetected,buttonRestoreAutoBackup" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -445,8 +445,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">أخرى</string>
     <string name="pref_autoupdatesummary">مزامنة وتحديث بيانات SeriesGuide تلقائيا</string>
-    <string name="pref_autobackup">نسخ احتياطي تلقائي</string>
-    <string name="pref_autobackupsummary">نسخ إحتياطي أسبوعي للمسلسلات، القوائم والأفلام</string>
     <string name="backup">النسخ الإحتياطي / الإستعادة</string>
     <string name="backup_summary">لعمل نسخ إحتياطي للمسلسلات أو إستعادتها</string>
     <string name="pref_number">تنسيق الأرقام</string>
@@ -466,14 +464,18 @@
     <string name="backup_button">نسخ احتياطي</string>
     <string name="import_button">استعادة</string>
     <string name="import_warning">أنا أفهم أن المسلسلات الحالية، القوائم والأفلام سوف تستبدل!</string>
-    <string name="last_auto_backup">آخر عملية نسخ تلقائية: %s</string>
-    <string name="restore_auto_backup">استعادة النسخ الاحتياطي التلقائي</string>
-    <string name="dataliberation_permission_missing">لعمل نسخ إحتياطي أو إستعادتها، وافق بالسماح للوصول إلى الملفات الخاصة بك.</string>
-    <string name="autobackup_permission_missing">لإستخدام النسخ الإحتياطي التلقائي، وافق بالسماح للوصول إلى الملفات الخاصة بك.</string>
-    <string name="autobackup_files_missing">لإستخدام النسخ الإحتياطي التلقائي، حدد ملفات النسخ الإحتياطية الصالحة.</string>
     <string name="no_file_selected">لم يتم إختيار أي ملف</string>
     <string name="action_select_file">حدد ملف</string>
-    <string name="backup_use_default_files">إستخدم النسخ الإحتياطي الإفتراضي</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">نسخ احتياطي تلقائي</string>
+    <string name="pref_autobackupsummary">نسخ إحتياطي أسبوعي للمسلسلات، القوائم والأفلام</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">آخر عملية نسخ تلقائية: %s</string>
+    <string name="restore_auto_backup">استعادة النسخ الاحتياطي التلقائي</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">لإستخدام النسخ الإحتياطي التلقائي، حدد ملفات النسخ الإحتياطية الصالحة.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">بدء</string>
     <string name="dismiss">إبعاد</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Други</string>
     <string name="pref_autoupdatesummary">Автоматично синхронизиране и актуализиране данните на SeriesGuide</string>
-    <string name="pref_autobackup">Автоматично създаване на резервно копие</string>
-    <string name="pref_autobackupsummary">Седмичен архив на вашите предавания, списъци и филми</string>
     <string name="backup">Архивиране/Възстановяване</string>
     <string name="backup_summary">Архивиране или възстановяване на вашите сериали</string>
     <string name="pref_number">Формат на числата</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Създаване на архив</string>
     <string name="import_button">Възстанови архив</string>
     <string name="import_warning">Разбирам моите текущи предавания, списъци и филми ще бъдат заменени!</string>
-    <string name="last_auto_backup">Последно автоматично архивиране: %s</string>
-    <string name="restore_auto_backup">Възстанови автоматично архивиране</string>
-    <string name="dataliberation_permission_missing">За да архивирате или възстановите, позволете достъп до вашите файлове.</string>
-    <string name="autobackup_permission_missing">За да използвате автоматичното архивиране, позволете достъп до вашите файлове.</string>
-    <string name="autobackup_files_missing">За да използвате автоматично архивиране, изберете валиден архивн файл.</string>
     <string name="no_file_selected">Няма избран файл</string>
     <string name="action_select_file">Избор на файл</string>
-    <string name="backup_use_default_files">Използвайте файловете подразбиране за архивиране</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Автоматично създаване на резервно копие</string>
+    <string name="pref_autobackupsummary">Седмичен архив на вашите предавания, списъци и филми</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Последно автоматично архивиране: %s</string>
+    <string name="restore_auto_backup">Възстанови автоматично архивиране</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">За да използвате автоматично архивиране, изберете валиден архивн файл.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Начало</string>
     <string name="dismiss">Отхвърли</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Altres</string>
     <string name="pref_autoupdatesummary">Sincronitzar i actualitzar les dades de SeriesGuide automàticament</string>
-    <string name="pref_autobackup">Còpies de seguretat automàtiques</string>
-    <string name="pref_autobackupsummary">Còpia de seguretat setmanal de les teves sèries, llistes i pel·lícules</string>
     <string name="backup">Còpies de seguretat</string>
     <string name="backup_summary">Creeu una còpia de seguretat de les vostres sèries o restaureu-ne alguna d\'existent</string>
     <string name="pref_number">Format de número</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Crea còpia de seg.</string>
     <string name="import_button">Restaura</string>
     <string name="import_warning">Entenc que les meves sèries, llistes i pel·lícules actuals seran reemplaçades</string>
-    <string name="last_auto_backup">Darrera còpia de seguretat automàtica: %s</string>
-    <string name="restore_auto_backup">Restaura la còpia de seguretat automàtica</string>
-    <string name="dataliberation_permission_missing">Per fer còpies de seguretat o restaurar, permet l\'accés als teus arxius.</string>
-    <string name="autobackup_permission_missing">Per utilitzar la còpia de seguretat automàtica, permet l\'accés als teus arxius.</string>
-    <string name="autobackup_files_missing">Per utilitzar la còpia de seguretat automàtica, selecciona arxius de còpia de seguretat vàlids.</string>
     <string name="no_file_selected">Cap arxiu seleccionat</string>
     <string name="action_select_file">Seleccionar arxiu</string>
-    <string name="backup_use_default_files">Utilitzar arxius de còpia de seguretat per defecte</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Còpies de seguretat automàtiques</string>
+    <string name="pref_autobackupsummary">Còpia de seguretat setmanal de les teves sèries, llistes i pel·lícules</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Darrera còpia de seguretat automàtica: %s</string>
+    <string name="restore_auto_backup">Restaura la còpia de seguretat automàtica</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Per utilitzar la còpia de seguretat automàtica, selecciona arxius de còpia de seguretat vàlids.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Inici</string>
     <string name="dismiss">Omet</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Ostatní</string>
     <string name="pref_autoupdatesummary">Automaticky synchronizuj a aktualizuj SeriesGuide data</string>
-    <string name="pref_autobackup">Automatická záloha</string>
-    <string name="pref_autobackupsummary">Týdenní záloha vašich seriálů, seznamů a filmů</string>
     <string name="backup">Zálohování/obnovení</string>
     <string name="backup_summary">Zálohování a obnovení Vašich pořadů</string>
     <string name="pref_number">Formát číslování</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Zálohovat</string>
     <string name="import_button">Obnovit</string>
     <string name="import_warning">Beru na vědomí, že mé aktuální seriály, seznamy a filmy budou přemazány!</string>
-    <string name="last_auto_backup">Poslední automatická záloha: %s</string>
-    <string name="restore_auto_backup">Obnovení automatické zálohy</string>
-    <string name="dataliberation_permission_missing">Pro zálohu nebo obnovení povolte přístup ke svým souborům.</string>
-    <string name="autobackup_permission_missing">Pro použití automatického zálohování povolte přístup ke svým souborům.</string>
-    <string name="autobackup_files_missing">Pro použití automatického zálohování vyberte platné záložní soubory.</string>
     <string name="no_file_selected">Nebyl vybrán žádný soubor</string>
     <string name="action_select_file">Vybrat soubor</string>
-    <string name="backup_use_default_files">Použít výchozí záložní soubory</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatická záloha</string>
+    <string name="pref_autobackupsummary">Týdenní záloha vašich seriálů, seznamů a filmů</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Poslední automatická záloha: %s</string>
+    <string name="restore_auto_backup">Obnovení automatické zálohy</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Pro použití automatického zálohování vyberte platné záložní soubory.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Začněte</string>
     <string name="dismiss">Storno</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Øvrige</string>
     <string name="pref_autoupdatesummary">Synkronisér og opdatér SeriesGuide-data automatisk</string>
-    <string name="pref_autobackup">Automatisk sikkerhedskopiering</string>
-    <string name="pref_autobackupsummary">Ugentlig sikkerhedskopiering af dine serier, lister og film</string>
     <string name="backup">Sikkerhedskopier/Gendan</string>
     <string name="backup_summary">Sikkerhedskopier eller gendan dine serier</string>
     <string name="pref_number">Talformat</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Opret sikkerhedskopi</string>
     <string name="import_button">Gendan sikkerhedskopi</string>
     <string name="import_warning">Jeg forstår, at mine nuværende serier, lister og film vil blive erstattet!</string>
-    <string name="last_auto_backup">Seneste auto-sikkerhedskopiering: %s</string>
-    <string name="restore_auto_backup">Gendan auto-sikkerhedskopi</string>
-    <string name="dataliberation_permission_missing">Tillad filadgang for at sikkerhedskopiere eller gendanne.</string>
-    <string name="autobackup_permission_missing">Tillad filadgang for at benytte auto-sikkerhedskopiering.</string>
-    <string name="autobackup_files_missing">Vælg gyldige sikkerhedskopifiler for at benytte auto-sikkerhedskopiering.</string>
     <string name="no_file_selected">Ingen fil valgt</string>
     <string name="action_select_file">Vælg fil</string>
-    <string name="backup_use_default_files">Benyt standardsikkerhedskopifiler</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatisk sikkerhedskopiering</string>
+    <string name="pref_autobackupsummary">Ugentlig sikkerhedskopiering af dine serier, lister og film</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Seneste auto-sikkerhedskopiering: %s</string>
+    <string name="restore_auto_backup">Gendan auto-sikkerhedskopi</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Vælg gyldige sikkerhedskopifiler for at benytte auto-sikkerhedskopiering.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Kom i gang</string>
     <string name="dismiss">Ignorér</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Anderes</string>
     <string name="pref_autoupdatesummary">Automatisch synchronisieren und Inhalte aktualisieren</string>
-    <string name="pref_autobackup">Automatische Sicherung</string>
-    <string name="pref_autobackupsummary">Wöchentliche Sicherung Ihrer Serien, Listen und Filme</string>
     <string name="backup">Sichern/Wiederherstellen</string>
     <string name="backup_summary">Sicherung aller Serien erstellen oder Sicherung wiederherstellen</string>
     <string name="pref_number">Zahlenformat</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Sicherung erstellen</string>
     <string name="import_button">Sicherung wiederherstellen</string>
     <string name="import_warning">Ihre aktuellen Serien, Listen oder Filme werden durch die Sicherung ersetzt</string>
-    <string name="last_auto_backup">Letzte Auto-Sicherung: %s</string>
-    <string name="restore_auto_backup">Auto-Sicherung wiederherstellen</string>
-    <string name="dataliberation_permission_missing">Um zu Sichern oder Wiederherzustellen, erlauben Sie Zugriff auf Ihre Dateien</string>
-    <string name="autobackup_permission_missing">Um die automatische Sicherung zu verwenden, erlauben Sie Zugriff auf Ihre Dateien</string>
-    <string name="autobackup_files_missing">Um die automatische Sicherung zu verwenden, wählen Sie gültige Sicherungsdateien</string>
     <string name="no_file_selected">Keine Datei ausgewählt</string>
     <string name="action_select_file">Datei auswählen</string>
-    <string name="backup_use_default_files">Standard-Sicherungsdateien verwenden</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatische Sicherung</string>
+    <string name="pref_autobackupsummary">Wöchentliche Sicherung Ihrer Serien, Listen und Filme im Gerätespeicher.</string>
+    <string name="autobackup_details">Diese Sicherungen sind nicht verfügbar, wenn die App neu installiert wird, es sei denn, die App-Daten-Sicherung ist für dieses Gerät aktiviert (Android 6+). Erstellen Sie ansonsten Kopien, um sie aufzubewahren.</string>
+    <string name="last_auto_backup">Letzte Auto-Sicherung: %s</string>
+    <string name="restore_auto_backup">Auto-Sicherung wiederherstellen</string>
+    <string name="autobackup_failed">Die letzte automatische Sicherung ist fehlgeschlagen</string>
+    <string name="autobackup_files_missing">Um die automatische Sicherung zu verwenden, wählen Sie gültige Sicherungsdateien</string>
+    <string name="autobackup_create_user_copy">Eine Kopie nach jeder Sicherung erstellen</string>
+    <string name="autobackup_restore_available">Eine automatische Sicherung könnte zum Wiederherstellen verfügbar sein.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Erste Schritte</string>
     <string name="dismiss">Schließen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Άλλα</string>
     <string name="pref_autoupdatesummary">Αυτόματος συγχρονισμός και ενημέρωση περιεχομένου</string>
-    <string name="pref_autobackup">Αυτόματο αντίγραφο ασφαλείας</string>
-    <string name="pref_autobackupsummary">Εβδομαδιαίο αντίγραφο ασφαλείας των σειρών, λιστών και ταινιών σας</string>
     <string name="backup">Δημιουργία αντιγράφου ασφαλείας/Επαναφορά</string>
     <string name="backup_summary">Δημιουργία αντιγράφου ασφαλείας ή επαναφορά των σειρών</string>
     <string name="pref_number">Μορφή των αριθμών</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Δημιουργία αντιγράφων ασφαλείας</string>
     <string name="import_button">Επαναφορά</string>
     <string name="import_warning">Οι τρέχουσες σειρές, λίστες και ταινίες θα αντικατασταθούν από το αντίγραφο ασφαλείας</string>
-    <string name="last_auto_backup">Τελευταίο αυτόματο αντίγραφο ασφαλείας: %s</string>
-    <string name="restore_auto_backup">Επαναφορά αντιγράφου ασφαλείας στο αυτόματο</string>
-    <string name="dataliberation_permission_missing">Για λήψη ή επαναφορά αντιγράφων ασφαλείας, επιτρέψτε πρόσβαση στα αρχεία σας</string>
-    <string name="autobackup_permission_missing">Για τη χρήση της αυτόματης λήψης αντιγράφων ασφαλείας, επιτρέψτε πρόσβαση στα αρχεία σας</string>
-    <string name="autobackup_files_missing">Για τη χρήση της αυτόματης λήψης αντιγράφων ασφαλείας, επιλέξτε έγκυρα αρχεία αντιγράφων ασφαλείας</string>
     <string name="no_file_selected">Δεν επιλέχθηκε αρχείο</string>
     <string name="action_select_file">Επιλογή αρχείου</string>
-    <string name="backup_use_default_files">Χρησιμοποιήστε τα προεπιλεγμένα αρχεία αντιγράφων ασφαλείας</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Αυτόματο αντίγραφο ασφαλείας</string>
+    <string name="pref_autobackupsummary">Εβδομαδιαίο αντίγραφο ασφαλείας των σειρών, λιστών και ταινιών σας</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Τελευταίο αυτόματο αντίγραφο ασφαλείας: %s</string>
+    <string name="restore_auto_backup">Επαναφορά αντιγράφου ασφαλείας στο αυτόματο</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Για τη χρήση της αυτόματης λήψης αντιγράφων ασφαλείας, επιλέξτε έγκυρα αρχεία αντιγράφων ασφαλείας</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Ξεκινήστε</string>
     <string name="dismiss">Απόρριψη</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -402,8 +402,6 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <!-- Other advanced settings -->
     <string name="pref_other">Otros</string>
     <string name="pref_autoupdatesummary">Sincronizar y actualizar automáticamente datos de SeriesGuide</string>
-    <string name="pref_autobackup">Copia de seguridad automática</string>
-    <string name="pref_autobackupsummary">Copia de seguridad semanal de tus series, listas y películas</string>
     <string name="backup">Respaldo/Restauración</string>
     <string name="backup_summary">Respaldar o restaurar sus programas</string>
     <string name="pref_number">Formato numérico</string>
@@ -423,14 +421,18 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="backup_button">Respaldo</string>
     <string name="import_button">Restaurar</string>
     <string name="import_warning">Entiendo que mis series, listas y películas actuales serán reemplazadas!</string>
-    <string name="last_auto_backup">Última copia de seguridad automática: %s</string>
-    <string name="restore_auto_backup">Restaurar la copia de seguridad automática</string>
-    <string name="dataliberation_permission_missing">Para crear o restaurar una copia de seguridad, permite el acceso a tus archivos.</string>
-    <string name="autobackup_permission_missing">Para utilizar la copia de seguridad automática, permite el acceso a tus archivos.</string>
-    <string name="autobackup_files_missing">Para utilizar la copia de seguridad automática, seleccione archivos de copia de seguridad válidos.</string>
     <string name="no_file_selected">No hay ningún archivo seleccionado</string>
     <string name="action_select_file">Seleccione un archivo</string>
-    <string name="backup_use_default_files">Utilizar archivos de copia de seguridad por defecto</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Copia de seguridad automática</string>
+    <string name="pref_autobackupsummary">Copia de seguridad semanal de tus series, listas y películas</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Última copia de seguridad automática: %s</string>
+    <string name="restore_auto_backup">Restaurar la copia de seguridad automática</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Para utilizar la copia de seguridad automática, seleccione archivos de copia de seguridad válidos.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Empezar</string>
     <string name="dismiss">Descartar</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">سایر موارد</string>
     <string name="pref_autoupdatesummary">به صورت خودکار داده های SeriesGuide را همگام سازی و بروزرسانی کن</string>
-    <string name="pref_autobackup">پشتیبان‌گیری خودکار</string>
-    <string name="pref_autobackupsummary">پشتیبان گرفتن هفتگی از نمایش‌ها، فهرست‌ها و فیلم‌هایتان</string>
     <string name="backup">پشتیبان گیری / بازیابی</string>
     <string name="backup_summary">پشتیبان گیری یا بازگردانی نمایش‌هایتان</string>
     <string name="pref_number">قالب شماره</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">ایجاد پشتیبان</string>
     <string name="import_button">بازگردانی پشتیبان</string>
     <string name="import_warning">فهمیدم که نمایش‌ها، فهرست‌ها و فیلم‌های جاریم تعویض خواهند شد!</string>
-    <string name="last_auto_backup">آخرین پشتیبان خودکار: %s</string>
-    <string name="restore_auto_backup">بازگردانی پشتیبان خودکار</string>
-    <string name="dataliberation_permission_missing">برای پشتیبان گیری یا بازگردانی، به پرونده‌هایتان اجازهٔ دسترسی بدهید.</string>
-    <string name="autobackup_permission_missing">برای استفاده از پشتیبان گیری خودکار، به پرونده‌هایتان اجازهٔ دسترسی بدهید.</string>
-    <string name="autobackup_files_missing">برای استفاده از پشتیبان گیری خودکار، پرونده‌های پشتیبان معتبر را برگزینید.</string>
     <string name="no_file_selected">هیچ پرونده‌ای گزیده نشده</string>
     <string name="action_select_file">گزینش پرونده</string>
-    <string name="backup_use_default_files">استفاده از پرونده‌های پشتیبان پیش‌گزیده</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">پشتیبان‌گیری خودکار</string>
+    <string name="pref_autobackupsummary">پشتیبان گرفتن هفتگی از نمایش‌ها، فهرست‌ها و فیلم‌هایتان</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">آخرین پشتیبان خودکار: %s</string>
+    <string name="restore_auto_backup">بازگردانی پشتیبان خودکار</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">برای استفاده از پشتیبان گیری خودکار، پرونده‌های پشتیبان معتبر را برگزینید.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">شروع به کار</string>
     <string name="dismiss">رد کردن</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Muu</string>
     <string name="pref_autoupdatesummary">Synkronoi ja päivitä sisältö automaattisesti</string>
-    <string name="pref_autobackup">Automaattinen varmuuskopiointi</string>
-    <string name="pref_autobackupsummary">Viikoittainen varmuuskopio ohjelmistasi, listoistasi ja elokuvistasi</string>
     <string name="backup">Varmuuskopioi/Palauta</string>
     <string name="backup_summary">Varmuuskopioi tai palauta ohjelmasi</string>
     <string name="pref_number">Lukumuoto</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Varmuuskopioi</string>
     <string name="import_button">Palauta</string>
     <string name="import_warning">Ymmärrän, että nykyiset ohjelmani, listani ja elokuvani korvataan!</string>
-    <string name="last_auto_backup">Viimeisin automaattinen varmuuskopiointi: %s</string>
-    <string name="restore_auto_backup">Palauta automaattinen varmuuskopio</string>
-    <string name="dataliberation_permission_missing">Varmuuskopiointi ja palautus edellyttää pääsyä tiedostoihin.</string>
-    <string name="autobackup_permission_missing">Automaattinen varmuuskopiointi edellyttää pääsyä tiedostoihin.</string>
-    <string name="autobackup_files_missing">Käyttääksesi automaattista varmuuskopiota, valitse kelvolliset varmuuskopiotiedostot.</string>
     <string name="no_file_selected">Tiedostoa ei ole valittu</string>
     <string name="action_select_file">Valitse tiedosto</string>
-    <string name="backup_use_default_files">Käytä oletusvarmuuskopiotiedostoja</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automaattinen varmuuskopiointi</string>
+    <string name="pref_autobackupsummary">Viikoittainen varmuuskopio ohjelmistasi, listoistasi ja elokuvistasi</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Viimeisin automaattinen varmuuskopiointi: %s</string>
+    <string name="restore_auto_backup">Palauta automaattinen varmuuskopio</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Käyttääksesi automaattista varmuuskopiota, valitse kelvolliset varmuuskopiotiedostot.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Aloita</string>
     <string name="dismiss">Hylkää</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Autres</string>
     <string name="pref_autoupdatesummary">Synchroniser automatiquement et mettre à jour les données de SeriesGuide</string>
-    <string name="pref_autobackup">Sauvegarde automatique</string>
-    <string name="pref_autobackupsummary">Sauvegarde hebdomadaire de vos émissions, vos listes et vos films</string>
     <string name="backup">Sauvegarde/Restauration</string>
     <string name="backup_summary">Sauvegarder ou restaurer vos séries</string>
     <string name="pref_number">Format de nombre</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Sauvegarder</string>
     <string name="import_button">Restaurer</string>
     <string name="import_warning">Je comprends que mes séries, listes et films actuels seront remplacés !</string>
-    <string name="last_auto_backup">Dernière sauvegarde auto : %s</string>
-    <string name="restore_auto_backup">Restaurer la sauvegarde automatique</string>
-    <string name="dataliberation_permission_missing">Pour sauvegarder ou restaurer, permettez l’accès à vos fichiers.</string>
-    <string name="autobackup_permission_missing">Pour utiliser la sauvegarde automatique, permettez l’accès à vos fichiers.</string>
-    <string name="autobackup_files_missing">Pour utiliser la sauvegarde automatique, sélectionnez un fichier de sauvegarde valides.</string>
     <string name="no_file_selected">Aucun fichier sélectionné</string>
     <string name="action_select_file">Choisir un fichier</string>
-    <string name="backup_use_default_files">Utiliser le fichier de sauvegarde par défaut</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Sauvegarde automatique</string>
+    <string name="pref_autobackupsummary">Sauvegarde hebdomadaire de vos émissions, vos listes et vos films</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Dernière sauvegarde auto : %s</string>
+    <string name="restore_auto_backup">Restaurer la sauvegarde automatique</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Pour utiliser la sauvegarde automatique, sélectionnez un fichier de sauvegarde valides.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Commencer</string>
     <string name="dismiss">Passer</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Outros</string>
     <string name="pref_autoupdatesummary">Sincronizar e actualizar os datos automaticamente</string>
-    <string name="pref_autobackup">Copias de seguridade automáticas</string>
-    <string name="pref_autobackupsummary">Copia de seguridade semanal das túas series, listas e películas</string>
     <string name="backup">Copa de seguridade / Recuperar</string>
     <string name="backup_summary">Facer unha copia de seguridade ou restaurar as túas series</string>
     <string name="pref_number">Formato numérico</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Crear unha copia de seguranza</string>
     <string name="import_button">Restaurar copia de seguranza</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Última copia de seguridade automática: %s</string>
-    <string name="restore_auto_backup">Restaurar copia de seguridade automática</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">Ningún ficheiro seleccionado</string>
     <string name="action_select_file">Seleccionar ficheiro</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Copias de seguridade automáticas</string>
+    <string name="pref_autobackupsummary">Copia de seguridade semanal das túas series, listas e películas</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Última copia de seguridade automática: %s</string>
+    <string name="restore_auto_backup">Restaurar copia de seguridade automática</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Comezar</string>
     <string name="dismiss">Rexeitar</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Other</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Backup/Restore</string>
     <string name="backup_summary">Backup or restore your shows</string>
     <string name="pref_number">Number format</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Create backup</string>
     <string name="import_button">Restore backup</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Last Auto Backup: %s</string>
-    <string name="restore_auto_backup">Restore Auto Backup</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Last Auto Backup: %s</string>
+    <string name="restore_auto_backup">Restore Auto Backup</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Get started</string>
     <string name="dismiss">Dismiss</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -412,8 +412,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Ostalo</string>
     <string name="pref_autoupdatesummary">Automatski sinkronizirajte i ažurirajte SeriesGuide podatke</string>
-    <string name="pref_autobackup">Automatska sigurnosna kopija</string>
-    <string name="pref_autobackupsummary">Tjedno sigurnosno kopiranje vaših serija, popisa i filmova</string>
     <string name="backup">Sigurnosno kopiranje/vraćanje</string>
     <string name="backup_summary">Napravi sigurnosnu kopiju ili obnovi svoje serije</string>
     <string name="pref_number">Format broja</string>
@@ -433,14 +431,18 @@
     <string name="backup_button">Stvori sigurnosnu kopiju</string>
     <string name="import_button">Obnovi</string>
     <string name="import_warning">Razumijem da će moje trenutačne serije i popisi biti zamijenjeni!</string>
-    <string name="last_auto_backup">Posljednja automatska Sigurnosna kopija: %s</string>
-    <string name="restore_auto_backup">Vrati automatsku sigurnosnu kopiju</string>
-    <string name="dataliberation_permission_missing">Kako bi stvarali sigur. kopije i vraćali ih, dopustite pristup vašim datotekama.</string>
-    <string name="autobackup_permission_missing">Kako bi koristili automatsko sigur. kopiranje, dopustite pristup vašim datotekama.</string>
-    <string name="autobackup_files_missing">Kako bi koristili automatsko sigur. kopiranje, odaberite valjane datoteke sigur. kopije.</string>
     <string name="no_file_selected">Nije odabrana niti jedna datoteka</string>
     <string name="action_select_file">Odaberi datoteku</string>
-    <string name="backup_use_default_files">Koristi zadane sigurnosne kopije</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatska sigurnosna kopija</string>
+    <string name="pref_autobackupsummary">Tjedno sigurnosno kopiranje vaših serija, popisa i filmova</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Posljednja automatska Sigurnosna kopija: %s</string>
+    <string name="restore_auto_backup">Vrati automatsku sigurnosnu kopiju</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Kako bi koristili automatsko sigur. kopiranje, odaberite valjane datoteke sigur. kopije.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Prvi koraci</string>
     <string name="dismiss">Odbaci</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Egyéb</string>
     <string name="pref_autoupdatesummary">SeriesGuide adatok automatikus szinkronizálása és frissítése</string>
-    <string name="pref_autobackup">Automatikus biztonsági másolat</string>
-    <string name="pref_autobackupsummary">Heti biztonsági másolat készítése a sorozatokról, listákról és filmekről</string>
     <string name="backup">Biztonsági Mentés/Visszaállítás</string>
     <string name="backup_summary">A sorozatokról biztonsági mentés készítése vagy annak visszaállítása</string>
     <string name="pref_number">Számozás formátuma</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Biztonsági Mentés</string>
     <string name="import_button">Visszaállítás</string>
     <string name="import_warning">Megértettem, hogy az aktuális sorozataim, listáim és filmjeim lecserélésre kerülnek!</string>
-    <string name="last_auto_backup">Utolsó automata mentés: %s</string>
-    <string name="restore_auto_backup">Automatikus mentés visszaállítása</string>
-    <string name="dataliberation_permission_missing">Biztonsági mentéshez vagy visszaállításhoz engedélyezd a fájljaidhoz való hozzáférést.</string>
-    <string name="autobackup_permission_missing">Az automatikus mentéshez engedélyezd a fájljaidhoz való hozzáférést.</string>
-    <string name="autobackup_files_missing">Az automatikus biztonsági másolat használatához válassz érvényes biztonsági másolat fájlokat.</string>
     <string name="no_file_selected">Nincs fájl  kijelölve</string>
     <string name="action_select_file">Fájl kiválasztása</string>
-    <string name="backup_use_default_files">Használja az alapértelmezett biztonsági mentés fájlokat</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatikus biztonsági másolat</string>
+    <string name="pref_autobackupsummary">Heti biztonsági másolat készítése a sorozatokról, listákról és filmekről</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Utolsó automata mentés: %s</string>
+    <string name="restore_auto_backup">Automatikus mentés visszaállítása</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Az automatikus biztonsági másolat használatához válassz érvényes biztonsági másolat fájlokat.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Vágjunk bele!</string>
     <string name="dismiss">Mégsem</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Lainnya</string>
     <string name="pref_autoupdatesummary">Secara otomatis melakukan sinkronisasi dan memperbarui data SeriesGuide</string>
-    <string name="pref_autobackup">Cadangkan otomatis</string>
-    <string name="pref_autobackupsummary">Cadangkan mingguan acara, daftar dan film anda</string>
     <string name="backup">Cadangkan/Pulihkan</string>
     <string name="backup_summary">Cadangkan atau pulihkan acara anda</string>
     <string name="pref_number">Format nomor</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">Buat cadangan</string>
     <string name="import_button">Pulihkan cadangan</string>
     <string name="import_warning">Saya mengerti acara, daftar dan film saya saat ini akan diganti!</string>
-    <string name="last_auto_backup">Pencadangan Otomatis Terakhir: %s</string>
-    <string name="restore_auto_backup">Pulihkan Cadangan Otomatis</string>
-    <string name="dataliberation_permission_missing">Untuk mencadangkan atau memulihkan, izinkan akses ke berkas Anda.</string>
-    <string name="autobackup_permission_missing">Untuk menggunakan cadangan otomatis, izinkan akses ke berkas Anda.</string>
-    <string name="autobackup_files_missing">Untuk menggunakan cadangan otomatis, pilih file cadangan yang benar.</string>
     <string name="no_file_selected">Tidak ada file terpilih</string>
     <string name="action_select_file">Pilih file</string>
-    <string name="backup_use_default_files">Gunakan cadangan file default</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Cadangkan otomatis</string>
+    <string name="pref_autobackupsummary">Cadangkan mingguan acara, daftar dan film anda</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Pencadangan Otomatis Terakhir: %s</string>
+    <string name="restore_auto_backup">Pulihkan Cadangan Otomatis</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Untuk menggunakan cadangan otomatis, pilih file cadangan yang benar.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Mulai</string>
     <string name="dismiss">Bubar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Altro</string>
     <string name="pref_autoupdatesummary">Sincronizza e aggiorna automaticamente i dati di SeriesGuide</string>
-    <string name="pref_autobackup">Backup automatico</string>
-    <string name="pref_autobackupsummary">Backup settimanali delle tue serie, liste e film</string>
     <string name="backup">Backup/Ripristino</string>
     <string name="backup_summary">Esegui il backup o ripristina le tue serie</string>
     <string name="pref_number">Formato numerico</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Backup</string>
     <string name="import_button">Ripristina</string>
     <string name="import_warning">Le mie serie attuali, liste e film verranno sostituiti!</string>
-    <string name="last_auto_backup">Ultimo backup automatico: %s</string>
-    <string name="restore_auto_backup">Ripristina il Backup automatico</string>
-    <string name="dataliberation_permission_missing">Per eseguire il backup o il ripristino, consenti l\'accesso ai file.</string>
-    <string name="autobackup_permission_missing">Per utilizzare il backup automatico, consenti l\'accesso ai file.</string>
-    <string name="autobackup_files_missing">Per utilizzare il backup automatico, seleziona file di backup validi.</string>
     <string name="no_file_selected">Nessun file selezionato</string>
     <string name="action_select_file">Seleziona file</string>
-    <string name="backup_use_default_files">Utilizza i file di backup predefiniti</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Backup automatico</string>
+    <string name="pref_autobackupsummary">Backup settimanali delle tue serie, liste e film</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Ultimo backup automatico: %s</string>
+    <string name="restore_auto_backup">Ripristina il Backup automatico</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Per utilizzare il backup automatico, seleziona file di backup validi.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Inizia qui</string>
     <string name="dismiss">Cancella</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">אחר</string>
     <string name="pref_autoupdatesummary">בצע סנכרון אוטומטי ועדכן נתונים של SeriesGuide</string>
-    <string name="pref_autobackup">גיבוי אוטומטי</string>
-    <string name="pref_autobackupsummary">גיבוי שבועי של הסדרות, רשימות והסרטים שלך</string>
     <string name="backup">גיבוי/שחזור</string>
     <string name="backup_summary">גבה או שחזר את סדרותיך</string>
     <string name="pref_number">תבנית מספרים</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">גיבוי</string>
     <string name="import_button">שחזר</string>
     <string name="import_warning">אני מבין שהסדרות, רשימות והסרטים הנוכחיים שלי יוחלפו!</string>
-    <string name="last_auto_backup">גיבוי אוטומטי אחרון: %s</string>
-    <string name="restore_auto_backup">שחזור גיבוי אוטומטי</string>
-    <string name="dataliberation_permission_missing">כדי לגבות או לשחזר, אפשר גישה לקבצים שלך.</string>
-    <string name="autobackup_permission_missing">כדי להשתמש בגיבוי אוטומטי, אפשר גישה לקבצים שלך.</string>
-    <string name="autobackup_files_missing">כדי להשתמש בגיבוי אוטומטי, בחר קבצי גיבוי חוקיים.</string>
     <string name="no_file_selected">לא נבחר קובץ</string>
     <string name="action_select_file">בחר קובץ</string>
-    <string name="backup_use_default_files">השתמש בברירת מחדל של קבצי גיבוי</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">גיבוי אוטומטי</string>
+    <string name="pref_autobackupsummary">גיבוי שבועי של הסדרות, רשימות והסרטים שלך</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">גיבוי אוטומטי אחרון: %s</string>
+    <string name="restore_auto_backup">שחזור גיבוי אוטומטי</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">כדי להשתמש בגיבוי אוטומטי, בחר קבצי גיבוי חוקיים.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">התחל</string>
     <string name="dismiss">סגור</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">その他</string>
     <string name="pref_autoupdatesummary">SeriesGuide データを自動的に同期および更新します</string>
-    <string name="pref_autobackup">自動バックアップ</string>
-    <string name="pref_autobackupsummary">番組、リスト、映画を毎週バックアップ</string>
     <string name="backup">バックアップ/復元</string>
     <string name="backup_summary">番組をバックアップまたは復元します</string>
     <string name="pref_number">表示形式</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">バックアップを作成</string>
     <string name="import_button">バックアップを復元</string>
     <string name="import_warning">あなたの現在の番組、リスト、映画がバックアップで置き換えられます</string>
-    <string name="last_auto_backup">最終の自動バックアップ: %s</string>
-    <string name="restore_auto_backup">自動バックアップを復元</string>
-    <string name="dataliberation_permission_missing">バックアップまたは復元するため、ファイルへのアクセスを許可してください。</string>
-    <string name="autobackup_permission_missing">自動バックアップを使用するため、ファイルへのアクセスを許可してください。</string>
-    <string name="autobackup_files_missing">自動バックアップを使用するため、有効なバックアップ ファイルを選択してください。</string>
     <string name="no_file_selected">ファイルが選択されていません</string>
     <string name="action_select_file">ファイルを選択</string>
-    <string name="backup_use_default_files">デフォルトのバックアップ ファイルを使用する</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">自動バックアップ</string>
+    <string name="pref_autobackupsummary">番組、リスト、映画を毎週バックアップ</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">最終の自動バックアップ: %s</string>
+    <string name="restore_auto_backup">自動バックアップを復元</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">自動バックアップを使用するため、有効なバックアップ ファイルを選択してください。</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">始めましょう</string>
     <string name="dismiss">中止</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">기타</string>
     <string name="pref_autoupdatesummary">자동으로 콘텐츠 동기화 및 업데이트</string>
-    <string name="pref_autobackup">자동 백업</string>
-    <string name="pref_autobackupsummary">매주 프로그램, 목록, 영화를 백업합니다.</string>
     <string name="backup">백업/복원</string>
     <string name="backup_summary">프로그램 목록을 백업학거나 복원합니다</string>
     <string name="pref_number">에피소드 표시 형식</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">백업</string>
     <string name="import_button">복원</string>
     <string name="import_warning">현재 앱에 저장한 프로그램 목록이 교체됩니다</string>
-    <string name="last_auto_backup">최근 자동 백업: %s</string>
-    <string name="restore_auto_backup">자동 백업 복원</string>
-    <string name="dataliberation_permission_missing">백업 및 복원하기 위해서는 파일 액세스를 허용해야 합니다.</string>
-    <string name="autobackup_permission_missing">자동 백업을 하기위해서는 파일 액세스를 허용해야 합니다.</string>
-    <string name="autobackup_files_missing">자동백업을 하기 위해서 유효한 백업파일을 선택하세요.</string>
     <string name="no_file_selected">선택된 파일을 찾을 수 없습니다.</string>
     <string name="action_select_file">파일 선택</string>
-    <string name="backup_use_default_files">기본 백업 파일 사용</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">자동 백업</string>
+    <string name="pref_autobackupsummary">매주 프로그램, 목록, 영화를 백업합니다.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">최근 자동 백업: %s</string>
+    <string name="restore_auto_backup">자동 백업 복원</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">자동백업을 하기 위해서 유효한 백업파일을 선택하세요.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">시작하기</string>
     <string name="dismiss">취소</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Kita</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Atsarginė kopija/atstatymas</string>
     <string name="backup_summary">Padaryti atsarginę kopiją arba atkurti serialus</string>
     <string name="pref_number">Skaičių formatas</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Create backup</string>
     <string name="import_button">Restore backup</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Last Auto Backup: %s</string>
-    <string name="restore_auto_backup">Restore Auto Backup</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Pasirinkite failą</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Last Auto Backup: %s</string>
+    <string name="restore_auto_backup">Restore Auto Backup</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Get started</string>
     <string name="dismiss">Dismiss</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -412,8 +412,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Citi</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Dublēt/Atjaunot</string>
     <string name="backup_summary">Dublēt vai atjaunot jūsu seriālus</string>
     <string name="pref_number">Epizožu formāts</string>
@@ -433,14 +431,18 @@
     <string name="backup_button">Dublēt</string>
     <string name="import_button">Atjaunot</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Pēdējais automātiskais dublējums: %s</string>
-    <string name="restore_auto_backup">Atjaunot no automātiskā dublējuma</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Pēdējais automātiskais dublējums: %s</string>
+    <string name="restore_auto_backup">Atjaunot no automātiskā dublējuma</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Gūsti startu</string>
     <string name="dismiss">Atcelt</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Друго</string>
     <string name="pref_autoupdatesummary">Автоматиско синхронизирање и абдејтирање опции</string>
-    <string name="pref_autobackup">Автoмaтски бекaп</string>
-    <string name="pref_autobackupsummary">Неделни бекупи од вашите серии, листи и филмови</string>
     <string name="backup">Backup/Restore</string>
     <string name="backup_summary">Backup или обновување на вашиите серии</string>
     <string name="pref_number">Формат бројки</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Архивирај</string>
     <string name="import_button">Restore backup</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Последен автоматски Backup: %s</string>
-    <string name="restore_auto_backup">Обнови автоматски Backup</string>
-    <string name="dataliberation_permission_missing">За да направите backup или restore, дозволете пристап до вашите фајлови.</string>
-    <string name="autobackup_permission_missing">За да можете да користите автоматски backup, овозможете пристап до вашите фајлови.</string>
-    <string name="autobackup_files_missing">За да користите автоматски бекап, селектирајте валиден бекап фајл.</string>
     <string name="no_file_selected">нема одбрано датотека</string>
     <string name="action_select_file">Изберете дадотека</string>
-    <string name="backup_use_default_files">Кoристи предефинирaни бекaп фaјлoви</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Автoмaтски бекaп</string>
+    <string name="pref_autobackupsummary">Неделни бекупи од вашите серии, листи и филмови</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Последен автоматски Backup: %s</string>
+    <string name="restore_auto_backup">Обнови автоматски Backup</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">За да користите автоматски бекап, селектирајте валиден бекап фајл.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Почни</string>
     <string name="dismiss">Откажи</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Annet</string>
     <string name="pref_autoupdatesummary">Synkroniser automatisk og oppdater SeriesGuide data</string>
-    <string name="pref_autobackup">Automatisk sikkerhetskopiering</string>
-    <string name="pref_autobackupsummary">Ukentlig sikkerhetskopiering av dine serier, lister og filmer</string>
     <string name="backup">Sikkerhetskopiering/gjenoppretting</string>
     <string name="backup_summary">Sikkerhetskopier eller gjenopprett dine serier</string>
     <string name="pref_number">Nummerering</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Opprett sikkerhetskopi</string>
     <string name="import_button">Gjenopprett</string>
     <string name="import_warning">Jeg forstår at mine valgte serier, lister og filmer vil bli erstattet.</string>
-    <string name="last_auto_backup">Siste automatiske sikkerhetskopiering: %s</string>
-    <string name="restore_auto_backup">Gjenopprett fra automatisk sikkerhetskopiering</string>
-    <string name="dataliberation_permission_missing">For å sikkerhetskopiere eller gjenopprette, gi tilgang til filene.</string>
-    <string name="autobackup_permission_missing">For å bruke automatisk sikkerhetskopiering, må du gi tilgang til filene dine.</string>
-    <string name="autobackup_files_missing">Bruke automatisk sikkerhetskopiering, må du velge gyldige sikkerhetskopifiler.</string>
     <string name="no_file_selected">Ingen fil valgt</string>
     <string name="action_select_file">Velg fil</string>
-    <string name="backup_use_default_files">Bruk standard sikkerhetskopifiler</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatisk sikkerhetskopiering</string>
+    <string name="pref_autobackupsummary">Ukentlig sikkerhetskopiering av dine serier, lister og filmer</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Siste automatiske sikkerhetskopiering: %s</string>
+    <string name="restore_auto_backup">Gjenopprett fra automatisk sikkerhetskopiering</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Bruke automatisk sikkerhetskopiering, må du velge gyldige sikkerhetskopifiler.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Kom i gang</string>
     <string name="dismiss">Avvis</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Andere</string>
     <string name="pref_autoupdatesummary">Automatisch data synchroniseren en bijwerken</string>
-    <string name="pref_autobackup">Automatische back-up</string>
-    <string name="pref_autobackupsummary">Wekelijkse back-up van uw series, lijsten en films</string>
     <string name="backup">Back-up maken/herstellen</string>
     <string name="backup_summary">Back-up van series maken/herstellen</string>
     <string name="pref_number">Nummer opmaak</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Back-up maken</string>
     <string name="import_button">Herstellen</string>
     <string name="import_warning">Uw huidige series, lijsten en films worden vervangen door de back-up</string>
-    <string name="last_auto_backup">Laatste auto back-up: %s</string>
-    <string name="restore_auto_backup">Auto back-up terugzetten</string>
-    <string name="dataliberation_permission_missing">Geef toegang tot uw bestanden om back-ups te maken en te herstellen</string>
-    <string name="autobackup_permission_missing">Geef toegang tot uw bestanden om automatisch te back-uppen</string>
-    <string name="autobackup_files_missing">Selecteer geldige back-upbestanden om automatisch te back-uppen</string>
     <string name="no_file_selected">Geen bestand geselecteerd</string>
     <string name="action_select_file">Bestand selecteren</string>
-    <string name="backup_use_default_files">Standaardbestanden voor back-up gebruiken</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatische back-up</string>
+    <string name="pref_autobackupsummary">Wekelijkse back-up van uw series, lijsten en films</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Laatste auto back-up: %s</string>
+    <string name="restore_auto_backup">Auto back-up terugzetten</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Selecteer geldige back-upbestanden om automatisch te back-uppen</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Aan de slag</string>
     <string name="dismiss">Afwijzen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Inne</string>
     <string name="pref_autoupdatesummary">Automatycznie synchronizuje i aktualizuje dane SeriesGuide</string>
-    <string name="pref_autobackup">Automatyczna kopia zapasowa</string>
-    <string name="pref_autobackupsummary">Tworzy co tydzień kopię zapasową seriali, list i filmów</string>
     <string name="backup">Kopia zapasowa</string>
     <string name="backup_summary">Utwórz/Przywróć kopię bazy seriali</string>
     <string name="pref_number">Format numeracji</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Kontynuuj</string>
     <string name="import_button">Przywróć</string>
     <string name="import_warning">Rozumiem, że moje seriale, listy i filmy zostaną zastąpione!</string>
-    <string name="last_auto_backup">Ostatnia kopia zapasowa: %s</string>
-    <string name="restore_auto_backup">Przywróć kopię zapasową</string>
-    <string name="dataliberation_permission_missing">Umożliwia dostęp do plików, aby użyć tworzenia i przywracania kopii zapasowych.</string>
-    <string name="autobackup_permission_missing">Umożliwia dostęp do plików, aby użyć automatycznego tworzenia kopii zapasowych.</string>
-    <string name="autobackup_files_missing">Aby użyć automatycznego tworzenia kopii zapasowych, wybierz prawidłowe pliki kopii zapasowych.</string>
     <string name="no_file_selected">Nie wybrano pliku</string>
     <string name="action_select_file">Wybierz plik</string>
-    <string name="backup_use_default_files">Użyj domyślnych plików kopii zapasowej</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatyczna kopia zapasowa</string>
+    <string name="pref_autobackupsummary">Tworzy co tydzień kopię zapasową seriali, list i filmów</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Ostatnia kopia zapasowa: %s</string>
+    <string name="restore_auto_backup">Przywróć kopię zapasową</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Aby użyć automatycznego tworzenia kopii zapasowych, wybierz prawidłowe pliki kopii zapasowych.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Wprowadzenie</string>
     <string name="dismiss">Zamknij</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Outro</string>
     <string name="pref_autoupdatesummary">Sincronizar e atualizar os dados automaticamente</string>
-    <string name="pref_autobackup">Backup Automático</string>
-    <string name="pref_autobackupsummary">Backup semanal de suas séries, listas e filmes</string>
     <string name="backup">Backup/Restauração</string>
     <string name="backup_summary">Fazer backup ou restaurar as suas séries</string>
     <string name="pref_number">Formato de número</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Backup</string>
     <string name="import_button">Restaurar</string>
     <string name="import_warning">Suas séries, listas ou filmes atuais serão substituídos pelo backup</string>
-    <string name="last_auto_backup">Último backup automático: %s</string>
-    <string name="restore_auto_backup">Restaurar backup automático</string>
-    <string name="dataliberation_permission_missing">Para fazer backup ou restaurar, permita acesso a seus arquivos.</string>
-    <string name="autobackup_permission_missing">Para usar o backup automático, permita o acesso a seus arquivos.</string>
-    <string name="autobackup_files_missing">Para usar o backup automático, selecione os arquivos de backup válidos.</string>
     <string name="no_file_selected">Nenhum arquivo selecionado</string>
     <string name="action_select_file">Selecionar arquivo</string>
-    <string name="backup_use_default_files">Usar arquivos padrões para backup</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Backup Automático</string>
+    <string name="pref_autobackupsummary">Backup semanal de suas séries, listas e filmes</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Último backup automático: %s</string>
+    <string name="restore_auto_backup">Restaurar backup automático</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Para usar o backup automático, selecione os arquivos de backup válidos.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Começar</string>
     <string name="dismiss">Dispensar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Outro</string>
     <string name="pref_autoupdatesummary">Sincroniza e atualiza automaticamente os dados do SeriesGuide</string>
-    <string name="pref_autobackup">Cópia de Segurança Automática</string>
-    <string name="pref_autobackupsummary">Cópia de segurança semanal das tuas listas, séries e filmes</string>
     <string name="backup">Cópia de Segurança/Restaurar</string>
     <string name="backup_summary">Fazer uma cópia de segurança ou restaurar as tuas séries</string>
     <string name="pref_number">Formato numérico</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Criar cópia de segurança</string>
     <string name="import_button">Restaurar cópia de segurança</string>
     <string name="import_warning">Estou ciente que as minhas listas, séries e filmes serão substituídos!</string>
-    <string name="last_auto_backup">Última Cópia de Segurança Automática: %s</string>
-    <string name="restore_auto_backup">Restaurar Cópia de Segurança Automática</string>
-    <string name="dataliberation_permission_missing">Para fazeres uma cópia de segurança ou restaurares, permite o acesso aos teus ficheiros.</string>
-    <string name="autobackup_permission_missing">Para usar a cópia de segurança automática, permite o acesso aos teus ficheiros.</string>
-    <string name="autobackup_files_missing">Para usar a cópia de segurança automática, seleciona ficheiros de cópias de segurança válidos.</string>
     <string name="no_file_selected">Nenhum ficheiro selecionado</string>
     <string name="action_select_file">Selecionar ficheiro</string>
-    <string name="backup_use_default_files">Usar ficheiros de cópias de segurança predefinidos</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Cópia de Segurança Automática</string>
+    <string name="pref_autobackupsummary">Cópia de segurança semanal das tuas listas, séries e filmes</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Última Cópia de Segurança Automática: %s</string>
+    <string name="restore_auto_backup">Restaurar Cópia de Segurança Automática</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Para usar a cópia de segurança automática, seleciona ficheiros de cópias de segurança válidos.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Não deixes para amanhã!</string>
     <string name="dismiss">Dispensar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -412,8 +412,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Alte</string>
     <string name="pref_autoupdatesummary">Sincronizează automat și actualizează datele de pe SeriesGuide</string>
-    <string name="pref_autobackup">Backup automat</string>
-    <string name="pref_autobackupsummary">Backup săptămânal al serialelor, listelor si filmelor</string>
     <string name="backup">Arhivare/Restaurare</string>
     <string name="backup_summary">Arhivează sau restaurează emisiunile</string>
     <string name="pref_number">Format număr</string>
@@ -433,14 +431,18 @@
     <string name="backup_button">Arhivare</string>
     <string name="import_button">Restaurează</string>
     <string name="import_warning">Sunt de acord ca serialele, listele și filmele să fie înlocuite!</string>
-    <string name="last_auto_backup">Ultimul backup automat: %s</string>
-    <string name="restore_auto_backup">Restaurare arhivă automat</string>
-    <string name="dataliberation_permission_missing">Pentru backup sau recuperare, permite accesul la fișierele tale.</string>
-    <string name="autobackup_permission_missing">Pentru backup automat, permite accesul la fișierele tale.</string>
-    <string name="autobackup_files_missing">Pentru backup automat, selectează fișiere de backup valabile.</string>
     <string name="no_file_selected">Niciun fișier selectat</string>
     <string name="action_select_file">Selectează fișierul</string>
-    <string name="backup_use_default_files">Folosește fișierele de backup implicite</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Backup automat</string>
+    <string name="pref_autobackupsummary">Backup săptămânal al serialelor, listelor si filmelor</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Ultimul backup automat: %s</string>
+    <string name="restore_auto_backup">Restaurare arhivă automat</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Pentru backup automat, selectează fișiere de backup valabile.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Cum să începeți</string>
     <string name="dismiss">Respingeți</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Другое</string>
     <string name="pref_autoupdatesummary">Автоматически синхронизировать и обновлять данные SeriesGuide</string>
-    <string name="pref_autobackup">Автоматическое резервное копирование</string>
-    <string name="pref_autobackupsummary">Еженедельное резервное копирование ваших сериалов, списков и фильмов</string>
     <string name="backup">Резервное копирование/восстановление</string>
     <string name="backup_summary">Резервное копирование или восстановление ваших сериалов</string>
     <string name="pref_number">Числовой формат серий</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Резервное копирование</string>
     <string name="import_button">Восстановление</string>
     <string name="import_warning">Я понимаю, что мои текущие сериалы, списки и фильмы будут заменены!</string>
-    <string name="last_auto_backup">Последнее автоматическое резервное копирование: %s</string>
-    <string name="restore_auto_backup">Восстановить автоматическую резервную копию</string>
-    <string name="dataliberation_permission_missing">Для резервного копирования или восстановления, разрешите доступ к вашим файлам.</string>
-    <string name="autobackup_permission_missing">Чтобы использовать автоматическое резервное копирование, разрешите доступ к вашим файлам.</string>
-    <string name="autobackup_files_missing">Чтобы использовать автоматическое резервное копирование, выберите допустимые файлы резервных копий.</string>
     <string name="no_file_selected">Файл не выбран</string>
     <string name="action_select_file">Выбрать файл</string>
-    <string name="backup_use_default_files">Использовать файлы резервных копий по умолчанию</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Автоматическое резервное копирование</string>
+    <string name="pref_autobackupsummary">Еженедельное резервное копирование ваших сериалов, списков и фильмов</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Последнее автоматическое резервное копирование: %s</string>
+    <string name="restore_auto_backup">Восстановить автоматическую резервную копию</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Чтобы использовать автоматическое резервное копирование, выберите допустимые файлы резервных копий.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Начать</string>
     <string name="dismiss">Отменить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Ostatné</string>
     <string name="pref_autoupdatesummary">Automaticky synchronizovať a aktualizovať SeriesGuide dáta</string>
-    <string name="pref_autobackup">Automatické zálohovanie</string>
-    <string name="pref_autobackupsummary">Týždenné zálohovanie vašich seriálov, zoznamov a filmov</string>
     <string name="backup">Zálohovanie / obnovenie</string>
     <string name="backup_summary">Zálohovanie alebo obnovenie vašich seriálov</string>
     <string name="pref_number">Formát číslovania</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Zálohovať</string>
     <string name="import_button">Obnoviť</string>
     <string name="import_warning">Rozumiem, moje aktuálne seriály, zoznamy a filmy budú nahradené zálohou!</string>
-    <string name="last_auto_backup">Posledná automatická záloha: %s</string>
-    <string name="restore_auto_backup">Obnoviť automatickú zálohu</string>
-    <string name="dataliberation_permission_missing">Pre zálohovanie alebo obnovenie, povoľte prístup k vašim súborom.</string>
-    <string name="autobackup_permission_missing">Ak chcete použiť automatické zálohovanie, povoľte prístup k vašim súborom.</string>
-    <string name="autobackup_files_missing">Ak chcete použiť automatické zálohovanie, vyberte platné záložné súbory.</string>
     <string name="no_file_selected">Nebol vybratý žiadny súbor</string>
     <string name="action_select_file">Vyberte súbor</string>
-    <string name="backup_use_default_files">Použiť predvolené záložné súbory</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatické zálohovanie</string>
+    <string name="pref_autobackupsummary">Týždenné zálohovanie vašich seriálov, zoznamov a filmov</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Posledná automatická záloha: %s</string>
+    <string name="restore_auto_backup">Obnoviť automatickú zálohu</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Ak chcete použiť automatické zálohovanie, vyberte platné záložné súbory.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Začíname</string>
     <string name="dismiss">Zatvoriť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Ostalo</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Varnostno kopiranje/Obnovitev</string>
     <string name="backup_summary">Naredite varnostno kopijo ali obnovite vaše oddaje</string>
     <string name="pref_number">Oblika števil</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Varnostno kopiranje</string>
     <string name="import_button">Obnovitev</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Nazadnje Auto Backup: %s</string>
-    <string name="restore_auto_backup">Obnovite varnostno kopijo</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Nazadnje Auto Backup: %s</string>
+    <string name="restore_auto_backup">Obnovite varnostno kopijo</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Get started</string>
     <string name="dismiss">Razveljavi</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -412,8 +412,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Остало</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Архивирање/ повраћај архиве</string>
     <string name="backup_summary">Архивирај или врати архивиране серије</string>
     <string name="pref_number">Облик нумерисања</string>
@@ -433,14 +431,18 @@
     <string name="backup_button">Архивирај</string>
     <string name="import_button">Поврати архивирану ставку</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Задње аутоматско архивирање: %s</string>
-    <string name="restore_auto_backup">Поврати податке</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">Нема одабраних фајлова</string>
     <string name="action_select_file">Изаберите фајл</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Задње аутоматско архивирање: %s</string>
+    <string name="restore_auto_backup">Поврати податке</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Почни</string>
     <string name="dismiss">Одбаци</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Övrigt</string>
     <string name="pref_autoupdatesummary">Automatiskt synkronisera och uppdatera SeriesGuide-data</string>
-    <string name="pref_autobackup">Automatisk säkerhetskopiering</string>
-    <string name="pref_autobackupsummary">Veckovis säkerhetskopiering av dina serier, listor och filmer</string>
     <string name="backup">Säkerhetskopiera/återställ</string>
     <string name="backup_summary">Säkerhetskopiera eller återställ dina serier</string>
     <string name="pref_number">Nummerformat</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Säkerhetskopiera</string>
     <string name="import_button">Återställ säkerhetskopia</string>
     <string name="import_warning">Jag förstår att mina nuvarande serier, listor och filmer kommer ersättas!</string>
-    <string name="last_auto_backup">Senaste automatiska säkerhetskopia: %s</string>
-    <string name="restore_auto_backup">Återställ automatisk säkerhetskopia</string>
-    <string name="dataliberation_permission_missing">För att säkerhetskopiera eller återställa måste du tillåta åtkomst till dina filer.</string>
-    <string name="autobackup_permission_missing">För att använda automatisk säkerhetskopiering måste du tillåta åtkomst till dina filer.</string>
-    <string name="autobackup_files_missing">För att använda automatisk säkerhetskopiering, välj giltiga filer för säkerhetskopiering.</string>
     <string name="no_file_selected">Ingen fil vald</string>
     <string name="action_select_file">Välj fil</string>
-    <string name="backup_use_default_files">Använd förvalda backupfiler</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Automatisk säkerhetskopiering</string>
+    <string name="pref_autobackupsummary">Veckovis säkerhetskopiering av dina serier, listor och filmer</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Senaste automatiska säkerhetskopia: %s</string>
+    <string name="restore_auto_backup">Återställ automatisk säkerhetskopia</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">För att använda automatisk säkerhetskopiering, välj giltiga filer för säkerhetskopiering.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Kom igång</string>
     <string name="dismiss">Avfärda</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">மற்ற</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">தானியங்கு மறுபிரதி</string>
-    <string name="pref_autobackupsummary">உங்கள் காட்சிகள், பட்டியல்கள் மற்றும் திரைப்படங்கள் வார மறுபிரதி</string>
     <string name="backup">மறுபிரதி/மீட்டெடுத்தல்</string>
     <string name="backup_summary">மறுபிரதி எடு அல்லது மீட்டெடு உங்கள் காட்சிகள்</string>
     <string name="pref_number">எண் வடிவமைப்பு</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">மறுபிரதி உருவாக்கு</string>
     <string name="import_button">மீட்டெடுக்க மறுபிரதி</string>
     <string name="import_warning">நான் எனது தற்போதைய காட்சிகள் புரிந்துகொள்ள, பட்டியல்கள் மற்றும் படங்கள் மாற்றப்படும்!</string>
-    <string name="last_auto_backup">கடைசி தானியங்கு மறுபிரதி: %s</string>
-    <string name="restore_auto_backup">தானியங்கு மறுபிரதி மீட்டெடு</string>
-    <string name="dataliberation_permission_missing">மறுபிரதி எடு அல்லது மீட்டெடு, உங்கள் கோப்புகளை பெற அனுமதி.</string>
-    <string name="autobackup_permission_missing">தானியங்கு மறுபிரதி பயன்படுத்த, உங்கள் கோப்புகளை பெற அனுமதி.</string>
-    <string name="autobackup_files_missing">தானியங்கு மறுபிரதி பயன்படுத்த, செல்லுபடியான மறுபிரதி கோப்புகளை தேர்ந்தெடுக்கவும்.</string>
     <string name="no_file_selected">தேர்ந்தெடுத்த கோப்பு இல்லை</string>
     <string name="action_select_file">கோப்பு தேர்ந்தெடு</string>
-    <string name="backup_use_default_files">மறுபிரதி கோப்புகளை இயல்புநிலை பயன்படுத்து</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">தானியங்கு மறுபிரதி</string>
+    <string name="pref_autobackupsummary">உங்கள் காட்சிகள், பட்டியல்கள் மற்றும் திரைப்படங்கள் வார மறுபிரதி</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">கடைசி தானியங்கு மறுபிரதி: %s</string>
+    <string name="restore_auto_backup">தானியங்கு மறுபிரதி மீட்டெடு</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">தானியங்கு மறுபிரதி பயன்படுத்த, செல்லுபடியான மறுபிரதி கோப்புகளை தேர்ந்தெடுக்கவும்.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">தொடங்குதல்</string>
     <string name="dismiss">நீக்கு</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">อื่นๆ</string>
     <string name="pref_autoupdatesummary">ซิงค์และอัปเดตข้อมูล SeriesGuide อัตโนมัติ</string>
-    <string name="pref_autobackup">สำรองอัตโนมัติ</string>
-    <string name="pref_autobackupsummary">สำรองข้อมูลซีรีส์, รายการ และภาพยนตร์รายสัปดาห์</string>
     <string name="backup">สำรอง/กู้คืน</string>
     <string name="backup_summary">สำรองหรือกู้คืนซีรีส์ของคุณ</string>
     <string name="pref_number">รูปแบบตัวเลข</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">สร้างข้อมูลสำรอง</string>
     <string name="import_button">กู้คืนการสำรองข้อมูล</string>
     <string name="import_warning">ฉันเข้าใจว่าซีรีส์, รายการ และภาพยนตร์ปัจจุบันของฉันจะถูกแทนที่!</string>
-    <string name="last_auto_backup">สำรองข้อมูลอัตโนมัติล่าสุด: %s</string>
-    <string name="restore_auto_backup">กู้คืนการสำรองข้อมูลอัตโนมัติ</string>
-    <string name="dataliberation_permission_missing">ในการสำรองข้อมูลหรือกู้คืน, อนุญาตให้เข้าถึงไฟล์ของคุณ</string>
-    <string name="autobackup_permission_missing">ในการใช้การสำรองข้อมูลอัตโนมัติ, อนุญาตให้เข้าถึงไฟล์ของคุณ</string>
-    <string name="autobackup_files_missing">ในการใช้การสำรองข้อมูลอัตโนมัติ, เลือกไฟล์สำรองที่ถูกต้อง</string>
     <string name="no_file_selected">ไม่ได้เลือกไฟล์ใด</string>
     <string name="action_select_file">เลือกไฟล์</string>
-    <string name="backup_use_default_files">ใช้ไฟล์สำรองเริ่มต้น</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">สำรองอัตโนมัติ</string>
+    <string name="pref_autobackupsummary">สำรองข้อมูลซีรีส์, รายการ และภาพยนตร์รายสัปดาห์</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">สำรองข้อมูลอัตโนมัติล่าสุด: %s</string>
+    <string name="restore_auto_backup">กู้คืนการสำรองข้อมูลอัตโนมัติ</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">ในการใช้การสำรองข้อมูลอัตโนมัติ, เลือกไฟล์สำรองที่ถูกต้อง</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">เริ่มต้น</string>
     <string name="dismiss">ปิด</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -401,8 +401,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Diğer</string>
     <string name="pref_autoupdatesummary">SeriesGuide verilerini otomatik olarak senkronize et ve güncelle</string>
-    <string name="pref_autobackup">Otomatik yedekleme</string>
-    <string name="pref_autobackupsummary">Şovlarınızın, listelerinizin ve filmlerinizin haftalık yedeği</string>
     <string name="backup">Yedekle/Geri Yükle</string>
     <string name="backup_summary">Dizilerinizi yedekleyin veya geri yükleyin</string>
     <string name="pref_number">Sayı biçimi</string>
@@ -422,14 +420,18 @@
     <string name="backup_button">Yedekle</string>
     <string name="import_button">Geri Yükle</string>
     <string name="import_warning">Mevcut şovlarımın, listelerimin ve filmlerimin silineceğini anlıyorum!</string>
-    <string name="last_auto_backup">Son Otomatik Yedekleme: %s</string>
-    <string name="restore_auto_backup">Otomatik Yedeklemeden Geri Yükle</string>
-    <string name="dataliberation_permission_missing">Yedeklemek veya geri yüklemek için dosyalarınıza erişime izin verin.</string>
-    <string name="autobackup_permission_missing">Otomatik yedekleme kullanmak için dosyalarınıza erişime izin verin.</string>
-    <string name="autobackup_files_missing">Otomatik yedeklemeyi kullanmak için geçerli yedekleme dosyaları seçin.</string>
     <string name="no_file_selected">Seçilmiş dosya yok</string>
     <string name="action_select_file">Dosya seçin</string>
-    <string name="backup_use_default_files">Varsayılan yedek dosyalarını kullan</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Otomatik yedekleme</string>
+    <string name="pref_autobackupsummary">Şovlarınızın, listelerinizin ve filmlerinizin haftalık yedeği</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Son Otomatik Yedekleme: %s</string>
+    <string name="restore_auto_backup">Otomatik Yedeklemeden Geri Yükle</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Otomatik yedeklemeyi kullanmak için geçerli yedekleme dosyaları seçin.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Başlarken</string>
     <string name="dismiss">Kapat</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -423,8 +423,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Інші</string>
     <string name="pref_autoupdatesummary">Автоматично синхронізування та оновлення даних SeriesGuide</string>
-    <string name="pref_autobackup">Автоматичне резервне копіювання</string>
-    <string name="pref_autobackupsummary">Щотижневе резервне копіювання ваших серіалів, списків та фільмів</string>
     <string name="backup">Бекап/Відновлення</string>
     <string name="backup_summary">Резервна копія або відновлення ваших серіалів</string>
     <string name="pref_number">Формат цифр</string>
@@ -444,14 +442,18 @@
     <string name="backup_button">Бекап</string>
     <string name="import_button">Відновити</string>
     <string name="import_warning">Я розумію, що мої поточні серіали, списки та фільми будуть замінені!</string>
-    <string name="last_auto_backup">Останній авто Бекап: %s</string>
-    <string name="restore_auto_backup">Відновити з авто Бекапу</string>
-    <string name="dataliberation_permission_missing">Щоб зберегти або відновити резервну копію дозвольте доступ до ваших файлів.</string>
-    <string name="autobackup_permission_missing">Щоб застосувати автоматичне резервне копіювання, дозвольте доступ до ваших файлів.</string>
-    <string name="autobackup_files_missing">Щоб використати автоматичну резервну копію, виберіть дійсні файли бекапу.</string>
     <string name="no_file_selected">Не вибрано жодного файлу</string>
     <string name="action_select_file">Виберіть файл</string>
-    <string name="backup_use_default_files">Використовувати резервну копію за замовчуванням</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Автоматичне резервне копіювання</string>
+    <string name="pref_autobackupsummary">Щотижневе резервне копіювання ваших серіалів, списків та фільмів</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">Останній авто Бекап: %s</string>
+    <string name="restore_auto_backup">Відновити з авто Бекапу</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">Щоб використати автоматичну резервну копію, виберіть дійсні файли бекапу.</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">Початок роботи</string>
     <string name="dismiss">Відхилити</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">其它</string>
     <string name="pref_autoupdatesummary">自动同步并更新 SeriesGuide 数据</string>
-    <string name="pref_autobackup">自动备份</string>
-    <string name="pref_autobackupsummary">每周定期备份剧集、列表和电影数据</string>
     <string name="backup">备份与还原</string>
     <string name="backup_summary">备份或还原节目单</string>
     <string name="pref_number">序号格式</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">备份</string>
     <string name="import_button">还原</string>
     <string name="import_warning">我已了解当前所有剧集、列表和电影数据将被替换。</string>
-    <string name="last_auto_backup">上次自动备份时间：%s</string>
-    <string name="restore_auto_backup">从自动备份恢复</string>
-    <string name="dataliberation_permission_missing">若要备份或恢复，允许访问您的文件。</string>
-    <string name="autobackup_permission_missing">若要使用自动备份，请允许访问您的文件。</string>
-    <string name="autobackup_files_missing">选择一个可用的备份文件以使用自动备份。</string>
     <string name="no_file_selected">没有选择的文件</string>
     <string name="action_select_file">选择文件</string>
-    <string name="backup_use_default_files">使用默认备份文件</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">自动备份</string>
+    <string name="pref_autobackupsummary">每周定期备份剧集、列表和电影数据</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">上次自动备份时间：%s</string>
+    <string name="restore_auto_backup">从自动备份恢复</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">选择一个可用的备份文件以使用自动备份。</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">入门</string>
     <string name="dismiss">忽略</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -390,8 +390,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">其他</string>
     <string name="pref_autoupdatesummary">自動同步和更新 SeriesGuide 資料</string>
-    <string name="pref_autobackup">自動備份</string>
-    <string name="pref_autobackupsummary">每週備份你的節目，清單和電影</string>
     <string name="backup">備份/還原</string>
     <string name="backup_summary">備份或還原你的影集</string>
     <string name="pref_number">數字格式</string>
@@ -411,14 +409,18 @@
     <string name="backup_button">備份</string>
     <string name="import_button">還原</string>
     <string name="import_warning">我明白我目前的節目，及其他清單和電影將會被取代 ！</string>
-    <string name="last_auto_backup">剩餘自動備份︰ %s</string>
-    <string name="restore_auto_backup">還原自動備份</string>
-    <string name="dataliberation_permission_missing">若要備份或復原，請允許存取您的檔案。</string>
-    <string name="autobackup_permission_missing">若要自動備份，請允許存取您的檔案。</string>
-    <string name="autobackup_files_missing">為了備份，請選擇一可用備份資料夾。</string>
     <string name="no_file_selected">沒有選擇檔案</string>
     <string name="action_select_file">選擇檔案</string>
-    <string name="backup_use_default_files">使用預設備份檔案</string>
+    <!-- Auto backup -->
+    <string name="pref_autobackup">自動備份</string>
+    <string name="pref_autobackupsummary">每週備份你的節目，清單和電影</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
+    <string name="last_auto_backup">剩餘自動備份︰ %s</string>
+    <string name="restore_auto_backup">還原自動備份</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
+    <string name="autobackup_files_missing">為了備份，請選擇一可用備份資料夾。</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
     <!-- Welcome dialog -->
     <string name="get_started">開始</string>
     <string name="dismiss">解除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,8 +458,6 @@
     <!-- Other advanced settings -->
     <string name="pref_other">Other</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
-    <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies</string>
     <string name="backup">Backup/Restore</string>
     <string name="backup_summary">Backup or restore your shows</string>
     <string name="pref_number">Number format</string>
@@ -480,12 +478,15 @@
     <string name="backup_button">Create backup</string>
     <string name="import_button">Restore backup</string>
     <string name="import_warning">Your current shows, lists or movies will be replaced by the backup</string>
-    <string name="last_auto_backup">Last Auto Backup: %s</string>
-    <string name="restore_auto_backup">Restore Auto Backup</string>
-    <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>
+
+    <!-- Auto backup -->
+    <string name="pref_autobackup">Auto Backup</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage</string>
+    <string name="last_auto_backup">Last Auto Backup: %s</string>
+    <string name="restore_auto_backup">Restore Auto Backup</string>
+    <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="autobackup_create_user_copy">Create a copy after each backup</string>
 
     <!-- Welcome dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,7 +483,8 @@
 
     <!-- Auto backup -->
     <string name="pref_autobackup">Auto Backup</string>
-    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage</string>
+    <string name="pref_autobackupsummary">Weekly backup of your shows, lists and movies to device storage.</string>
+    <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
     <string name="last_auto_backup">Last Auto Backup: %s</string>
     <string name="restore_auto_backup">Restore Auto Backup</string>
     <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,7 +487,7 @@
     <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>
-    <string name="backup_use_default_files">Use default backup files</string>
+    <string name="autobackup_create_user_copy">Create a copy after each backup</string>
 
     <!-- Welcome dialog -->
     <string name="get_started">Get started</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,6 +487,7 @@
     <string name="autobackup_details">These backups are unavailable if the app is installed again unless app data backup is turned on for this device (Android 6+). Create copies to preserve them otherwise.</string>
     <string name="last_auto_backup">Last Auto Backup: %s</string>
     <string name="restore_auto_backup">Restore Auto Backup</string>
+    <string name="autobackup_failed">The last auto backup has failed</string>
     <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="autobackup_create_user_copy">Create a copy after each backup</string>
     <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,6 +488,7 @@
     <string name="restore_auto_backup">Restore Auto Backup</string>
     <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="autobackup_create_user_copy">Create a copy after each backup</string>
+    <string name="autobackup_restore_available">An auto backup might be available to restore from.</string>
 
     <!-- Welcome dialog -->
     <string name="get_started">Get started</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,7 +483,6 @@
     <string name="last_auto_backup">Last Auto Backup: %s</string>
     <string name="restore_auto_backup">Restore Auto Backup</string>
     <string name="dataliberation_permission_missing">To backup or restore, allow access to your files</string>
-    <string name="autobackup_permission_missing">To use auto backup, allow access to your files</string>
     <string name="autobackup_files_missing">To use auto backup, select valid backup files</string>
     <string name="no_file_selected">No file selected</string>
     <string name="action_select_file">Select file</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -140,6 +140,9 @@
         <item name="fontFamily">sans-serif-medium</item>
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
+    <style name="TextAppearance.SeriesGuide.Body2.Bold.Accent">
+        <item name="android:textColor">@color/sg_text_color_accent</item>
+    </style>
     <style name="TextAppearance.SeriesGuide.Body2.Italics">
         <item name="android:textStyle">italic</item>
     </style>

--- a/app/src/main/res/xml/sg_full_backup_rules.xml
+++ b/app/src/main/res/xml/sg_full_backup_rules.xml
@@ -4,4 +4,6 @@
     <!-- Not including the database, it likely exceeds the 25 MB limit. -->
     <!-- https://developer.android.com/guide/topics/data/autobackup -->
     <include domain="sharedpref" path="com.battlelancer.seriesguide_preferences.xml" />
+    <!-- Recent automatic backups. -->
+    <include domain="external" path="Backups/" />
 </full-backup-content>


### PR DESCRIPTION
Also auto backup by default onto external storage, not requiring storage permissions.

- [x] If user has specified auto backup files, copy the latest backup to them instead.
- [x] Move settings to dedicated class.
- [x] Import from new auto backup location.
  - [x] Make clear that backups are deleted when re-installing if app data backup is turned off.
- [x] Detect backups in first run dialog, add button to go to auto backup restore screen.
- [x] Test backup and restore, e.g. on emulator using local backup transport.
  - https://developer.android.com/guide/topics/data/testingbackup
- [x] Display Snackbar if last auto backup failed.
- [x] Add button to run auto backup now (e.g. for testing it is set up correctly).
- [x] Update strings.
- [x] Resolve all FIXMEs and TODOs.