### PR TITLE
Truncate Storage Access Framework file before writing backup to it.

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -258,6 +258,12 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
                 }
                 FileOutputStream out = new FileOutputStream(pfd.getFileDescriptor());
 
+                // Even though using streams and FileOutputStream does not append by
+                // default, using Storage Access Framework just overwrites existing
+                // bytes, potentially leaving old bytes hanging over:
+                // so truncate the file first to clear any existing bytes.
+                out.getChannel().truncate(0);
+
                 if (type == BACKUP_SHOWS) {
                     writeJsonStreamShows(out, data);
                 } else if (type == BACKUP_LISTS) {


### PR DESCRIPTION
Closes https://github.com/UweTrottmann/SeriesGuide/issues/719

Taken from #718 to ensure it makes it to the upcoming release.