### PR TITLE
Use Countly to report some network request errors.

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -204,6 +204,31 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+Licensed under the MIT License
+------------------------------
+
+countly-sdk-android (https://github.com/Countly/countly-sdk-android)
+Copyright (c) 2012, 2013 Countly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 Crashlytics (https://firebase.google.com/docs/crashlytics/)
 -----------------------------------------------------------
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,8 @@ android {
         buildConfigField("String", "TRAKT_CLIENT_SECRET", propertyOrEmpty("SG_TRAKT_CLIENT_SECRET"))
         buildConfigField("String", "IMAGE_CACHE_URL", propertyOrNull("SG_IMAGE_CACHE_URL"))
         buildConfigField("String", "IMAGE_CACHE_SECRET", propertyOrEmpty("SG_IMAGE_CACHE_SECRET"))
+        buildConfigField("String", "COUNT_URL", propertyOrNull("SG_COUNT_URL"))
+        buildConfigField("String", "COUNT_SECRET", propertyOrEmpty("SG_COUNT_SECRET"))
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -207,6 +209,9 @@ dependencies {
 
     // Crashlytics
     implementation "com.google.firebase:firebase-crashlytics:${versions.crashlytics}"
+
+    // Countly
+    implementation "ly.count.android:sdk:20.11.0"
 
     // Google Play Services
     // https://developers.google.com/android/guides/releases

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -19,6 +19,7 @@ import com.battlelancer.seriesguide.modules.TvdbModule
 import com.battlelancer.seriesguide.service.NotificationService
 import com.battlelancer.seriesguide.settings.AppSettings
 import com.battlelancer.seriesguide.settings.DisplaySettings
+import com.battlelancer.seriesguide.util.Errors
 import com.battlelancer.seriesguide.util.SgPicassoRequestHandler
 import com.battlelancer.seriesguide.util.ThemeUtils
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException
@@ -183,6 +184,9 @@ class SgApp : Application() {
         val isSendErrors = AppSettings.isSendErrorReports(this)
         Timber.d("Turning error reporting %s", if (isSendErrors) "ON" else "OFF")
         FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(isSendErrors)
+        if (isSendErrors) {
+            Errors.setUpCounter(this)
+        }
 
         if (AppSettings.isUserDebugModeEnabled(this)) {
             // debug drawer logging

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
@@ -24,6 +24,7 @@ import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity;
 import com.battlelancer.seriesguide.sync.AccountUtils;
 import com.battlelancer.seriesguide.ui.preferences.MoreOptionsActivity;
 import com.battlelancer.seriesguide.ui.stats.StatsActivity;
+import com.battlelancer.seriesguide.util.Errors;
 import com.battlelancer.seriesguide.util.Utils;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.snackbar.Snackbar;
@@ -140,6 +141,9 @@ public abstract class BaseTopActivity extends BaseMessageActivity {
         if (Utils.hasAccessToX(this) && HexagonSettings.shouldValidateAccount(this)) {
             onShowCloudAccountWarning();
         }
+
+        // Trigger session start only for top activities.
+        Errors.onSessionStart();
     }
 
     @Override
@@ -174,6 +178,10 @@ public abstract class BaseTopActivity extends BaseMessageActivity {
         if (snackbar != null && snackbar.isShown()) {
             snackbar.dismiss();
         }
+
+        // Trigger session stop only for top activities so errors are sent frequently
+        // (when all are stopped).
+        Errors.onSessionStop();
     }
 
     @Override

--- a/app/src/main/java/com/battlelancer/seriesguide/util/Errors.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/Errors.kt
@@ -1,28 +1,39 @@
 package com.battlelancer.seriesguide.util
 
 import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Build
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.battlelancer.seriesguide.BuildConfig
 import com.battlelancer.seriesguide.thetvdbapi.TvdbException
 import com.battlelancer.seriesguide.traktapi.SgTrakt
 import com.google.api.client.http.HttpResponseException
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import ly.count.android.sdk.Countly
+import ly.count.android.sdk.CountlyConfig
+import ly.count.android.sdk.DeviceId
 import retrofit2.Response
 import timber.log.Timber
 import java.io.InterruptedIOException
 import java.net.ConnectException
 import java.net.UnknownHostException
+import java.util.UUID
+
 
 class Errors {
 
     companion object {
+
+        private lateinit var appVersion: String
+        private var isCounterAvailable = false
 
         /**
          * Returns null instead of crashing when Firebase is not configured, e.g. for vanilla debug
          * builds and CI builds.
          */
         @SuppressLint("LogNotTimber")
-        fun getReporter() : FirebaseCrashlytics? {
+        fun getReporter(): FirebaseCrashlytics? {
             return try {
                 FirebaseCrashlytics.getInstance()
             } catch (e: Exception) {
@@ -34,6 +45,45 @@ class Errors {
                 )
                 return null
             }
+        }
+
+        fun setUpCounter(application: Application) {
+            appVersion = Utils.getVersion(application.applicationContext)
+
+            @Suppress("SENSELESS_COMPARISON")
+            if (BuildConfig.COUNT_URL != null) {
+                if (Countly.sharedInstance().isInitialized) return
+
+                val config = CountlyConfig(
+                    application,
+                    BuildConfig.COUNT_SECRET,
+                    BuildConfig.COUNT_URL
+                )
+                    // Use random UUID as Countly OpenUDID might use ANDROID_ID.
+                    .setDeviceId(UUID.randomUUID().toString())
+                    .setIdMode(DeviceId.Type.DEVELOPER_SUPPLIED)
+//                .setLoggingEnabled(BuildConfig.DEBUG) // Spams logs, only enable if needed.
+                    .setRequiresConsent(true)
+                    // Only allow sending of events.
+                    .setConsentEnabled(arrayOf(Countly.CountlyFeatureNames.events))
+                Countly.sharedInstance().init(config)
+                isCounterAvailable = true
+            }
+        }
+
+        private fun getCounter(): Countly? {
+            return if (isCounterAvailable) Countly.sharedInstance() else null
+        }
+
+        @JvmStatic
+        fun onSessionStart() {
+            // Don't need an activity name, sessions not sent, just to ensure events are sent.
+            getCounter()?.onStart(null)
+        }
+
+        @JvmStatic
+        fun onSessionStop() {
+            getCounter()?.onStop()
         }
 
         /**
@@ -141,10 +191,27 @@ class Errors {
 
             Timber.e(throwable, action)
 
-            if (response.code == 404) return // do not send 404 to Crashlytics
+            if (response.code == 404) return // Do not report 404 responses.
 
-            getReporter()?.setCustomKey("action", action)
-            getReporter()?.recordException(throwable)
+//            getReporter()?.setCustomKey("action", action)
+//            getReporter()?.recordException(throwable)
+
+            getCounter()?.also {
+                val messageOrNone = when {
+                    message != null -> message
+                    response.message.isNotEmpty() -> response.message
+                    else -> "none"
+                }
+                it.events().recordEvent(
+                    "$action ${response.code}",
+                    mapOf(
+                        "message" to messageOrNone,
+                        "android" to Build.VERSION.RELEASE,
+                        "version" to appVersion,
+                        "device" to Build.MODEL
+                    )
+                )
+            }
         }
 
         /**


### PR DESCRIPTION
Try to get reports by error code so it's easier to share feedback to Trakt about what's going wrong. This is harder to do on Crashlytics, so hopefully running a Countly instance is better.

- [x] Check why Countly instance not reachable via IPv6.
- [ ] Update privacy policy if this leaves beta.
  - Records ~IP address~ (can turn off Request Logs plugin!), anonymous installation identifier, device model and Android version.
  - Data kept for at most 90 days.
- [ ] Check if server can handle load.