### PR TITLE
ButterKnife: try if using R2 shuts up lint warning (no, it doesn't).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ if (project.file('google-services.json').exists()) {
     apply plugin: 'com.google.gms.google-services'
 }
 apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.jakewharton.butterknife'
 
 android {
     compileSdkVersion versions.compileSdk

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/DataLiberationFragment.java
@@ -21,6 +21,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
 import com.battlelancer.seriesguide.R;
+import com.battlelancer.seriesguide.R2;
 import com.battlelancer.seriesguide.util.Utils;
 import com.google.android.material.snackbar.Snackbar;
 import org.greenrobot.eventbus.EventBus;
@@ -74,26 +75,26 @@ public class DataLiberationFragment extends Fragment implements
     private static final int REQUEST_CODE_MOVIES_EXPORT_URI = 7;
     private static final int REQUEST_CODE_MOVIES_IMPORT_URI = 8;
 
-    @BindView(R.id.textViewDataLibShowsExportFile) TextView textShowsExportFile;
-    @BindView(R.id.buttonDataLibShowsExportFile) Button buttonShowsExportFile;
-    @BindView(R.id.textViewDataLibListsExportFile) TextView textListsExportFile;
-    @BindView(R.id.buttonDataLibListsExportFile) Button buttonListsExportFile;
-    @BindView(R.id.textViewDataLibMoviesExportFile) TextView textMoviesExportFile;
-    @BindView(R.id.buttonDataLibMoviesExportFile) Button buttonMoviesExportFile;
+    @BindView(R2.id.textViewDataLibShowsExportFile) TextView textShowsExportFile;
+    @BindView(R2.id.buttonDataLibShowsExportFile) Button buttonShowsExportFile;
+    @BindView(R2.id.textViewDataLibListsExportFile) TextView textListsExportFile;
+    @BindView(R2.id.buttonDataLibListsExportFile) Button buttonListsExportFile;
+    @BindView(R2.id.textViewDataLibMoviesExportFile) TextView textMoviesExportFile;
+    @BindView(R2.id.buttonDataLibMoviesExportFile) Button buttonMoviesExportFile;
 
-    @BindView(R.id.checkBoxDataLibShows) CheckBox checkBoxShows;
-    @BindView(R.id.checkBoxDataLibLists) CheckBox checkBoxLists;
-    @BindView(R.id.checkBoxDataLibMovies) CheckBox checkBoxMovies;
-    @BindView(R.id.textViewDataLibShowsImportFile) TextView textShowsImportFile;
-    @BindView(R.id.buttonDataLibShowsImportFile) Button buttonShowsImportFile;
-    @BindView(R.id.textViewDataLibListsImportFile) TextView textListsImportFile;
-    @BindView(R.id.buttonDataLibListsImportFile) Button buttonListsImportFile;
-    @BindView(R.id.textViewDataLibMoviesImportFile) TextView textMoviesImportFile;
-    @BindView(R.id.buttonDataLibMoviesImportFile) Button buttonMoviesImportFile;
+    @BindView(R2.id.checkBoxDataLibShows) CheckBox checkBoxShows;
+    @BindView(R2.id.checkBoxDataLibLists) CheckBox checkBoxLists;
+    @BindView(R2.id.checkBoxDataLibMovies) CheckBox checkBoxMovies;
+    @BindView(R2.id.textViewDataLibShowsImportFile) TextView textShowsImportFile;
+    @BindView(R2.id.buttonDataLibShowsImportFile) Button buttonShowsImportFile;
+    @BindView(R2.id.textViewDataLibListsImportFile) TextView textListsImportFile;
+    @BindView(R2.id.buttonDataLibListsImportFile) Button buttonListsImportFile;
+    @BindView(R2.id.textViewDataLibMoviesImportFile) TextView textMoviesImportFile;
+    @BindView(R2.id.buttonDataLibMoviesImportFile) Button buttonMoviesImportFile;
 
-    @BindView(R.id.buttonDataLibImport) Button buttonImport;
-    @BindView(R.id.progressBarDataLib) ProgressBar progressBar;
-    @BindView(R.id.checkBoxDataLibFullDump) CheckBox checkBoxFullDump;
+    @BindView(R2.id.buttonDataLibImport) Button buttonImport;
+    @BindView(R2.id.progressBarDataLib) ProgressBar progressBar;
+    @BindView(R2.id.checkBoxDataLibFullDump) CheckBox checkBoxFullDump;
 
     @Nullable private Integer type;
     private AsyncTask<Void, Integer, Integer> dataLibTask;

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ buildscript {
         // https://firebase.google.com/support/release-notes/android
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
+        classpath "com.jakewharton:butterknife-gradle-plugin:${versions.butterknife}"
     }
 }
 


### PR DESCRIPTION
Keep this if moving to view binding before Android Gradle Plugin 5.x fails.