### PR TITLE
Statistics for shows I've finished watching

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/provider/SgShow2Helper.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/provider/SgShow2Helper.kt
@@ -94,6 +94,12 @@ interface SgShow2Helper {
     @Query("SELECT _id, series_status, series_next, series_runtime FROM sg_show")
     fun getStats(): List<SgShow2Stats>
 
+    @Query("SELECT count(series_id) FROM (SELECT series_id, series_status, sum(case when episode_watched = '0' then 1 else 0 end) as episodes_unwatched FROM sg_episode LEFT OUTER JOIN sg_show ON sg_episode.series_id = sg_show._id GROUP BY series_id) WHERE episodes_unwatched = 0 AND series_status IN (0, 3)")
+    fun countShowsFinishedWatching(): Int
+
+    @Query("SELECT count(series_id) FROM (SELECT series_id, series_status, sum(case when episode_watched = '0' then 1 else 0 end) as episodes_unwatched FROM sg_episode LEFT OUTER JOIN sg_show ON sg_episode.series_id = sg_show._id WHERE episode_season_number != 0 GROUP BY series_id) WHERE episodes_unwatched = 0 AND series_status IN (0, 3)")
+    fun countShowsFinishedWatchingWithoutSpecials(): Int
+
     @Update(entity = SgShow2::class)
     fun updateShowNextEpisode(updates: List<SgShow2NextEpisodeUpdate>): Int
 

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsFragment.kt
@@ -49,6 +49,8 @@ class StatsFragment : Fragment() {
         binding.errorView.setButtonClickListener { loadStats() }
 
         // set some views invisible so they can be animated in once stats are computed
+        binding.textViewShowsFinished.visibility = View.INVISIBLE
+        binding.progressBarShowsFinished.visibility = View.INVISIBLE
         binding.textViewShowsWithNextEpisode.visibility = View.INVISIBLE
         binding.progressBarShowsWithNextEpisode.visibility = View.INVISIBLE
         binding.textViewShowsContinuing.visibility = View.INVISIBLE
@@ -71,6 +73,7 @@ class StatsFragment : Fragment() {
 
         // set up long-press to copy text to clipboard (d-pad friendly vs text selection)
         binding.textViewShows.copyTextToClipboardOnLongClick()
+        binding.textViewShowsFinished.copyTextToClipboardOnLongClick()
         binding.textViewShowsWithNextEpisode.copyTextToClipboardOnLongClick()
         binding.textViewShowsContinuing.copyTextToClipboardOnLongClick()
         binding.textViewEpisodes.copyTextToClipboardOnLongClick()
@@ -151,6 +154,21 @@ class StatsFragment : Fragment() {
 
         // all shows
         binding.textViewShows.text = format.format(stats.shows.toLong())
+
+        // shows finished
+        binding.progressBarShowsFinished.apply {
+            max = stats.shows
+            progress = stats.showsFinished
+            visibility = View.VISIBLE
+        }
+
+        binding.textViewShowsFinished.apply {
+            text = getString(
+                R.string.shows_finished,
+                format.format(stats.showsFinished.toLong())
+            )
+            visibility = View.VISIBLE
+        }
 
         // shows with next episodes
         binding.progressBarShowsWithNextEpisode.apply {

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsFragment.kt
@@ -325,6 +325,10 @@ class StatsFragment : Fragment() {
         val format = NumberFormat.getIntegerInstance()
 
         val shows = format.format(currentStats.shows.toLong())
+        val showsFinished = getString(
+            R.string.shows_finished,
+            format.format(currentStats.showsFinished.toLong())
+        )
         val showsWithNext = getString(
             R.string.shows_with_next,
             format.format(currentStats.showsWithNextEpisodes.toLong())
@@ -343,6 +347,7 @@ class StatsFragment : Fragment() {
         val showStats =
             "${getString(R.string.app_name)} ${getString(R.string.statistics)}\n\n" +
                     "$shows ${getString(R.string.statistics_shows)}\n" +
+                    "$showsFinished\n" +
                     "$showsWithNext\n" +
                     "$showsContinuing\n\n" +
                     "$episodes ${getString(R.string.statistics_episodes)}\n" +

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/stats/StatsViewModel.kt
@@ -117,10 +117,15 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
     ): Map<Long, Int> {
         val showStats = SgRoomDatabase.getInstance(getApplication()).sgShow2Helper().getStats()
 
+        var finished = 0
         var continuing = 0
         var withnext = 0
         val showRuntimes = mutableMapOf<Long, Int>()
         for (show in showStats) {
+            // count finished shows
+            if (show.status == ShowTools.Status.ENDED && show.nextEpisode.isNullOrBlank()) {
+                finished++
+            }
             // count continuing shows
             if (show.status == ShowTools.Status.CONTINUING) {
                 continuing++
@@ -134,6 +139,7 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
         }
 
         stats.shows = showStats.size
+        stats.showsFinished = finished
         stats.showsContinuing = continuing
         stats.showsWithNextEpisodes = withnext
         return showRuntimes
@@ -161,6 +167,7 @@ class StatsViewModel(application: Application) : AndroidViewModel(application) {
 
 data class Stats(
     var shows: Int = 0,
+    var showsFinished: Int = 0,
     var showsContinuing: Int = 0,
     var showsWithNextEpisodes: Int = 0,
     var episodes: Int = 0,

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -45,29 +45,6 @@
             tools:text="42" />
 
         <ProgressBar
-            android:id="@+id/progressBarShowsFinished"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textViewShows"
-            tools:progress="60" />
-
-        <TextView
-            android:id="@+id/textViewShowsFinished"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:background="?attr/selectableItemBackground"
-            android:focusable="true"
-            android:textAppearance="@style/TextAppearance.SeriesGuide.Subtitle1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/progressBarShowsFinished"
-            tools:text="3 finished" />
-
-        <ProgressBar
             android:id="@+id/progressBarShowsWithNextEpisode"
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
@@ -75,7 +52,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textViewShowsFinished"
+            app:layout_constraintTop_toBottomOf="@id/textViewShows"
             tools:progress="60" />
 
         <TextView
@@ -113,6 +90,29 @@
             app:layout_constraintTop_toBottomOf="@+id/progressBarShowsContinuing"
             tools:text="10 continuing" />
 
+        <ProgressBar
+            android:id="@+id/progressBarShowsFinished"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewShowsContinuing"
+            tools:progress="60" />
+
+        <TextView
+            android:id="@+id/textViewShowsFinished"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:background="?attr/selectableItemBackground"
+            android:focusable="true"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Subtitle1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/progressBarShowsFinished"
+            tools:text="3 finished watching" />
+
         <TextView
             android:id="@+id/labelStatsEpisodes"
             android:layout_width="wrap_content"
@@ -121,7 +121,7 @@
             android:text="@string/episodes"
             android:textAppearance="@style/TextAppearance.SeriesGuide.Headline6"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textViewShowsContinuing" />
+            app:layout_constraintTop_toBottomOf="@+id/textViewShowsFinished" />
 
         <TextView
             android:id="@+id/textViewEpisodes"

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -45,6 +45,29 @@
             tools:text="42" />
 
         <ProgressBar
+            android:id="@+id/progressBarShowsFinished"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewShows"
+            tools:progress="60" />
+
+        <TextView
+            android:id="@+id/textViewShowsFinished"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:background="?attr/selectableItemBackground"
+            android:focusable="true"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Subtitle1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/progressBarShowsFinished"
+            tools:text="3 finished" />
+
+        <ProgressBar
             android:id="@+id/progressBarShowsWithNextEpisode"
             style="?android:attr/progressBarStyleHorizontal"
             android:layout_width="match_parent"
@@ -52,7 +75,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textViewShows"
+            app:layout_constraintTop_toBottomOf="@id/textViewShowsFinished"
             tools:progress="60" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="statistics_shows">shows</string>
     <string name="statistics_episodes">episodes</string>
     <string name="statistics_movies">movies</string>
+    <string name="shows_finished" translatable="false">%s finished watching</string>
     <string name="shows_with_next">%s with next episodes</string>
     <string name="shows_continuing">%s continuing</string>
     <string name="episodes_watched">%s watched</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,7 +276,7 @@
     <string name="statistics_shows">shows</string>
     <string name="statistics_episodes">episodes</string>
     <string name="statistics_movies">movies</string>
-    <string name="shows_finished" translatable="false">%s finished watching</string>
+    <string name="shows_finished">%s finished watching</string>
     <string name="shows_with_next">%s with next episodes</string>
     <string name="shows_continuing">%s continuing</string>
     <string name="episodes_watched">%s watched</string>


### PR DESCRIPTION
Relates to #773 

https://github.com/UweTrottmann/SeriesGuide/issues/773#issuecomment-821980582

I'm up for discussion on this statistics enhancement. This can also be solved by joining sg_show, sg_season, and sg_episode tables and extracting more granular information than just relying on the "next episode" info from the stats object.

Also, I added a string key and I don't yet know about the process of translations. For now I marked the string key as non-translatable. This is why this is a draft pull request. New translation will probably be injected by the translation tool. I'd like to ask for help on this part.