### PR TITLE
Limited support for multiple plays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/
 
 ## Proguard
 unused.txt
+
+## Flatbuffers
+flatc.exe

--- a/app/schemas/com.battlelancer.seriesguide.provider.SgRoomDatabase/48.json
+++ b/app/schemas/com.battlelancer.seriesguide.provider.SgRoomDatabase/48.json
@@ -1,0 +1,882 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 48,
+    "identityHash": "d192cb5f96137cdca07b029247d2772b",
+    "entities": [
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `series_slug` TEXT, `seriestitle` TEXT NOT NULL, `series_title_noarticle` TEXT, `overview` TEXT, `airstime` INTEGER, `airsdayofweek` INTEGER, `series_airtime` TEXT, `series_timezone` TEXT, `firstaired` TEXT, `genres` TEXT, `network` TEXT, `rating` REAL, `series_rating_votes` INTEGER, `series_rating_user` INTEGER, `runtime` TEXT, `status` TEXT, `contentrating` TEXT, `next` TEXT, `poster` TEXT, `series_poster_small` TEXT, `series_nextairdate` INTEGER, `nexttext` TEXT, `imdbid` TEXT, `series_trakt_id` INTEGER, `series_favorite` INTEGER NOT NULL, `series_syncenabled` INTEGER NOT NULL, `series_hidden` INTEGER NOT NULL, `series_lastupdate` INTEGER NOT NULL, `series_lastedit` INTEGER NOT NULL, `series_lastwatchedid` INTEGER NOT NULL, `series_lastwatched_ms` INTEGER NOT NULL, `series_language` TEXT, `series_unwatched_count` INTEGER NOT NULL, `series_notify` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "series_slug",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "seriestitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleNoArticle",
+            "columnName": "series_title_noarticle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseTime",
+            "columnName": "airstime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseWeekDay",
+            "columnName": "airsdayofweek",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseCountry",
+            "columnName": "series_airtime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseTimeZone",
+            "columnName": "series_timezone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstRelease",
+            "columnName": "firstaired",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "network",
+            "columnName": "network",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingGlobal",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotes",
+            "columnName": "series_rating_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "series_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentRating",
+            "columnName": "contentrating",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextEpisode",
+            "columnName": "next",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poster",
+            "columnName": "poster",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "posterSmall",
+            "columnName": "series_poster_small",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextAirdateMs",
+            "columnName": "series_nextairdate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nextText",
+            "columnName": "nexttext",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traktId",
+            "columnName": "series_trakt_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "series_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hexagonMergeComplete",
+            "columnName": "series_syncenabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "series_hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdatedMs",
+            "columnName": "series_lastupdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEditedSec",
+            "columnName": "series_lastedit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastWatchedEpisodeId",
+            "columnName": "series_lastwatchedid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastWatchedMs",
+            "columnName": "series_lastwatched_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "series_language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "unwatchedCount",
+            "columnName": "series_unwatched_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notify",
+            "columnName": "series_notify",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER, `combinednr` INTEGER, `series_id` TEXT, `watchcount` INTEGER, `willaircount` INTEGER, `noairdatecount` INTEGER, `seasonposter` TEXT, `season_totalcount` INTEGER, PRIMARY KEY(`_id`), FOREIGN KEY(`series_id`) REFERENCES `series`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "combinednr",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "series_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watchCount",
+            "columnName": "watchcount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notReleasedCount",
+            "columnName": "willaircount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noReleaseDateCount",
+            "columnName": "noairdatecount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "seasonposter",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "season_totalcount",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_seasons_series_id",
+            "unique": false,
+            "columnNames": [
+              "series_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seasons_series_id` ON `${TABLE_NAME}` (`series_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "series_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER NOT NULL, `episodetitle` TEXT NOT NULL, `episodedescription` TEXT, `episodenumber` INTEGER NOT NULL, `season` INTEGER NOT NULL, `dvdnumber` REAL, `season_id` INTEGER NOT NULL, `series_id` INTEGER NOT NULL, `watched` INTEGER NOT NULL, `plays` INTEGER, `directors` TEXT, `gueststars` TEXT, `writers` TEXT, `episodeimage` TEXT, `episode_firstairedms` INTEGER NOT NULL, `episode_collected` INTEGER NOT NULL, `rating` REAL, `episode_rating_votes` INTEGER, `episode_rating_user` INTEGER, `episode_imdbid` TEXT, `episode_lastedit` INTEGER NOT NULL, `absolute_number` INTEGER, `episode_lastupdate` INTEGER NOT NULL, PRIMARY KEY(`_id`), FOREIGN KEY(`season_id`) REFERENCES `seasons`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`series_id`) REFERENCES `series`(`_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tvdbId",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "episodetitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "episodedescription",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "episodenumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dvdNumber",
+            "columnName": "dvdnumber",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seasonTvdbId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "series_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "watched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "plays",
+            "columnName": "plays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "directors",
+            "columnName": "directors",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "guestStars",
+            "columnName": "gueststars",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "writers",
+            "columnName": "writers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "episodeimage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstReleasedMs",
+            "columnName": "episode_firstairedms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collected",
+            "columnName": "episode_collected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ratingGlobal",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotes",
+            "columnName": "episode_rating_votes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "episode_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "episode_imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastEditedSec",
+            "columnName": "episode_lastedit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absoluteNumber",
+            "columnName": "absolute_number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdatedSec",
+            "columnName": "episode_lastupdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_episodes_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_episodes_series_id",
+            "unique": false,
+            "columnNames": [
+              "series_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_episodes_series_id` ON `${TABLE_NAME}` (`series_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "seasons",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          },
+          {
+            "table": "series",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "series_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "lists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `list_id` TEXT NOT NULL, `list_name` TEXT NOT NULL, `list_order` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "list_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "list_order",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_lists_list_id",
+            "unique": true,
+            "columnNames": [
+              "list_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lists_list_id` ON `${TABLE_NAME}` (`list_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "listitems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `list_item_id` TEXT NOT NULL, `item_ref_id` TEXT NOT NULL, `item_type` INTEGER NOT NULL, `list_id` TEXT, FOREIGN KEY(`list_id`) REFERENCES `lists`(`list_id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "listItemId",
+            "columnName": "list_item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemRefId",
+            "columnName": "item_ref_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "item_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_listitems_list_item_id",
+            "unique": true,
+            "columnNames": [
+              "list_item_id"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_listitems_list_item_id` ON `${TABLE_NAME}` (`list_item_id`)"
+          },
+          {
+            "name": "index_listitems_list_id",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listitems_list_id` ON `${TABLE_NAME}` (`list_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "lists",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "list_id"
+            ],
+            "referencedColumns": [
+              "list_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "movies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `movies_tmdbid` INTEGER NOT NULL, `movies_imdbid` TEXT, `movies_title` TEXT, `movies_title_noarticle` TEXT, `movies_poster` TEXT, `movies_genres` TEXT, `movies_overview` TEXT, `movies_released` INTEGER, `movies_runtime` INTEGER, `movies_trailer` TEXT, `movies_certification` TEXT, `movies_incollection` INTEGER, `movies_inwatchlist` INTEGER, `movies_plays` INTEGER, `movies_watched` INTEGER, `movies_rating_tmdb` REAL, `movies_rating_votes_tmdb` INTEGER, `movies_rating_trakt` INTEGER, `movies_rating_votes_trakt` INTEGER, `movies_rating_user` INTEGER, `movies_last_updated` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tmdbId",
+            "columnName": "movies_tmdbid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imdbId",
+            "columnName": "movies_imdbid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "movies_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "titleNoArticle",
+            "columnName": "movies_title_noarticle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poster",
+            "columnName": "movies_poster",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "movies_genres",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "movies_overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releasedMs",
+            "columnName": "movies_released",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "runtimeMin",
+            "columnName": "movies_runtime",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trailer",
+            "columnName": "movies_trailer",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "certification",
+            "columnName": "movies_certification",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inCollection",
+            "columnName": "movies_incollection",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inWatchlist",
+            "columnName": "movies_inwatchlist",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "plays",
+            "columnName": "movies_plays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "movies_watched",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingTmdb",
+            "columnName": "movies_rating_tmdb",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotesTmdb",
+            "columnName": "movies_rating_votes_tmdb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingTrakt",
+            "columnName": "movies_rating_trakt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingVotesTrakt",
+            "columnName": "movies_rating_votes_trakt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ratingUser",
+            "columnName": "movies_rating_user",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "movies_last_updated",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_movies_movies_tmdbid",
+            "unique": true,
+            "columnNames": [
+              "movies_tmdbid"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_movies_movies_tmdbid` ON `${TABLE_NAME}` (`movies_tmdbid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "activity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `activity_episode` TEXT NOT NULL, `activity_show` TEXT NOT NULL, `activity_time` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeTvdbId",
+            "columnName": "activity_episode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTvdbId",
+            "columnName": "activity_show",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMs",
+            "columnName": "activity_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_activity_activity_episode",
+            "unique": true,
+            "columnNames": [
+              "activity_episode"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_activity_activity_episode` ON `${TABLE_NAME}` (`activity_episode`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "jobs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `job_created_at` INTEGER, `job_type` INTEGER, `job_extras` BLOB)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdMs",
+            "columnName": "job_created_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "job_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extras",
+            "columnName": "job_extras",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_jobs_job_created_at",
+            "unique": true,
+            "columnNames": [
+              "job_created_at"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_jobs_job_created_at` ON `${TABLE_NAME}` (`job_created_at`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd192cb5f96137cdca07b029247d2772b')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/jobs/FlatbufferTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/jobs/FlatbufferTest.java
@@ -17,10 +17,10 @@ public class FlatbufferTest {
 
         int[] episodeInfos = new int[42];
         for (int i = 0; i < 21; i++) {
-            episodeInfos[i] = EpisodeInfo.createEpisodeInfo(builder, 1, i + 1);
+            episodeInfos[i] = EpisodeInfo.createEpisodeInfo(builder, 1, i + 1, i);
         }
         for (int i = 21; i < 42; i++) {
-            episodeInfos[i] = EpisodeInfo.createEpisodeInfo(builder, 2, i + 1);
+            episodeInfos[i] = EpisodeInfo.createEpisodeInfo(builder, 2, i + 1, i);
         }
 
         int episodes = SgJobInfo.createEpisodesVector(builder, episodeInfos);
@@ -41,11 +41,13 @@ public class FlatbufferTest {
             EpisodeInfo episodeInfo = jobInfoReloaded.episodes(i);
             assertThat(episodeInfo.season()).isEqualTo(1);
             assertThat(episodeInfo.number()).isEqualTo(i + 1);
+            assertThat(episodeInfo.plays()).isEqualTo(i);
         }
         for (int i = 21; i < 42; i++) {
             EpisodeInfo episodeInfo = jobInfoReloaded.episodes(i);
             assertThat(episodeInfo.season()).isEqualTo(2);
             assertThat(episodeInfo.number()).isEqualTo(i + 1);
+            assertThat(episodeInfo.plays()).isEqualTo(i);
         }
     }
 

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -5,9 +5,11 @@ import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_43_
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_44_45;
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_45_46;
 import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_46_47;
+import static com.battlelancer.seriesguide.provider.SgRoomDatabase.MIGRATION_47_48;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.database.sqlite.SQLiteDatabase;
+import androidx.annotation.Nullable;
 import androidx.room.Room;
 import androidx.room.testing.MigrationTestHelper;
 import androidx.sqlite.db.SupportSQLiteDatabase;
@@ -17,10 +19,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.battlelancer.seriesguide.dataliberation.model.Show;
 import com.battlelancer.seriesguide.model.SgEpisode;
+import com.battlelancer.seriesguide.model.SgMovie;
 import com.battlelancer.seriesguide.model.SgSeason;
 import com.battlelancer.seriesguide.model.SgShow;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
+import com.battlelancer.seriesguide.ui.movies.MovieDetails;
 import com.uwetrottmann.thetvdb.entities.Episode;
+import com.uwetrottmann.tmdb2.entities.Movie;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
@@ -50,6 +55,30 @@ public class MigrationTest {
         EPISODE.id = 21;
         EPISODE.episodeName = "Episode Title";
         EPISODE.airedEpisodeNumber = 1;
+    }
+
+    private static Episode getTestEpisode(@Nullable Integer tvdbId) {
+        Episode episode = new Episode();
+        if (tvdbId != null) {
+            episode.id = tvdbId;
+        } else {
+            episode.id = 21;
+        }
+        episode.episodeName = "Episode Title";
+        episode.airedEpisodeNumber = 1;
+        return episode;
+    }
+
+    private static MovieDetails getTestMovieDetails(@Nullable Integer tmdbId) {
+        MovieDetails movieDetails = new MovieDetails();
+        Movie tmdbMovie = new Movie();
+        if (tmdbId != null) {
+            tmdbMovie.id = tmdbId;
+        } else {
+            tmdbMovie.id = 12;
+        }
+        movieDetails.tmdbMovie(tmdbMovie);
+        return movieDetails;
     }
 
     // Helper for creating Room databases and migrations
@@ -167,6 +196,49 @@ public class MigrationTest {
         assertThat(dbShow.posterSmall).isEqualTo(TvdbImageTools.TVDB_LEGACY_CACHE_PREFIX + dbShow.poster);
     }
 
+    @Test
+    public void migrationFrom47To48_containsCorrectData() throws IOException {
+        SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 47);
+        RoomDatabaseTestHelper.insertShow(SHOW, db, 47);
+        RoomDatabaseTestHelper.insertSeason(SEASON, db);
+
+        Episode testEpisode = getTestEpisode(21);
+        RoomDatabaseTestHelper
+                .insertEpisode(db, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
+                        true);
+
+        testEpisode = getTestEpisode(22);
+        RoomDatabaseTestHelper
+                .insertEpisode(db, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
+                        false);
+
+        MovieDetails testMovieDetails = getTestMovieDetails(12);
+        testMovieDetails.setWatched(true);
+        RoomDatabaseTestHelper.insertMovie(db, testMovieDetails);
+
+        testMovieDetails = getTestMovieDetails(13);
+        testMovieDetails.setWatched(false);
+        RoomDatabaseTestHelper.insertMovie(db, testMovieDetails);
+        db.close();
+
+        SgRoomDatabase database = getMigratedRoomDatabase();
+        assertTestData(database);
+
+        // Watched episode should have 1 play.
+        SgEpisode episodeWatched = database.episodeHelper().getEpisode(21);
+        assertThat(episodeWatched.plays).isEqualTo(1);
+
+        SgEpisode episodeNotWatched = database.episodeHelper().getEpisode(22);
+        assertThat(episodeNotWatched.plays).isEqualTo(0);
+
+        // Watched movie should have 1 play.
+        SgMovie movieWatched = database.movieHelper().getMovie(12);
+        assertThat(movieWatched.plays).isEqualTo(1);
+
+        SgMovie movieNotWatched = database.movieHelper().getMovie(13);
+        assertThat(movieNotWatched.plays).isEqualTo(0);
+    }
+
     private void assertTestData(SgRoomDatabase database) {
         // MigrationTestHelper automatically verifies the schema changes, but not the data validity.
         // Validate that the data was migrated properly.
@@ -198,7 +270,8 @@ public class MigrationTest {
                         MIGRATION_43_44,
                         MIGRATION_44_45,
                         MIGRATION_45_46,
-                        MIGRATION_46_47
+                        MIGRATION_46_47,
+                        MIGRATION_47_48
                 )
                 .build();
         // close the database and release any stream resources when the test finishes

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -193,23 +193,25 @@ public class MigrationTest {
         SgRoomDatabase database = getMigratedRoomDatabase();
         assertTestData(database);
         SgShow dbShow = database.showHelper().getShow();
-        assertThat(dbShow.posterSmall).isEqualTo(TvdbImageTools.TVDB_LEGACY_CACHE_PREFIX + dbShow.poster);
+        assertThat(dbShow.posterSmall)
+                .isEqualTo(TvdbImageTools.TVDB_LEGACY_CACHE_PREFIX + dbShow.poster);
     }
 
     @Test
     public void migrationFrom47To48_containsCorrectData() throws IOException {
-        SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, 47);
-        RoomDatabaseTestHelper.insertShow(SHOW, db, 47);
+        int v47 = SgRoomDatabase.VERSION_47_SERIES_POSTER_THUMB;
+        SupportSQLiteDatabase db = migrationTestHelper.createDatabase(TEST_DB_NAME, v47);
+        RoomDatabaseTestHelper.insertShow(SHOW, db, v47);
         RoomDatabaseTestHelper.insertSeason(SEASON, db);
 
         Episode testEpisode = getTestEpisode(21);
         RoomDatabaseTestHelper
-                .insertEpisode(db, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
+                .insertEpisode(db, v47, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
                         true);
 
         testEpisode = getTestEpisode(22);
         RoomDatabaseTestHelper
-                .insertEpisode(db, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
+                .insertEpisode(db, v47, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
                         false);
 
         MovieDetails testMovieDetails = getTestMovieDetails(12);

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/MigrationTest.java
@@ -19,7 +19,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.battlelancer.seriesguide.dataliberation.model.Show;
 import com.battlelancer.seriesguide.model.SgEpisode;
-import com.battlelancer.seriesguide.model.SgMovie;
 import com.battlelancer.seriesguide.model.SgSeason;
 import com.battlelancer.seriesguide.model.SgShow;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbImageTools;
@@ -214,13 +213,6 @@ public class MigrationTest {
                 .insertEpisode(db, v47, testEpisode, SHOW.tvdb_id, SEASON.tvdbId, SEASON.number,
                         false);
 
-        MovieDetails testMovieDetails = getTestMovieDetails(12);
-        testMovieDetails.setWatched(true);
-        RoomDatabaseTestHelper.insertMovie(db, testMovieDetails);
-
-        testMovieDetails = getTestMovieDetails(13);
-        testMovieDetails.setWatched(false);
-        RoomDatabaseTestHelper.insertMovie(db, testMovieDetails);
         db.close();
 
         SgRoomDatabase database = getMigratedRoomDatabase();
@@ -232,13 +224,6 @@ public class MigrationTest {
 
         SgEpisode episodeNotWatched = database.episodeHelper().getEpisode(22);
         assertThat(episodeNotWatched.plays).isEqualTo(0);
-
-        // Watched movie should have 1 play.
-        SgMovie movieWatched = database.movieHelper().getMovie(12);
-        assertThat(movieWatched.plays).isEqualTo(1);
-
-        SgMovie movieNotWatched = database.movieHelper().getMovie(13);
-        assertThat(movieNotWatched.plays).isEqualTo(0);
     }
 
     private void assertTestData(SgRoomDatabase database) {

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/ProviderTest.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/ProviderTest.java
@@ -235,6 +235,7 @@ public class ProviderTest {
         assertNotNullValue(query, Episodes.TITLE);
         assertDefaultValue(query, Episodes.NUMBER, 0);
         assertDefaultValue(query, Episodes.WATCHED, 0);
+        assertDefaultValue(query, Episodes.PLAYS, 0);
         assertNotNullValue(query, Episodes.DIRECTORS);
         assertNotNullValue(query, Episodes.GUESTSTARS);
         assertNotNullValue(query, Episodes.WRITERS);

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.battlelancer.seriesguide.Constants;
 import com.battlelancer.seriesguide.dataliberation.model.Show;
 import com.battlelancer.seriesguide.model.SgSeason;
+import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
 import com.battlelancer.seriesguide.provider.SeriesGuideDatabase.Tables;
@@ -47,11 +48,14 @@ public class RoomDatabaseTestHelper {
 
     public static void insertEpisode(Episode episode, int showTvdbId, int seasonTvdbId,
             int seasonNumber, SupportSQLiteDatabase db) {
-        insertEpisode(db, episode, showTvdbId, seasonTvdbId, seasonNumber, false);
+        // Note: use version 47 as no changes before that.
+        insertEpisode(db, SgRoomDatabase.VERSION_47_SERIES_POSTER_THUMB,
+                episode, showTvdbId, seasonTvdbId, seasonNumber, false);
     }
 
     public static void insertEpisode(
             SupportSQLiteDatabase db,
+            int version,
             Episode episode,
             int showTvdbId,
             int seasonTvdbId,
@@ -63,7 +67,13 @@ public class RoomDatabaseTestHelper {
                 episode.id, seasonTvdbId, showTvdbId, seasonNumber,
                 Constants.EPISODE_UNKNOWN_RELEASE, true);
 
-        if (watched) values.put(SeriesGuideContract.Episodes.WATCHED, EpisodeFlags.WATCHED);
+        if (watched) values.put(Episodes.WATCHED, EpisodeFlags.WATCHED);
+
+        // Remove columns added in newer versions.
+        // Also check SqliteDatabaseTestHelper!
+        if (version < SgRoomDatabase.VERSION_48_EPISODE_PLAYS) {
+            values.remove(Episodes.PLAYS);
+        }
 
         db.insert(Tables.EPISODES, SQLiteDatabase.CONFLICT_REPLACE, values);
     }

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/RoomDatabaseTestHelper.java
@@ -11,6 +11,8 @@ import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
 import com.battlelancer.seriesguide.provider.SeriesGuideDatabase.Tables;
 import com.battlelancer.seriesguide.thetvdbapi.TvdbEpisodeTools;
+import com.battlelancer.seriesguide.ui.episodes.EpisodeFlags;
+import com.battlelancer.seriesguide.ui.movies.MovieDetails;
 import com.uwetrottmann.thetvdb.entities.Episode;
 
 /**
@@ -45,11 +47,29 @@ public class RoomDatabaseTestHelper {
 
     public static void insertEpisode(Episode episode, int showTvdbId, int seasonTvdbId,
             int seasonNumber, SupportSQLiteDatabase db) {
+        insertEpisode(db, episode, showTvdbId, seasonTvdbId, seasonNumber, false);
+    }
+
+    public static void insertEpisode(
+            SupportSQLiteDatabase db,
+            Episode episode,
+            int showTvdbId,
+            int seasonTvdbId,
+            int seasonNumber,
+            boolean watched
+    ) {
         ContentValues values = new ContentValues();
         TvdbEpisodeTools.toContentValues(episode, values,
                 episode.id, seasonTvdbId, showTvdbId, seasonNumber,
                 Constants.EPISODE_UNKNOWN_RELEASE, true);
 
+        if (watched) values.put(SeriesGuideContract.Episodes.WATCHED, EpisodeFlags.WATCHED);
+
         db.insert(Tables.EPISODES, SQLiteDatabase.CONFLICT_REPLACE, values);
+    }
+
+    public static void insertMovie(SupportSQLiteDatabase db, MovieDetails movieDetails) {
+        db.insert(Tables.MOVIES, SQLiteDatabase.CONFLICT_REPLACE,
+                movieDetails.toContentValuesInsert());
     }
 }

--- a/app/src/androidTest/java/com/battlelancer/seriesguide/provider/SqliteDatabaseTestHelper.java
+++ b/app/src/androidTest/java/com/battlelancer/seriesguide/provider/SqliteDatabaseTestHelper.java
@@ -2,10 +2,11 @@ package com.battlelancer.seriesguide.provider;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import com.battlelancer.seriesguide.Constants;
 import com.battlelancer.seriesguide.dataliberation.model.Show;
 import com.battlelancer.seriesguide.model.SgSeason;
+import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
 import com.battlelancer.seriesguide.provider.SeriesGuideDatabase.Tables;
@@ -18,10 +19,10 @@ import com.uwetrottmann.thetvdb.entities.Episode;
 public class SqliteDatabaseTestHelper {
 
     public static void insertShow(Show show, SQLiteDatabase db) {
-        ContentValues values = show.toContentValues(InstrumentationRegistry.getTargetContext(),
+        ContentValues values = show.toContentValues(ApplicationProvider.getApplicationContext(),
                 true);
 
-        // Remove columns added after version 42.
+        // Remove columns added after version 42 (last version before Room).
         // Also check RoomDatabaseTestHelper!
         values.remove(Shows.SLUG);
         values.remove(Shows.POSTER_SMALL);
@@ -46,6 +47,10 @@ public class SqliteDatabaseTestHelper {
         TvdbEpisodeTools.toContentValues(episode, values,
                 episode.id, seasonTvdbId, showTvdbId, seasonNumber,
                 Constants.EPISODE_UNKNOWN_RELEASE, true);
+
+        // Remove columns added after version 42 (last version before Room).
+        // Also check RoomDatabaseTestHelper!
+        values.remove(Episodes.PLAYS);
 
         db.insertWithOnConflict(Tables.EPISODES, null, values,
                 SQLiteDatabase.CONFLICT_REPLACE);

--- a/app/src/endpoints/episodes-v2-rest.discovery
+++ b/app/src/endpoints/episodes-v2-rest.discovery
@@ -134,6 +134,10 @@
     "isInCollection": {
      "type": "boolean"
     },
+    "plays": {
+     "format": "int32",
+     "type": "integer"
+    },
     "seasonNumber": {
      "format": "int32",
      "type": "integer"

--- a/app/src/endpoints/movies-v2-rest.discovery
+++ b/app/src/endpoints/movies-v2-rest.discovery
@@ -131,6 +131,10 @@
     "isWatched": {
      "type": "boolean"
     },
+    "plays": {
+     "format": "int32",
+     "type": "integer"
+    },
     "tmdbId": {
      "format": "int32",
      "type": "integer"

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.java
@@ -398,6 +398,7 @@ public class JsonExportTask extends AsyncTask<Void, Integer, Integer> {
             int episodeFlag = episodeDb.watched;
             episodeExport.watched = EpisodeTools.isWatched(episodeFlag);
             episodeExport.skipped = EpisodeTools.isSkipped(episodeFlag);
+            episodeExport.plays = episodeDb.plays;
             episodeExport.collected = episodeDb.collected;
             episodeExport.title = episodeDb.title;
             episodeExport.firstAired = episodeDb.firstReleasedMs;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
@@ -91,7 +91,7 @@ public class Episode {
                 ? EpisodeFlags.SKIPPED : watched
                 ? EpisodeFlags.WATCHED : EpisodeFlags.UNWATCHED);
         int playsValue;
-        if (plays >= 1) {
+        if (watched && plays >= 1) {
             playsValue = plays;
         } else {
             playsValue = watched ? 1 : 0;

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
@@ -25,6 +25,8 @@ public class Episode {
 
     public boolean watched;
 
+    public int plays;
+
     public boolean skipped;
 
     public boolean collected;
@@ -73,6 +75,13 @@ public class Episode {
         values.put(Episodes.WATCHED, skipped
                 ? EpisodeFlags.SKIPPED : watched
                 ? EpisodeFlags.WATCHED : EpisodeFlags.UNWATCHED);
+        int playsValue;
+        if (plays >= 1) {
+            playsValue = plays;
+        } else {
+            playsValue = watched ? 1 : 0;
+        }
+        values.put(Episodes.PLAYS, playsValue);
 
         values.put(Episodes.DIRECTORS, directors != null ? directors : "");
         values.put(Episodes.GUESTSTARS, gueststars != null ? gueststars : "");

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/model/Episode.java
@@ -2,6 +2,7 @@
 package com.battlelancer.seriesguide.dataliberation.model;
 
 import android.content.ContentValues;
+import androidx.annotation.Nullable;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Seasons;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Shows;
@@ -15,9 +16,11 @@ public class Episode {
 
     public int episode;
 
+    @Nullable
     @SerializedName("episode_absolute")
-    public int episodeAbsolute;
+    public Integer episodeAbsolute;
 
+    @Nullable
     public String title;
 
     @SerializedName("first_aired")
@@ -31,6 +34,7 @@ public class Episode {
 
     public boolean collected;
 
+    @Nullable
     @SerializedName("imdb_id")
     public String imdbId;
 
@@ -38,22 +42,31 @@ public class Episode {
      * Full dump only follows.
      */
 
+    @Nullable
     @SerializedName("episode_dvd")
-    public double episodeDvd;
+    public Double episodeDvd;
 
+    @Nullable
     public String overview;
 
+    @Nullable
     public String image;
 
+    @Nullable
     public String writers;
 
+    @Nullable
     public String gueststars;
 
+    @Nullable
     public String directors;
 
-    public double rating;
-    public int rating_votes;
-    public int rating_user;
+    @Nullable
+    public Double rating;
+    @Nullable
+    public Integer rating_votes;
+    @Nullable
+    public Integer rating_user;
 
     @SerializedName("last_edited")
     public long lastEdited;
@@ -64,9 +77,11 @@ public class Episode {
 
         values.put(Episodes.TITLE, title != null ? title : "");
         values.put(Episodes.OVERVIEW, overview);
-        values.put(Episodes.NUMBER, episode >= 0 ? episode : 0);
+        values.put(Episodes.NUMBER, Math.max(episode, 0));
         values.put(Episodes.SEASON, seasonNumber);
-        values.put(Episodes.DVDNUMBER, episodeDvd >= 0 ? episodeDvd : 0);
+        if (episodeDvd != null) {
+            values.put(Episodes.DVDNUMBER, episodeDvd >= 0 ? episodeDvd : 0);
+        }
 
         values.put(Shows.REF_SHOW_ID, showTvdbId);
         values.put(Seasons.REF_SEASON_ID, seasonTvdbId);
@@ -91,14 +106,22 @@ public class Episode {
         values.put(Episodes.FIRSTAIREDMS, firstAired);
         values.put(Episodes.COLLECTED, collected ? 1 : 0);
 
-        values.put(Episodes.RATING_GLOBAL, (rating >= 0 && rating <= 10) ? rating : 0);
-        values.put(Episodes.RATING_VOTES, rating_votes >= 0 ? rating_votes : 0);
-        values.put(Episodes.RATING_USER,
-                (rating_user >= 0 && rating_user <= 10) ? rating_user : 0);
+        if (rating != null) {
+            values.put(Episodes.RATING_GLOBAL, (rating >= 0 && rating <= 10) ? rating : 0);
+        }
+        if (rating_votes != null) {
+            values.put(Episodes.RATING_VOTES, rating_votes >= 0 ? rating_votes : 0);
+        }
+        if (rating_user != null) {
+            values.put(Episodes.RATING_USER, (rating_user >= 0 && rating_user <= 10)
+                    ? rating_user : 0);
+        }
 
         values.put(Episodes.IMDBID, imdbId != null ? imdbId : "");
         values.put(Episodes.LAST_EDITED, lastEdited);
-        values.put(Episodes.ABSOLUTE_NUMBER, episodeAbsolute >= 0 ? episodeAbsolute : 0);
+        if (episodeAbsolute != null) {
+            values.put(Episodes.ABSOLUTE_NUMBER, episodeAbsolute >= 0 ? episodeAbsolute : 0);
+        }
 
         // set default values
         values.put(Episodes.LAST_UPDATED, 0);

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/EpisodeInfo.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/EpisodeInfo.java
@@ -19,19 +19,23 @@ public final class EpisodeInfo extends Table {
 
   public int season() { int o = __offset(4); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
   public int number() { int o = __offset(6); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public int plays() { int o = __offset(8); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
 
   public static int createEpisodeInfo(FlatBufferBuilder builder,
       int season,
-      int number) {
-    builder.startTable(2);
+      int number,
+      int plays) {
+    builder.startTable(3);
+    EpisodeInfo.addPlays(builder, plays);
     EpisodeInfo.addNumber(builder, number);
     EpisodeInfo.addSeason(builder, season);
     return EpisodeInfo.endEpisodeInfo(builder);
   }
 
-  public static void startEpisodeInfo(FlatBufferBuilder builder) { builder.startTable(2); }
+  public static void startEpisodeInfo(FlatBufferBuilder builder) { builder.startTable(3); }
   public static void addSeason(FlatBufferBuilder builder, int season) { builder.addInt(0, season, 0); }
   public static void addNumber(FlatBufferBuilder builder, int number) { builder.addInt(1, number, 0); }
+  public static void addPlays(FlatBufferBuilder builder, int plays) { builder.addInt(2, plays, 0); }
   public static int endEpisodeInfo(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/HexagonEpisodeJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/HexagonEpisodeJob.java
@@ -106,6 +106,9 @@ public class HexagonEpisodeJob extends BaseNetworkEpisodeJob {
             episode.setEpisodeNumber(episodeInfo.number());
             if (isWatchedNotCollected) {
                 episode.setWatchedFlag(jobInfo.flagValue());
+                // Always upload (regardless if watched, skipped or not watched).
+                // Also ensures legacy data slowly adds the new plays field.
+                episode.setPlays(episodeInfo.plays());
             } else {
                 episode.setIsInCollection(EpisodeTools.isCollected(jobInfo.flagValue()));
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.java
@@ -112,7 +112,7 @@ public abstract class BaseEpisodesJob extends BaseJob implements FlagJob {
         return true;
     }
 
-    protected boolean applyDatabaseChanges(Context context, Uri uri) {
+    protected boolean applyDatabaseChanges(@NonNull Context context, @NonNull Uri uri) {
         ContentValues values = new ContentValues();
         values.put(getDatabaseColumnToUpdate(), getFlagValue());
         int updated = context.getContentResolver()

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.java
@@ -91,12 +91,9 @@ public abstract class BaseEpisodesJob extends BaseJob implements FlagJob {
         }
 
         // apply local updates
-        ContentValues values = new ContentValues();
-        values.put(getDatabaseColumnToUpdate(), getFlagValue());
-        int updated = context.getContentResolver()
-                .update(uri, values, getDatabaseSelection(), null);
-        if (updated < 0) {
-            return false; // -1 means error
+        boolean updated = applyDatabaseChanges(context, uri);
+        if (!updated) {
+            return false;
         }
 
         // persist network job after successful local updates
@@ -113,6 +110,14 @@ public abstract class BaseEpisodesJob extends BaseJob implements FlagJob {
                 .notifyChange(SeriesGuideContract.ListItems.CONTENT_WITH_DETAILS_URI, null);
 
         return true;
+    }
+
+    protected boolean applyDatabaseChanges(Context context, Uri uri) {
+        ContentValues values = new ContentValues();
+        values.put(getDatabaseColumnToUpdate(), getFlagValue());
+        int updated = context.getContentResolver()
+                .update(uri, values, getDatabaseSelection(), null);
+        return updated >= 0; // -1 means error
     }
 
     @Nullable

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeCollectedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeCollectedJob.java
@@ -22,6 +22,11 @@ public class EpisodeCollectedJob extends EpisodeBaseJob {
         return SeriesGuideContract.Episodes.COLLECTED;
     }
 
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        return plays; // Collected change does not change plays.
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedJob.java
@@ -106,7 +106,7 @@ public class EpisodeWatchedJob extends EpisodeBaseJob {
     }
 
     @Override
-    protected boolean applyDatabaseChanges(Context context, Uri uri) {
+    protected boolean applyDatabaseChanges(@NonNull Context context, @NonNull Uri uri) {
         EpisodeHelper episodeHelper = SgRoomDatabase.getInstance(context).episodeHelper();
         int flagValue = getFlagValue();
 

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedJob.java
@@ -128,6 +128,23 @@ public class EpisodeWatchedJob extends EpisodeBaseJob {
         return rowsUpdated == 1;
     }
 
+    /**
+     * Note: this should mirror the planned database changes in {@link #applyDatabaseChanges(Context, Uri)}.
+     */
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        switch (getFlagValue()) {
+            case EpisodeFlags.SKIPPED:
+                return plays;
+            case EpisodeFlags.WATCHED:
+                return plays + 1;
+            case EpisodeFlags.UNWATCHED:
+                return 0;
+            default:
+                throw new IllegalArgumentException("Flag value not supported");
+        }
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedUpToJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedUpToJob.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.appwidget.ListWidgetProvider
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes
+import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.ui.episodes.EpisodeFlags
 
 /**
@@ -51,6 +52,12 @@ class EpisodeWatchedUpToJob(
         ListWidgetProvider.notifyDataChanged(context)
 
         return true
+    }
+
+    override fun applyDatabaseChanges(context: Context, uri: Uri): Boolean {
+        val rowsUpdated = SgRoomDatabase.getInstance(context).episodeHelper()
+            .setWatchedUpToAndAddPlay(showTvdbId, episodeFirstAired, episodeNumber)
+        return rowsUpdated >= 0 // -1 means error
     }
 
     override fun getConfirmationText(context: Context): String {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedUpToJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeWatchedUpToJob.kt
@@ -60,6 +60,13 @@ class EpisodeWatchedUpToJob(
         return rowsUpdated >= 0 // -1 means error
     }
 
+    /**
+     * Note: this should mirror the planned database changes in [applyDatabaseChanges].
+     */
+    override fun getPlaysForNetworkJob(plays: Int): Int {
+        return plays + 1
+    }
+
     override fun getConfirmationText(context: Context): String {
         return context.getString(R.string.action_watched_up_to)
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonCollectedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonCollectedJob.java
@@ -27,6 +27,11 @@ public class SeasonCollectedJob extends SeasonBaseJob {
         return SeriesGuideContract.Episodes.COLLECTED;
     }
 
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        return plays; // Collected change does not change plays.
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonWatchedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonWatchedJob.java
@@ -112,6 +112,23 @@ public class SeasonWatchedJob extends SeasonBaseJob {
         return rowsUpdated >= 0; // -1 means error.
     }
 
+    /**
+     * Note: this should mirror the planned database changes in {@link #applyDatabaseChanges(Context, Uri)}.
+     */
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        switch (getFlagValue()) {
+            case EpisodeFlags.SKIPPED:
+                return plays;
+            case EpisodeFlags.WATCHED:
+                return plays + 1;
+            case EpisodeFlags.UNWATCHED:
+                return 0;
+            default:
+                throw new IllegalArgumentException("Flag value not supported");
+        }
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowCollectedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowCollectedJob.java
@@ -25,6 +25,11 @@ public class ShowCollectedJob extends ShowBaseJob {
         return SeriesGuideContract.Episodes.COLLECTED;
     }
 
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        return plays; // Collected change does not change plays.
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowWatchedJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowWatchedJob.java
@@ -84,6 +84,22 @@ public class ShowWatchedJob extends ShowBaseJob {
         return rowsUpdated >= 0; // -1 means error.
     }
 
+    /**
+     * Note: this should mirror the planned database changes in {@link #applyDatabaseChanges(Context, Uri)}.
+     */
+    @Override
+    protected int getPlaysForNetworkJob(int plays) {
+        switch (getFlagValue()) {
+            case EpisodeFlags.WATCHED:
+                return plays + 1;
+            case EpisodeFlags.UNWATCHED:
+                return 0;
+            default:
+                // Note: Skip not supported for whole show.
+                throw new IllegalArgumentException("Flag value not supported");
+        }
+    }
+
     @NonNull
     @Override
     public String getConfirmationText(Context context) {

--- a/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisode.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisode.java
@@ -52,6 +52,10 @@ public class SgEpisode {
 
     @ColumnInfo(name = Episodes.WATCHED)
     public int watched = 0;
+    /**
+     * The number of times an episode was watched.
+     */
+    public Integer plays = 0;
 
     @ColumnInfo(name = Episodes.DIRECTORS)
     public String directors = "";

--- a/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisode.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisode.java
@@ -52,9 +52,7 @@ public class SgEpisode {
 
     @ColumnInfo(name = Episodes.WATCHED)
     public int watched = 0;
-    /**
-     * The number of times an episode was watched.
-     */
+    @ColumnInfo(name = Episodes.PLAYS)
     public Integer plays = 0;
 
     @ColumnInfo(name = Episodes.DIRECTORS)

--- a/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisodeForTraktSync.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/model/SgEpisodeForTraktSync.kt
@@ -1,0 +1,17 @@
+package com.battlelancer.seriesguide.model
+
+import androidx.room.ColumnInfo
+import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes
+
+data class SgEpisodeForTraktSync(
+    @ColumnInfo(name = Episodes._ID)
+    val tvdbId: Int,
+    @ColumnInfo(name = Episodes.NUMBER)
+    var number: Int,
+    @ColumnInfo(name = Episodes.WATCHED)
+    val watched: Int,
+    @ColumnInfo(name = Episodes.PLAYS)
+    val plays: Int?,
+    @ColumnInfo(name = Episodes.COLLECTED)
+    val collected: Boolean
+)

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
@@ -10,6 +10,7 @@ import androidx.room.RawQuery;
 import androidx.sqlite.db.SupportSQLiteQuery;
 import com.battlelancer.seriesguide.model.EpisodeWithShow;
 import com.battlelancer.seriesguide.model.SgEpisode;
+import com.battlelancer.seriesguide.model.SgEpisodeForTraktSync;
 import com.battlelancer.seriesguide.model.SgEpisodeSeasonAndShow;
 import com.battlelancer.seriesguide.model.SgShow;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
@@ -38,6 +39,9 @@ public interface EpisodeHelper {
      */
     @Query("SELECT * FROM episodes WHERE season_id=:seasonTvdbId ORDER BY episodenumber ASC")
     List<SgEpisode> getSeason(int seasonTvdbId);
+
+    @Query("SELECT _id, episodenumber, watched, plays, episode_collected FROM episodes WHERE season_id=:seasonTvdbId")
+    List<SgEpisodeForTraktSync> getSeasonForTraktSync(int seasonTvdbId);
 
     @Nullable
     @Query("SELECT season_id, season, series_id  FROM episodes WHERE _id=:episodeTvdbId")

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
@@ -13,6 +13,7 @@ import com.battlelancer.seriesguide.model.SgEpisode;
 import com.battlelancer.seriesguide.model.SgEpisodeSeasonAndShow;
 import com.battlelancer.seriesguide.model.SgShow;
 import com.battlelancer.seriesguide.provider.SeriesGuideContract.Episodes;
+import java.util.List;
 
 /**
  * Data Access Object for the episodes table.
@@ -31,6 +32,12 @@ public interface EpisodeHelper {
      */
     @Query("SELECT * FROM " + EPISODES + " WHERE _id=:episodeTvdbId")
     SgEpisode getEpisode(int episodeTvdbId);
+
+    /**
+     * Gets episodes of season ordered by episode number.
+     */
+    @Query("SELECT * FROM episodes WHERE season_id=:seasonTvdbId ORDER BY episodenumber ASC")
+    List<SgEpisode> getSeason(int seasonTvdbId);
 
     @Nullable
     @Query("SELECT season_id, season, series_id  FROM episodes WHERE _id=:episodeTvdbId")

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
@@ -100,4 +100,31 @@ public interface EpisodeHelper {
             + " AND " + Episodes.SELECTION_HAS_RELEASE_DATE
             + " AND " + Episodes.SELECTION_UNWATCHED)
     int setSeasonSkipped(int seasonTvdbId, long currentTimePlusOneHour);
+
+    /**
+     * Sets watched or skipped episodes, excluding specials,
+     * as not watched and removes all plays.
+     * <p>
+     * Note: keep in sync with ShowWatchedJob.
+     */
+    @Query("UPDATE episodes SET watched = 0, plays = 0 WHERE series_id=:showTvdbId"
+            + " AND " + Episodes.SELECTION_WATCHED_OR_SKIPPED
+            + " AND " + Episodes.SELECTION_NO_SPECIALS)
+    int setShowNotWatchedAndRemovePlays(int showTvdbId);
+
+    /**
+     * Sets not watched or skipped episodes, released until within the hour, excluding specials,
+     * as watched and adds play.
+     * <p>
+     * Does NOT mark watched episodes again to avoid adding a new play (Trakt and local).
+     * <p>
+     * Note: keep in sync with ShowWatchedJob.
+     */
+    @Query("UPDATE episodes SET watched = 1, plays = plays + 1 WHERE series_id=:showTvdbId"
+            + " AND episode_firstairedms <= :currentTimePlusOneHour"
+            + " AND " + Episodes.SELECTION_HAS_RELEASE_DATE
+            + " AND " + Episodes.SELECTION_UNWATCHED_OR_SKIPPED
+            + " AND " + Episodes.SELECTION_NO_SPECIALS)
+    int setShowWatchedAndAddPlay(int showTvdbId, long currentTimePlusOneHour);
+
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
@@ -25,6 +25,12 @@ public interface EpisodeHelper {
     @Query("SELECT * FROM " + EPISODES + " LIMIT 1")
     SgEpisode getEpisode();
 
+    /**
+     * For testing: Get single episode.
+     */
+    @Query("SELECT * FROM " + EPISODES + " WHERE _id=:episodeTvdbId")
+    SgEpisode getEpisode(int episodeTvdbId);
+
     @Nullable
     @Query("SELECT season_id, season, series_id  FROM episodes WHERE _id=:episodeTvdbId")
     SgEpisodeSeasonAndShow getEpisodeMinimal(int episodeTvdbId);

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/EpisodeHelper.java
@@ -12,6 +12,7 @@ import com.battlelancer.seriesguide.model.EpisodeWithShow;
 import com.battlelancer.seriesguide.model.SgEpisode;
 import com.battlelancer.seriesguide.model.SgEpisodeSeasonAndShow;
 import com.battlelancer.seriesguide.model.SgShow;
+import com.battlelancer.seriesguide.ui.episodes.EpisodeFlags;
 
 /**
  * Data Access Object for the episodes table.
@@ -37,4 +38,15 @@ public interface EpisodeHelper {
 
     @RawQuery(observedEntities = {SgEpisode.class, SgShow.class})
     DataSource.Factory<Integer, EpisodeWithShow> getEpisodesWithShow(SupportSQLiteQuery query);
+
+    @Query("UPDATE episodes SET watched = " + EpisodeFlags.WATCHED
+            + ", plays = plays + 1 WHERE _id=:episodeTvdbId")
+    int setWatchedAndAddPlay(int episodeTvdbId);
+
+    @Query("UPDATE episodes SET watched = " + EpisodeFlags.UNWATCHED
+            + ", plays = 0 WHERE _id=:episodeTvdbId")
+    int setNotWatchedAndRemovePlays(int episodeTvdbId);
+
+    @Query("UPDATE episodes SET watched = " + EpisodeFlags.SKIPPED + " WHERE _id=:episodeTvdbId")
+    int setSkipped(int episodeTvdbId);
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/MovieHelper.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/MovieHelper.java
@@ -18,6 +18,12 @@ import java.util.List;
 @Dao
 public interface MovieHelper {
 
+    /**
+     * For testing: get single movie.
+     */
+    @Query("SELECT * FROM movies WHERE movies_tmdbid=:tmdbId")
+    SgMovie getMovie(int tmdbId);
+
     @Query("SELECT movies_tmdbid FROM movies WHERE "
             + "(movies_incollection=1 OR movies_inwatchlist=1 OR movies_watched=1)"
             + " AND ("

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
@@ -389,6 +389,11 @@ public class SeriesGuideContract {
         String WATCHED = "watched";
 
         /**
+         * The number of times an episode was watched.
+         */
+        String PLAYS = "plays";
+
+        /**
          * Whether an episode has been collected in digital, physical form.
          */
         String COLLECTED = "episode_collected";

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SeriesGuideContract.java
@@ -534,7 +534,7 @@ public class SeriesGuideContract {
         String WATCHED = "movies_watched";
 
         /**
-         * Currently unused.
+         * The number of times a movie was watched.
          */
         String PLAYS = "movies_plays";
 

--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SgRoomDatabase.kt
@@ -126,8 +126,6 @@ abstract class SgRoomDatabase : RoomDatabase() {
                 database.execSQL("ALTER TABLE episodes ADD COLUMN plays INTEGER;")
                 database.execSQL("UPDATE episodes SET plays = 1 WHERE watched = 1;")
                 database.execSQL("UPDATE episodes SET plays = 0 WHERE watched != 1;")
-                // Movies already have plays column, but also prepopulate it.
-                database.execSQL("UPDATE movies SET movies_plays = 1 WHERE movies_watched = 1;")
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbEpisodeTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/thetvdbapi/TvdbEpisodeTools.kt
@@ -225,6 +225,7 @@ class TvdbEpisodeTools constructor(
             if (forInsert) {
                 // set default values
                 values.put(Episodes.WATCHED, 0)
+                values.put(Episodes.PLAYS, 0)
                 values.put(Episodes.COLLECTED, 0)
             }
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools.java
@@ -13,7 +13,6 @@ import com.uwetrottmann.trakt5.entities.BaseSeason;
 import com.uwetrottmann.trakt5.entities.BaseShow;
 import java.math.BigDecimal;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -55,13 +54,13 @@ public class TraktTools {
     }
 
     @NonNull
-    public static HashSet<Integer> buildTraktEpisodesMap(List<BaseEpisode> episodes) {
-        HashSet<Integer> traktEpisodesMap = new HashSet<>(episodes.size());
+    public static HashMap<Integer, BaseEpisode> buildTraktEpisodesMap(List<BaseEpisode> episodes) {
+        HashMap<Integer, BaseEpisode> traktEpisodesMap = new HashMap<>(episodes.size());
         for (BaseEpisode episode : episodes) {
             if (episode.number == null) {
                 continue; // trakt episode misses required data, skip.
             }
-            traktEpisodesMap.add(episode.number);
+            traktEpisodesMap.put(episode.number, episode);
         }
         return traktEpisodesMap;
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
@@ -550,8 +550,8 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
                     R.drawable.ic_watch_black_24dp);
         }
         bindingButtons.buttonEpisodeWatched.setOnClickListener(v -> onToggleWatched());
-        bindingButtons.buttonEpisodeWatched
-                .setText(isWatched ? R.string.state_watched : R.string.action_watched);
+        int plays = cursor.getInt(DetailsQuery.PLAYS);
+        bindingButtons.buttonEpisodeWatched.setText(getWatchedButtonText(isWatched, plays));
         CheatSheet.setup(bindingButtons.buttonEpisodeWatched, isWatched ? R.string.action_unwatched
                 : R.string.action_watched);
 
@@ -590,6 +590,18 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
                     .setText(isSkipped ? R.string.state_skipped : R.string.action_skip);
             CheatSheet.setup(bindingButtons.buttonEpisodeSkip,
                     isSkipped ? R.string.action_dont_skip : R.string.action_skip);
+        }
+    }
+
+    private String getWatchedButtonText(boolean isWatched, int plays) {
+        if (isWatched) {
+            if (plays <= 1) {
+                return getString(R.string.state_watched);
+            } else {
+                return getString(R.string.state_watched_multiple_format, plays);
+            }
+        } else {
+            return getString(R.string.action_watched);
         }
     }
 
@@ -746,6 +758,7 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
                 Episodes.RATING_VOTES,
                 Episodes.RATING_USER,
                 Episodes.WATCHED,
+                Episodes.PLAYS,
                 Episodes.COLLECTED,
                 Episodes.LAST_EDITED,
                 Shows.REF_SHOW_ID,
@@ -774,13 +787,14 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
         int RATING_VOTES = 15;
         int RATING_USER = 16;
         int WATCHED = 17;
-        int COLLECTED = 18;
-        int LAST_EDITED = 19;
-        int SHOW_ID = 20;
-        int SHOW_IMDBID = 21;
-        int SHOW_TITLE = 22;
-        int SHOW_RUNTIME = 23;
-        int SHOW_LANGUAGE = 24;
-        int SHOW_SLUG = 25;
+        int PLAYS = 18;
+        int COLLECTED = 19;
+        int LAST_EDITED = 20;
+        int SHOW_ID = 21;
+        int SHOW_IMDBID = 22;
+        int SHOW_TITLE = 23;
+        int SHOW_RUNTIME = 24;
+        int SHOW_LANGUAGE = 25;
+        int SHOW_SLUG = 26;
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/episodes/EpisodeDetailsFragment.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.PopupMenu;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.widget.TextViewCompat;
@@ -240,8 +241,31 @@ public class EpisodeDetailsFragment extends Fragment implements EpisodeActionsCo
      */
     private void onToggleWatched() {
         boolean watched = EpisodeTools.isWatched(episodeFlag);
-        changeEpisodeFlag(watched ? EpisodeFlags.UNWATCHED : EpisodeFlags.WATCHED);
+        if (watched) {
+            View anchor = bindingButtons.buttonEpisodeWatched;
+            PopupMenu popupMenu = new PopupMenu(anchor.getContext(), anchor);
+            popupMenu.inflate(R.menu.watched_episode_popup_menu);
+            popupMenu.setOnMenuItemClickListener(watchedEpisodePopupMenuListener);
+            popupMenu.show();
+        } else {
+            changeEpisodeFlag(EpisodeFlags.WATCHED);
+        }
     }
+
+    private final PopupMenu.OnMenuItemClickListener watchedEpisodePopupMenuListener = item -> {
+        int itemId = item.getItemId();
+        if (itemId == R.id.watched_episode_popup_menu_watch_again) {
+            // Multiple plays are for supporters only.
+            if (!Utils.hasAccessToX(requireContext())) {
+                Utils.advertiseSubscription(requireContext());
+            } else {
+                changeEpisodeFlag(EpisodeFlags.WATCHED);
+            }
+        } else if (itemId == R.id.watched_episode_popup_menu_set_not_watched) {
+            changeEpisodeFlag(EpisodeFlags.UNWATCHED);
+        }
+        return true;
+    };
 
     /**
      * If episode was skipped, flags as unwatched. Otherwise, flags as skipped.

--- a/app/src/main/res/menu/watched_episode_popup_menu.xml
+++ b/app/src/main/res/menu/watched_episode_popup_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/watched_episode_popup_menu_watch_again"
+        android:title="@string/action_watched" />
+    <item
+        android:id="@+id/watched_episode_popup_menu_set_not_watched"
+        android:title="@string/action_unwatched" />
+
+</menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -116,6 +116,7 @@
     <string name="action_watched">تعيين كمشاهد</string>
     <string name="action_unwatched">تعيين كغير مشاهد</string>
     <string name="state_watched">تمت مشاهدتها</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">تم تخطيه</string>
     <string name="state_in_collection">قيد التحصيل</string>
     <string name="state_on_watchlist">في قائمة المراقبة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Гледано</string>
     <string name="action_unwatched">Негледан</string>
     <string name="state_watched">Гледано</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Vist</string>
     <string name="action_unwatched">No vist</string>
     <string name="state_watched">Vist</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">Zhlédnuto</string>
     <string name="action_unwatched">Nezhlédnuto</string>
     <string name="state_watched">Zhlédnuto</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Markér som set</string>
     <string name="action_unwatched">Markér som ikke set</string>
     <string name="state_watched">Set</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Sprunget over</string>
     <string name="state_in_collection">I samling</string>
     <string name="state_on_watchlist">På overvågningsliste</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Angesehen markieren</string>
     <string name="action_unwatched">Nicht angesehen markieren</string>
     <string name="state_watched">Angesehen</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Angesehen (%d)</string>
     <string name="state_skipped">Übersprungen</string>
     <string name="state_in_collection">In Sammlung</string>
     <string name="state_on_watchlist">Auf Merkliste</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Έχει παρακολουθηθεί </string>
     <string name="action_unwatched">Δεν παρακολούθησα</string>
     <string name="state_watched">Είδατε</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Παραλείφθηκε</string>
     <string name="state_in_collection">Σε συλλογή</string>
     <string name="state_on_watchlist">Σε λίστα παρακολούθησης</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Visto</string>
     <string name="action_unwatched">No visto</string>
     <string name="state_watched">Visto</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Omitido</string>
     <string name="state_in_collection">En colección</string>
     <string name="state_on_watchlist">En la lista de visualización</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">تنظیم به تماشا شده</string>
     <string name="action_unwatched">تنظیم به تماشا نشده</string>
     <string name="state_watched">تماشا شده</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Katsottu</string>
     <string name="action_unwatched">Katsomaton</string>
     <string name="state_watched">Katsottu</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Ohitettu</string>
     <string name="state_in_collection">Kokoelmassa</string>
     <string name="state_on_watchlist"> Seurantalistalla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Vu</string>
     <string name="action_unwatched">Pas vu</string>
     <string name="state_watched">Vu</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">Collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Marcar como visto</string>
     <string name="action_unwatched">Marcar como non visto</string>
     <string name="state_watched">Vistas</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -113,6 +113,7 @@
     <string name="action_watched">Pogledano</string>
     <string name="action_unwatched">Nije pogledano</string>
     <string name="state_watched">Pogledano</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Megnézve</string>
     <string name="action_unwatched">Még nem láttam</string>
     <string name="state_watched">Megnézve</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">Ubah ditonton</string>
     <string name="action_unwatched">Ubah belum ditonton</string>
     <string name="state_watched">Ditonton</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Visto</string>
     <string name="action_unwatched">Non visto</string>
     <string name="state_watched">Visto</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Saltato</string>
     <string name="state_in_collection">In collezione</string>
     <string name="state_on_watchlist">Da vedere</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">נצפה</string>
     <string name="action_unwatched">לא נצפה</string>
     <string name="state_watched">נצפה</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">דילוג</string>
     <string name="state_in_collection">באוסף</string>
     <string name="state_on_watchlist">ברשימת הצפייה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">視聴済に設定</string>
     <string name="action_unwatched">未視聴に設定</string>
     <string name="state_watched">視聴済</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">スキップ済</string>
     <string name="state_in_collection">コレクション内</string>
     <string name="state_on_watchlist">ウォッチリスト内</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">시청함</string>
     <string name="action_unwatched">시청하지 않음</string>
     <string name="state_watched">시청한 목록</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Гледано</string>
     <string name="action_unwatched">Негледано</string>
     <string name="state_watched">Гледано</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Sett</string>
     <string name="action_unwatched">Ikke sett</string>
     <string name="state_watched">Sett</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Bekeken</string>
     <string name="action_unwatched">Niet bekeken</string>
     <string name="state_watched">Bekeken</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Overgeslagen</string>
     <string name="state_in_collection">In collectie</string>
     <string name="state_on_watchlist">Op volglijst</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">Ust. obejrzane</string>
     <string name="action_unwatched">Ust. nieobejrzane</string>
     <string name="state_watched">Obejrzane</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Pominięty</string>
     <string name="state_in_collection">W kolekcji</string>
     <string name="state_on_watchlist">Na liście do obejrzenia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Marcar como assistido</string>
     <string name="action_unwatched">Marcar como não assistido</string>
     <string name="state_watched">Assistido</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Ignorado</string>
     <string name="state_in_collection">Na coleção</string>
     <string name="state_on_watchlist">Na lista</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Marcar como visto</string>
     <string name="action_unwatched">Marcado como não visto</string>
     <string name="state_watched">Visto</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Ignorado</string>
     <string name="state_in_collection">Na Coleção</string>
     <string name="state_on_watchlist">Na Lista dos que Desejo Ver</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -113,6 +113,7 @@
     <string name="action_watched">Vizionat</string>
     <string name="action_unwatched">Marchează nevizionat</string>
     <string name="state_watched">Vizionat</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">Просмотрен</string>
     <string name="action_unwatched">Не просмотрено</string>
     <string name="state_watched">Просмотрено</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">пропущено</string>
     <string name="state_in_collection">В коллекции</string>
     <string name="state_on_watchlist">В списке просмотра</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">Označiť ako videné</string>
     <string name="action_unwatched">Označiť ako nevidené</string>
     <string name="state_watched">Videné</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -113,6 +113,7 @@
     <string name="action_watched">Одгледано</string>
     <string name="action_unwatched">Није одгледано</string>
     <string name="state_watched">Одгледано</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">Sett</string>
     <string name="action_unwatched">Markera som osedd</string>
     <string name="state_watched">Sedda</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Hoppat över</string>
     <string name="state_in_collection">I samling</string>
     <string name="state_on_watchlist">På bevakningslistan</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">பார்த்த அமை</string>
     <string name="action_unwatched">இல்லை பார்த்த அமை</string>
     <string name="state_watched">பார்த்த</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">ดูแล้ว</string>
     <string name="action_unwatched">ยังไม่ได้ดู</string>
     <string name="state_watched">ดูแล้ว</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">ข้ามแล้ว</string>
     <string name="state_in_collection">ในคลังเก็บ</string>
     <string name="state_on_watchlist">ในรายการที่อยากดู</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_watched">İzlendi yap</string>
     <string name="action_unwatched">İzlenmedi yap</string>
     <string name="state_watched">İzlenmiş</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -114,6 +114,7 @@
     <string name="action_watched">Переглянуто</string>
     <string name="action_unwatched">Не переглянуто</string>
     <string name="state_watched">Переглянуто</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Пропущено</string>
     <string name="state_in_collection">В колекції</string>
     <string name="state_on_watchlist">В списку перегляду</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">标记为已观看</string>
     <string name="action_unwatched">标记为未观看</string>
     <string name="state_watched">已观看</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">已跳过</string>
     <string name="state_in_collection">在收藏中</string>
     <string name="state_on_watchlist">在待看列表中</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -111,6 +111,7 @@
     <string name="action_watched">設為已觀看</string>
     <string name="action_unwatched">設為尚未觀看</string>
     <string name="state_watched">已看過</string>
+    <string name="state_watched_multiple_format" comment="Like watched, but includes the number of times in parentheses. Example: Watched (3)">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="action_watched">Set watched</string>
     <string name="action_unwatched">Set not watched</string>
     <string name="state_watched">Watched</string>
+    <string name="state_watched_multiple_format">Watched (%d)</string>
     <string name="state_skipped">Skipped</string>
     <string name="state_in_collection">In collection</string>
     <string name="state_on_watchlist">On watchlist</string>

--- a/flatbuffers/SgJobInfo.fbs
+++ b/flatbuffers/SgJobInfo.fbs
@@ -14,6 +14,7 @@ table SgJobInfo {
 table EpisodeInfo {
     season:int;
     number:int;
+    plays:int;
 }
 
 root_type SgJobInfo;


### PR DESCRIPTION
- [x] Database + Migration Test
- [x] Import/Export
- [x] Watched jobs
- [x] UI
- [x] Trakt sync
  - [x] Test
- [x] Cloud + cloud sync
- [x] Translations

---
Notes
- Only count of plays is stored, not the actual time of the play.
- Unsupported: episode has multiple plays, upload all plays on initial sync with Trakt.
  - This is only an issue if switching from no sync or Cloud to Trakt. Multiple plays will then be lost.

---
Future PRs
- [ ] Change next episode selection if multiple plays
  - Support re-watching in overview then as well.
- [x] Movies (probably separate PR/release) #751