### PR TITLE
Switch to Firebase Auth for email sign-in on non-Google devices

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -238,7 +238,7 @@ dependencies {
 
     // Import the Firebase BoM
     implementation(platform("com.google.firebase:firebase-bom:27.1.0"))
-    // Firebase Sign-In
+    // Firebase Sign-In https://github.com/firebase/FirebaseUI-Android/releases
     implementation("com.firebaseui:firebase-ui-auth:7.1.1")
 
     // Crashlytics

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -236,13 +236,14 @@ dependencies {
     implementation("com.github.lenguyenthanh.debugdrawer:debugdrawer-actions:$debugDrawerVersion")
     implementation("com.github.lenguyenthanh.debugdrawer:debugdrawer-timber:$debugDrawerVersion")
 
+    // Import the Firebase BoM
+    implementation(platform("com.google.firebase:firebase-bom:27.1.0"))
+    // Firebase Sign-In
+    implementation("com.firebaseui:firebase-ui-auth:7.1.1")
+
     // Crashlytics
     // https://firebase.google.com/support/release-notes/android
     implementation("com.google.firebase:firebase-crashlytics:18.1.0")
-
-    // Google Play Services
-    // https://developers.google.com/android/guides/releases
-    implementation("com.google.android.gms:play-services-auth:19.0.0")
 
     // App Engine
     // https://github.com/googleapis/google-api-java-client/releases

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudEndpointUtils.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudEndpointUtils.kt
@@ -25,8 +25,9 @@ object CloudEndpointUtils {
     @Suppress("SimplifyBooleanWithConstants")
     private val USE_LOCAL_VERSION = false && BuildConfig.DEBUG
 
+    // FIXME Revert to stable API before going to production
     @Suppress("SimplifyBooleanWithConstants")
-    private val USE_STAGING_VERSION = false && BuildConfig.DEBUG
+    private val USE_STAGING_VERSION = true && BuildConfig.DEBUG
 
     private const val ROOT_URL_STAGING = "https://staging-dot-optical-hexagon-364.appspot.com"
 

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
@@ -208,11 +208,19 @@ class CloudSetupFragment : Fragment() {
                                 errorMessage = null
                             }
                             else -> {
-                                errorMessage = ex.message
-                                Errors.logAndReport(
-                                    ACTION_SIGN_IN,
-                                    HexagonAuthError.build(ACTION_SIGN_IN, ex)
-                                )
+                                if (ex.errorCode == ErrorCodes.DEVELOPER_ERROR
+                                    && !hexagonTools.isGoogleSignInAvailable) {
+                                    // Note: If trying to sign-in with email already used with
+                                    // Google Sign-In on other device, fails to fall back to
+                                    // Google Sign-In because Play Services is not available.
+                                    errorMessage = getString(R.string.hexagon_signin_google_only)
+                                } else {
+                                    errorMessage = ex.message
+                                    Errors.logAndReport(
+                                        ACTION_SIGN_IN,
+                                        HexagonAuthError.build(ACTION_SIGN_IN, ex)
+                                    )
+                                }
                             }
                         }
                     } else {

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
@@ -17,6 +17,7 @@ import com.battlelancer.seriesguide.databinding.FragmentCloudSetupBinding
 import com.battlelancer.seriesguide.sync.SgSyncAdapter
 import com.battlelancer.seriesguide.sync.SyncProgress
 import com.battlelancer.seriesguide.traktapi.ConnectTraktActivity
+import com.battlelancer.seriesguide.ui.SeriesGuidePreferences
 import com.battlelancer.seriesguide.util.Errors
 import com.battlelancer.seriesguide.util.Utils
 import com.battlelancer.seriesguide.util.safeShow
@@ -222,6 +223,7 @@ class CloudSetupFragment : Fragment() {
         val intent = AuthUI.getInstance()
             .createSignInIntentBuilder()
             .setAvailableProviders(HexagonTools.firebaseSignInProviders)
+            .setTheme(SeriesGuidePreferences.THEME)
             .build()
 
         signInWithFirebase.launch(intent)

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
@@ -126,7 +126,7 @@ class CloudSetupFragment : Fragment() {
 
         // check if the user is still signed in
         val signInTask = AuthUI.getInstance()
-            .silentSignIn(requireContext(), HexagonTools.firebaseSignInProviders)
+            .silentSignIn(requireContext(), hexagonTools.firebaseSignInProviders)
         if (signInTask.isSuccessful) {
             // If the user's cached credentials are valid, the OptionalPendingResult will be "done"
             // and the GoogleSignInResult will be available instantly.
@@ -232,7 +232,8 @@ class CloudSetupFragment : Fragment() {
         // Create and launch sign-in intent
         val intent = AuthUI.getInstance()
             .createSignInIntentBuilder()
-            .setAvailableProviders(HexagonTools.firebaseSignInProviders)
+            .setAvailableProviders(hexagonTools.firebaseSignInProviders)
+            .setIsSmartLockEnabled(hexagonTools.isGoogleSignInAvailable)
             .setTheme(SeriesGuidePreferences.THEME)
             .build()
 

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
@@ -197,22 +197,32 @@ class CloudSetupFragment : Fragment() {
                     changeAccount(null, null)
                 } else {
                     val errorMessage: String?
-                    when (val errorCode = response.error?.errorCode ?: 0) {
-                        ErrorCodes.NO_NETWORK -> {
-                            errorMessage = getString(R.string.offline)
+                    val ex = response.error
+                    if (ex != null) {
+                        when (ex.errorCode) {
+                            ErrorCodes.NO_NETWORK -> {
+                                errorMessage = getString(R.string.offline)
+                            }
+                            ErrorCodes.PLAY_SERVICES_UPDATE_CANCELLED -> {
+                                // user cancelled, show no error message
+                                errorMessage = null
+                            }
+                            else -> {
+                                errorMessage = ex.message
+                                Errors.logAndReport(
+                                    ACTION_SIGN_IN,
+                                    HexagonAuthError.build(ACTION_SIGN_IN, ex)
+                                )
+                            }
                         }
-                        ErrorCodes.PLAY_SERVICES_UPDATE_CANCELLED -> {
-                            // user cancelled, show no error message
-                            errorMessage = null
-                        }
-                        else -> {
-                            errorMessage = errorCode.toString()
-                            Errors.logAndReport(
-                                ACTION_SIGN_IN,
-                                HexagonAuthError(ACTION_SIGN_IN, errorMessage)
-                            )
-                        }
+                    } else {
+                        errorMessage = "Unknown error"
+                        Errors.logAndReport(
+                            ACTION_SIGN_IN,
+                            HexagonAuthError(ACTION_SIGN_IN, errorMessage)
+                        )
                     }
+
                     changeAccount(null, errorMessage)
                 }
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/FirebaseHttpRequestInitializer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/FirebaseHttpRequestInitializer.kt
@@ -1,0 +1,38 @@
+package com.battlelancer.seriesguide.backend
+
+import com.google.android.gms.tasks.Tasks
+import com.google.api.client.http.HttpExecuteInterceptor
+import com.google.api.client.http.HttpRequest
+import com.google.api.client.http.HttpRequestInitializer
+import com.google.firebase.auth.FirebaseAuthInvalidUserException
+import com.google.firebase.auth.FirebaseUser
+
+class FirebaseHttpRequestInitializer : HttpRequestInitializer {
+
+    var firebaseUser: FirebaseUser? = null
+
+    override fun initialize(request: HttpRequest?) {
+        request?.interceptor = FirebaseHttpExecuteInterceptor(this)
+    }
+
+    @Throws(FirebaseAuthInvalidUserException::class)
+    fun getJwtToken(): String? {
+        val firebaseUser = firebaseUser ?: return null
+
+        // https://firebase.google.com/docs/auth/admin/verify-id-tokens
+        val task = firebaseUser.getIdToken(true)
+
+        return Tasks.await(task).token
+    }
+}
+
+private class FirebaseHttpExecuteInterceptor(
+    private val firebaseHttpRequestInitializer: FirebaseHttpRequestInitializer
+) : HttpExecuteInterceptor {
+
+    override fun intercept(request: HttpRequest?) {
+        val token = firebaseHttpRequestInitializer.getJwtToken()
+        request?.headers?.authorization = "Bearer $token"
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/FirebaseHttpRequestInitializer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/FirebaseHttpRequestInitializer.kt
@@ -4,8 +4,10 @@ import com.google.android.gms.tasks.Tasks
 import com.google.api.client.http.HttpExecuteInterceptor
 import com.google.api.client.http.HttpRequest
 import com.google.api.client.http.HttpRequestInitializer
+import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.FirebaseUser
+import java.io.IOException
 
 class FirebaseHttpRequestInitializer : HttpRequestInitializer {
 
@@ -31,8 +33,15 @@ private class FirebaseHttpExecuteInterceptor(
 ) : HttpExecuteInterceptor {
 
     override fun intercept(request: HttpRequest?) {
-        val token = firebaseHttpRequestInitializer.getJwtToken()
-        request?.headers?.authorization = "Bearer $token"
+        try {
+            val token = firebaseHttpRequestInitializer.getJwtToken()
+            request?.headers?.authorization = "Bearer $token"
+        } catch (e: FirebaseAuthException) {
+            // Wrap in IOException so it is caught.
+            throw FirebaseAuthIOException(e)
+        }
     }
 
 }
+
+class FirebaseAuthIOException(cause: FirebaseAuthException) : IOException(cause)

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/HexagonAuthError.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/HexagonAuthError.kt
@@ -1,10 +1,9 @@
 package com.battlelancer.seriesguide.backend
 
-import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
 import com.google.android.gms.common.api.ApiException
 
 /**
- * Error for tracking Google Sign-In failures.
+ * Error for tracking Cloud Sign-In failures.
  */
 class HexagonAuthError(action: String, failure: String, cause: Throwable?) :
     Throwable("$action: $failure", cause) {
@@ -18,19 +17,14 @@ class HexagonAuthError(action: String, failure: String, cause: Throwable?) :
         }
 
         private fun extractStatusCodeString(throwable: Throwable): String {
-            val cause = throwable.cause
-            return if (throwable is ApiException) {
-                throwable.getStatusCodeString()
-            } else if (cause != null && cause is ApiException) {
-                cause.getStatusCodeString()
+            // Prefer ApiException message if it is the direct cause.
+            val causeMessage = throwable.cause?.message
+            return if (causeMessage != null && throwable.cause is ApiException) {
+                causeMessage
             } else {
                 throwable.message ?: ""
             }
         }
     }
 
-}
-
-private fun ApiException.getStatusCodeString(): String {
-    return GoogleSignInStatusCodes.getStatusCodeString(statusCode)
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/RemoveCloudAccountDialogFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/RemoveCloudAccountDialogFragment.kt
@@ -80,7 +80,7 @@ class RemoveCloudAccountDialogFragment : AppCompatDialogFragment() {
             }
 
             // disable Hexagon integration, remove local account data
-            hexagonTools.setDisabled()
+            hexagonTools.removeAccountAndSetDisabled()
             return true
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/RemoveCloudAccountDialogFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/RemoveCloudAccountDialogFragment.kt
@@ -11,13 +11,12 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp.Companion.getServicesComponent
 import com.battlelancer.seriesguide.backend.HexagonAuthError.Companion.build
-import com.battlelancer.seriesguide.backend.HexagonTools.Companion.googleSignInOptions
 import com.battlelancer.seriesguide.backend.RemoveCloudAccountDialogFragment.AccountRemovedEvent
 import com.battlelancer.seriesguide.backend.RemoveCloudAccountDialogFragment.CanceledEvent
 import com.battlelancer.seriesguide.util.Errors.Companion.logAndReport
 import com.battlelancer.seriesguide.util.Errors.Companion.logAndReportHexagon
 import com.battlelancer.seriesguide.util.Utils
-import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.firebase.ui.auth.AuthUI
 import com.google.android.gms.tasks.Tasks
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.greenrobot.eventbus.EventBus
@@ -71,9 +70,8 @@ class RemoveCloudAccountDialogFragment : AppCompatDialogFragment() {
                 return false
             }
 
-            // de-authorize app so other clients are signed out as well
-            val googleSignInClient = GoogleSignIn.getClient(context, googleSignInOptions)
-            val task = googleSignInClient.revokeAccess()
+            // Delete Firebase account so other clients are signed out as well
+            val task = AuthUI.getInstance().delete(context)
             try {
                 Tasks.await(task)
             } catch (e: Exception) {

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.java
@@ -52,6 +52,13 @@ public class HexagonSettings {
                 .getBoolean(KEY_ENABLED, false);
     }
 
+    public static void shouldValidateAccount(Context context, boolean value) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(KEY_SHOULD_VALIDATE_ACCOUNT, value)
+                .apply();
+    }
+
     /**
      * Returns true if there is an issue with the current account and the user should be sent to the
      * setup screen.

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/NetworkJobProcessor.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/NetworkJobProcessor.java
@@ -224,8 +224,8 @@ public class NetworkJobProcessor {
     /**
      * If neither trakt or Cloud are connected, clears all remaining jobs.
      */
-    public void removeObsoleteJobs() {
-        if (shouldSendToHexagon || shouldSendToTrakt) {
+    public void removeObsoleteJobs(boolean ignoreHexagonState) {
+        if ((!ignoreHexagonState && shouldSendToHexagon) || shouldSendToTrakt) {
             return; // still signed in to either service, do not clear jobs
         }
         context.getContentResolver().delete(Jobs.CONTENT_URI, null, null);

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktAuthActivityModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktAuthActivityModel.kt
@@ -93,7 +93,7 @@ class TraktAuthActivityModel(application: Application) : AndroidViewModel(applic
             }
 
             // reset sync state before hasCredentials may return true
-            NetworkJobProcessor(getApplication()).removeObsoleteJobs()
+            NetworkJobProcessor(getApplication()).removeObsoleteJobs(false)
             PreferenceManager.getDefaultSharedPreferences(getApplication()).edit {
                 // make next sync merge local watched and collected episodes with those on trakt
                 putBoolean(TraktSettings.KEY_HAS_MERGED_EPISODES, false)

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.java
@@ -286,7 +286,7 @@ public abstract class BaseTopActivity extends BaseMessageActivity {
                     // user has dismissed warning, so disable Cloud
                     HexagonTools hexagonTools = SgApp.getServicesComponent(BaseTopActivity.this)
                             .hexagonTools();
-                    hexagonTools.setDisabled();
+                    hexagonTools.removeAccountAndSetDisabled();
                 }
             }
         }).setAction(R.string.hexagon_signin, v -> {

--- a/app/src/main/res/layout/fragment_cloud_setup.xml
+++ b/app/src/main/res/layout/fragment_cloud_setup.xml
@@ -54,21 +54,36 @@
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:layout_gravity="center_horizontal"
-            app:layout_constraintEnd_toEndOf="@+id/buttonCloudAction"
-            app:layout_constraintStart_toStartOf="@+id/buttonCloudAction"
-            app:layout_constraintTop_toBottomOf="@+id/buttonCloudAction" />
+            app:layout_constraintEnd_toEndOf="@+id/flowCloudSignInButtons"
+            app:layout_constraintStart_toStartOf="@+id/flowCloudSignInButtons"
+            app:layout_constraintTop_toBottomOf="@+id/flowCloudSignInButtons" />
 
-        <Button
-            android:id="@+id/buttonCloudAction"
-            style="@style/Widget.SeriesGuide.Button"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.helper.widget.Flow
+            android:id="@+id/flowCloudSignInButtons"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
             android:layout_marginTop="8dp"
-            android:text="@string/hexagon_signin"
+            app:constraint_referenced_ids="buttonCloudSignIn,buttonCloudSignOut"
+            app:flow_horizontalStyle="packed"
+            app:flow_wrapMode="chain"
+            app:flow_horizontalGap="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/syncStatusCloud" />
+
+        <Button
+            android:id="@+id/buttonCloudSignIn"
+            style="@style/Widget.SeriesGuide.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/hexagon_signin" />
+
+        <Button
+            android:id="@+id/buttonCloudSignOut"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/hexagon_signout" />
 
         <com.battlelancer.seriesguide.widgets.SyncStatusView
             android:id="@+id/syncStatusCloud"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -312,14 +312,15 @@
     <string name="hexagon_signin">تسجيل الدخول</string>
     <string name="hexagon_signout">تسجيل الخروج</string>
     <string name="hexagon_setup_incomplete">لم يتم إكمال إعداد سحابة تخزين دليل المسلسلات.</string>
-    <string name="hexagon_setup_fail_auth">حشاب Google الخاص بك لم يقم بعمل Check Out.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">إزالة الحساب</string>
     <string name="hexagon_remove_account_success">تم إلغاء الحساب.</string>
     <string name="hexagon_remove_account_failure">لم نستطع إزالة حسابك</string>
     <string name="hexagon_remove_account_confirmation">إزالة حسابك ستؤدي إلى إلغاء كل مسلسلاتك و افلامك من سحابة SeriesGuide. تأكد من إزالته من الأجهزة الأخرى المتصلة أيضا.</string>
     <string name="hexagon_api_queued">جار الإرسال إلى سحابة دليل المسلسلات.</string>
     <string name="hexagon_signed_out">تسجيل الخروج من SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">خطأ في تسجيل الدخول الى Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">تقديم إلى تراكت.</string>
     <string name="checkin_success_trakt">تم فحص %s على التراكت.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Вписване</string>
     <string name="hexagon_signout">Отписване</string>
     <string name="hexagon_setup_incomplete">Настройването на SeriesGuide облака не беше завършено.</string>
-    <string name="hexagon_setup_fail_auth">Профилът ви в Google е инвалиден.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Премахване на акаунт</string>
     <string name="hexagon_remove_account_success">Акаунт унищожен.</string>
     <string name="hexagon_remove_account_failure">Не може да се премахне акаунта.</string>
     <string name="hexagon_remove_account_confirmation">С премахването на акаунта ви ще се изтрият всички предавания и филми от SeriesGuide облака. Не забраявайте да го премахнете и на други свързани устройства.</string>
     <string name="hexagon_api_queued">Изпращане към SeriesGuide облака.</string>
     <string name="hexagon_signed_out">Излизане от облака SeriesGuide.</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Подаване към trakt.</string>
     <string name="checkin_success_trakt">Отметнато %s в trakt.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Inicia la sessió</string>
     <string name="hexagon_signout">Tanca la sessió</string>
     <string name="hexagon_setup_incomplete">No s\'ha pogut configurar el Cloud de SeriesGuide.</string>
-    <string name="hexagon_setup_fail_auth">El vostre compte de Google no sembla correcte.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Esborra el compte</string>
     <string name="hexagon_remove_account_success">Compte esborrat.</string>
     <string name="hexagon_remove_account_failure">No s\'ha pogut esborrar el compte.</string>
     <string name="hexagon_remove_account_confirmation">Si esborreu el vostre compte, també s\'esborraran totes les sèries i peŀlícules que tingueu al Cloud de SeriesGuide. Assegureu-vos d\'esborrar-ho dels altres dispositius on el tingueu sincronitzat.</string>
     <string name="hexagon_api_queued">Enviant a SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Has desconnectat de SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Error amb l\'inici de sessió de Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">S\'està enviant a trakt.</string>
     <string name="checkin_success_trakt">S\'ha enregistrat a %s de trakt.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">Přihlásit se</string>
     <string name="hexagon_signout">Odhlásit se</string>
     <string name="hexagon_setup_incomplete">Nastavení SeriesGuide cloudu nebylo dokončeno</string>
-    <string name="hexagon_setup_fail_auth">Nastala chyba s vaším Google účtem.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Odebrat účet</string>
     <string name="hexagon_remove_account_success">Účet vymazán.</string>
     <string name="hexagon_remove_account_failure">Nelze odebrat účet.</string>
     <string name="hexagon_remove_account_confirmation">Odebráním účtu smažete veškeré seriály a filmy ze SeriesGuide cloudu. Ujistěte se, že jste ho odebrali i na ostatních připojených zařízeních.</string>
     <string name="hexagon_api_queued">Odesílání do SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Odhlášeno z SeriesGuide Cloudu.</string>
-    <string name="hexagon_signin_fail_format">Chyba při přihlášení prostřednictvím Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Odesíláno na trakt.</string>
     <string name="checkin_success_trakt">Ohlášen u %s na traktu.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Log ind</string>
     <string name="hexagon_signout">Log ud</string>
     <string name="hexagon_setup_incomplete">Opsætning af SeriesGuide Cloud blev ikke fuldført.</string>
-    <string name="hexagon_setup_fail_auth">Der er et problem med din Google-konto.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Fjern konto</string>
     <string name="hexagon_remove_account_success">Konto slettet.</string>
     <string name="hexagon_remove_account_failure">Kunne ikke fjerne konto.</string>
     <string name="hexagon_remove_account_confirmation">Hvis du sletter din konto, slettes alle film og serier fra SeriesGuide Cloud. Sørg for også at fjerne kontoen på andre tilsluttede enheder.</string>
     <string name="hexagon_api_queued">Sender til SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Logget ud af SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Fejl i Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Sender til trakt.</string>
     <string name="checkin_success_trakt">%s tjekket ind på trakt.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Anmelden</string>
     <string name="hexagon_signout">Abmelden</string>
     <string name="hexagon_setup_incomplete">Die Einrichtung von SeriesGuide Cloud wurde nicht abgeschlossen</string>
-    <string name="hexagon_setup_fail_auth">Es gab ein Problem mit Ihrem Google Konto</string>
-    <string name="hexagon_remove_account">Konto entfernen</string>
-    <string name="hexagon_remove_account_success">Konto vaporisiert</string>
-    <string name="hexagon_remove_account_failure">Konto konnte nicht entfernt werden</string>
+    <string name="hexagon_setup_fail_auth">Ihr Konto hat keine E-Mail-Adresse</string>
+    <string name="hexagon_remove_account">Konto löschen</string>
+    <string name="hexagon_remove_account_success">Konto gelöscht</string>
+    <string name="hexagon_remove_account_failure">Konto konnte nicht gelöscht werden</string>
     <string name="hexagon_remove_account_confirmation">Dies entfernt Ihre Serien, Listen und Filme aus SeriesGuide Cloud</string>
     <string name="hexagon_api_queued">Sende an SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Von SeriesGuide Cloud abgemeldet</string>
-    <string name="hexagon_signin_fail_format">Fehler bei der Google-Anmeldung (%s)</string>
+    <string name="hexagon_signin_fail_format">Fehler beim Anmelden (%s)</string>
+    <string name="hexagon_signin_google_only">E-Mail-Adresse erfordert Anmeldung mit Google</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Sende an Trakt.</string>
     <string name="checkin_success_trakt">Auf Trakt in %s eingecheckt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Σύνδεση</string>
     <string name="hexagon_signout">Αποσύνδεση</string>
     <string name="hexagon_setup_incomplete">Η ρύθμιση του SeriesGuide cloud δεν ολοκληρώθηκε.</string>
-    <string name="hexagon_setup_fail_auth">Ο λογαριασμός σας Google δεν επαληθεύτηκε.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Αφαίρεση λογαριασμού</string>
     <string name="hexagon_remove_account_success">Ο λογαριασμός διαγράφηκε.</string>
     <string name="hexagon_remove_account_failure">Δεν ήταν δυνατή η κατάργηση του λογαριασμού.</string>
     <string name="hexagon_remove_account_confirmation">Η αφαίρεση του λογαριασμού σας θα διαγράψει όλες τις σειρές και τις ταινίες από το SeriesGuide cloud. Σιγουρευτείτε ότι θα τον αφαιρέσετε και από τις άλλες συνδεδεμένες συσκευές σας.</string>
     <string name="hexagon_api_queued">Αποστολή στο SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Αποσυνδεθείτε από το SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Σφάλμα με τη σύνδεση Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Υποβολή στο trakt.</string>
     <string name="checkin_success_trakt">Ελέγχεται σε %s στο trakt.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Ensaluti</string>
     <string name="hexagon_signout">Elsaluti</string>
     <string name="hexagon_setup_incomplete">Setting up SeriesGuide Cloud was not completed</string>
-    <string name="hexagon_setup_fail_auth">Via Google-konto ne sukcesas konekti</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Forigi konton</string>
     <string name="hexagon_remove_account_success">Konto elviŝita</string>
     <string name="hexagon_remove_account_failure">Ne povis forigi konton</string>
     <string name="hexagon_remove_account_confirmation">This will delete your shows, lists and movies from SeriesGuide Cloud</string>
     <string name="hexagon_api_queued">Sendas al SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Elsalutis el SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Eraro dum ensalutado de Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Sendado al Trakt.</string>
     <string name="checkin_success_trakt">Markis je %s je Trakt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,7 +284,7 @@
     <string name="hexagon_signin">Iniciar sesión</string>
     <string name="hexagon_signout">Cerrar sesión</string>
     <string name="hexagon_setup_incomplete">La configuración de SeriesGuide cloud no se completó.</string>
-    <string name="hexagon_setup_fail_auth">Tu cuenta de Google no es válida.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Eliminar cuenta</string>
     <string name="hexagon_remove_account_success">Cuenta borrada.</string>
     <string name="hexagon_remove_account_failure">No se pudo eliminar la cuenta.</string>
@@ -292,7 +292,8 @@
 Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="hexagon_api_queued">Enviando a SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Desconectado de SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Error con Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Enviando a trakt.</string>
     <string name="checkin_success_trakt">Registrado en %s en trakt.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">ورود</string>
     <string name="hexagon_signout">خروج از سیستم</string>
     <string name="hexagon_setup_incomplete">راه اندازی فضای ابری SeriesGuide کامل نشد.</string>
-    <string name="hexagon_setup_fail_auth">مشکل دردسترسی به حساب گوگل.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">حذف حساب</string>
     <string name="hexagon_remove_account_success">حساب حذف شد.</string>
     <string name="hexagon_remove_account_failure">قادر به حذف حساب نیست.</string>
     <string name="hexagon_remove_account_confirmation">حذف حسابتان تمام نمایش‌ها و فیلم‌ها را از فضای ابری SeriesGuide پاک می‌کند. مطمئن شوید که آن را از دیگر افزاره‌های وصل شده نیز حذف میکنید.</string>
     <string name="hexagon_api_queued">در حال ارسال به فضای ابری SeriesGuide.</string>
     <string name="hexagon_signed_out">از فضای ابری SeriesGuide خارج شدید.</string>
-    <string name="hexagon_signin_fail_format">خطا در ورود با گوگل (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">ارسال به trakt.</string>
     <string name="checkin_success_trakt">%s روی trakt ثبت شد.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Kirjaudu sisään</string>
     <string name="hexagon_signout">Kirjaudu ulos</string>
     <string name="hexagon_setup_incomplete">SeriesGuide Cloudin määrittäminen epäonnistui.</string>
-    <string name="hexagon_setup_fail_auth">Google-tilisi kanssa oli ongelmia</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Poista tili</string>
     <string name="hexagon_remove_account_success">Tili poistettu.</string>
     <string name="hexagon_remove_account_failure">Tiliä ei voitu poistaa.</string>
     <string name="hexagon_remove_account_confirmation">Tämä poistaa ohjelmasi, listasi ja elokuvasi SeriesGuide Cloudista</string>
     <string name="hexagon_api_queued">Lähetetään SeriesGuide Cloudiin.</string>
     <string name="hexagon_signed_out">Kirjauduttu ulos SeriesGuide Cloudista.</string>
-    <string name="hexagon_signin_fail_format">Virhe Google-kirjautumisessa (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Lähetetään Traktiin.</string>
     <string name="checkin_success_trakt">Kuitattu kohteeseen %s Traktissa</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Connexion</string>
     <string name="hexagon_signout">Déconnexion</string>
     <string name="hexagon_setup_incomplete">La configuration du cloud SeriesGuide n\'était pas terminée.</string>
-    <string name="hexagon_setup_fail_auth">Problème rencontré avec votre compte Google.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Supprimer le compte</string>
     <string name="hexagon_remove_account_success">Compte supprimé.</string>
     <string name="hexagon_remove_account_failure">Problème lors de la suppression du compte.</string>
     <string name="hexagon_remove_account_confirmation">Retirer votre compte supprimera tous les films et séries se trouvant sur le cloud SeriesGuide. Assurez-vous de le retirer également sur vos autres appareils connectés.</string>
     <string name="hexagon_api_queued">Envoi vers SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Déconnecté du cloud SeriesGuide.</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Envoi vers trakt.</string>
     <string name="checkin_success_trakt">Check-in de %s sur trakt effectué.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Iniciar sesión</string>
     <string name="hexagon_signout">Pechar sesión</string>
     <string name="hexagon_setup_incomplete">A configuración de SeriesGuide cloud non se completou</string>
-    <string name="hexagon_setup_fail_auth">A túa conta de Google non é válida</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Eliminar conta</string>
     <string name="hexagon_remove_account_success">Conta borrada</string>
     <string name="hexagon_remove_account_failure">Non se puido borrar a conta</string>
     <string name="hexagon_remove_account_confirmation">Isto borrará as túas series, listas e películas de SeriesGuides Cloud</string>
     <string name="hexagon_api_queued">Enviando a SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Desconectado de SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Erro ao facer login con Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Enviando a trakt.</string>
     <string name="checkin_success_trakt">Rexistrado en %s en trakt</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -291,14 +291,15 @@
     <string name="hexagon_signin">Prijava</string>
     <string name="hexagon_signout">Odjava</string>
     <string name="hexagon_setup_incomplete">Postavljanje SeriesGuide oblaka nije dovršena.</string>
-    <string name="hexagon_setup_fail_auth">Vaš Google račun nije uspio.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Ukloni račun</string>
     <string name="hexagon_remove_account_success">Račun je izbrisan.</string>
     <string name="hexagon_remove_account_failure">Nije moguće izbrisati račun.</string>
     <string name="hexagon_remove_account_confirmation">Uklanjanjem svog računa će te izbrisati sve serije i filmove sa SeriesGuide Oblaka. Ne zaboravite ih ukloniti i sa ostalih povezanih uređaja.</string>
     <string name="hexagon_api_queued">Slanje na SeriesGuide oblak.</string>
     <string name="hexagon_signed_out">Odjavljeni ste sa SeriesGuide oblaka.</string>
-    <string name="hexagon_signin_fail_format">Problem s prijavom u Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Poslano na trakt.</string>
     <string name="checkin_success_trakt">Prijavljen u %s na traktu.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Bejelentkezés</string>
     <string name="hexagon_signout">Kijelentkezés</string>
     <string name="hexagon_setup_incomplete">A SeriesGuide Cloud beállítása nem fejeződött be.</string>
-    <string name="hexagon_setup_fail_auth">A Google-fiókod hibás.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Fiók eltávolítása</string>
     <string name="hexagon_remove_account_success">Fiók törölve.</string>
     <string name="hexagon_remove_account_failure">A fiók eltávolítása sikertelen.</string>
     <string name="hexagon_remove_account_confirmation">A fiókod eltávolításával minden sorozat és film törlődni fog a SeriesGuide Cloudról. Gondoskodj minden más eszközről való törléséről is.</string>
     <string name="hexagon_api_queued">Küldés a SeriesGuide felhő tárhelyre.</string>
     <string name="hexagon_signed_out">Kijelentkezett a SeriesGuide felhő tárhelyről.</string>
-    <string name="hexagon_signin_fail_format">Hiba történt a Google Bejelentkezéssel (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Elküldés a traktnak.</string>
     <string name="checkin_success_trakt">Bejelentkezve trakttal ide: %s.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">Masuk</string>
     <string name="hexagon_signout">Keluar</string>
     <string name="hexagon_setup_incomplete">Pengaturan SeriesGuide Cloud Tidak selesai.</string>
-    <string name="hexagon_setup_fail_auth">Akun Google anda tidak melapor.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Hapus Akun</string>
     <string name="hexagon_remove_account_success">Akun dimusnahkan.</string>
     <string name="hexagon_remove_account_failure">Tidak dapat menghapus akun.</string>
     <string name="hexagon_remove_account_confirmation">Menghapus akun anda akan menghapus semua acara dan film dari SeriesGuide Cloud. Pastikan untuk menghapusnya dari perangkat terhubung lainnya juga.</string>
     <string name="hexagon_api_queued">Mengirim ke SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Keluar dari SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Mengirim ke trakt.</string>
     <string name="checkin_success_trakt">Check-in %s pada trakt.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Connettiti</string>
     <string name="hexagon_signout">Esci</string>
     <string name="hexagon_setup_incomplete">La configurazione di SeriesGuide Cloud non è stata completata.</string>
-    <string name="hexagon_setup_fail_auth">È stato riscontrato un problema con il tuo account Google.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Rimuovi l\'account</string>
     <string name="hexagon_remove_account_success">Account rimosso.</string>
     <string name="hexagon_remove_account_failure">Impossibile rimuovere l\'account.</string>
     <string name="hexagon_remove_account_confirmation">Rimuovendo il tuo account verranno eliminati tutti i film e le serie TV dalla SeriesGuide Cloud. Assicurati di rimuoverlo anche su tutti gli altri dispositivi connessi.</string>
     <string name="hexagon_api_queued">Invio a SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Disconnesso da SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Errore con l\'accesso a Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Invio a trakt.</string>
     <string name="checkin_success_trakt">Check-in di %s su trakt riuscito.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">התחבר</string>
     <string name="hexagon_signout">התנתק</string>
     <string name="hexagon_setup_incomplete">הגדרת SeriesGuide Cloud לא הושלמה.</string>
-    <string name="hexagon_setup_fail_auth">חשבון הגוגל שלך לא אומת בהצלחה.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">הסר חשבון</string>
     <string name="hexagon_remove_account_success">החשבון נמחק.</string>
     <string name="hexagon_remove_account_failure">לא ניתן להסיר את החשבון.</string>
     <string name="hexagon_remove_account_confirmation">הסרת החשבון שלך תמחק את כל התוכניות והסרטים מ-SeriesGuide Cloud. הקפד למחוק אותם גם בהתקנים מחוברים אחרים.</string>
     <string name="hexagon_api_queued">שולח ל-SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">אינך מחובר לענן SeriesGuide.</string>
-    <string name="hexagon_signin_fail_format">כניסה דרך גוגל נכשלה (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">שלח ל-trakt.</string>
     <string name="checkin_success_trakt">נעשה צ\'ק-אין ל-%s ב-trakt.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">サインイン</string>
     <string name="hexagon_signout">サインアウト</string>
     <string name="hexagon_setup_incomplete">SeriesGuide クラウドのセットアップは完了しませんでした。</string>
-    <string name="hexagon_setup_fail_auth">Google アカウントを確認できませんでした。</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">アカウントを削除</string>
     <string name="hexagon_remove_account_success">アカウントを抹消しました。</string>
     <string name="hexagon_remove_account_failure">アカウントを削除できませんでした。</string>
     <string name="hexagon_remove_account_confirmation">SeriesGuide Cloud からすべての番組や映画が削除されます</string>
     <string name="hexagon_api_queued">SeriesGuide クラウドに送信しています。</string>
     <string name="hexagon_signed_out">SeriesGuide クラウドからサインアウトします。</string>
-    <string name="hexagon_signin_fail_format">Google サインインでエラー (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Trakt に送信しています</string>
     <string name="checkin_success_trakt">Trakt で %s にチェックインしました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">로그인</string>
     <string name="hexagon_signout">로그아웃</string>
     <string name="hexagon_setup_incomplete">SeriesGuide Cloud 설정이 완료되지 않았습니다.</string>
-    <string name="hexagon_setup_fail_auth">입력한 Google 계정이 확인되지 않습니다.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">계정 삭제</string>
     <string name="hexagon_remove_account_success">계정이 삭제되었습니다</string>
     <string name="hexagon_remove_account_failure">계정을 제거할 수 없습니다</string>
     <string name="hexagon_remove_account_confirmation">계정을 삭제하면 SeriesGuide Cloud에서 모든 프로그램과 영화가 제거됩니다.</string>
     <string name="hexagon_api_queued">SeriesGuide Cloud로 전송합니다.</string>
     <string name="hexagon_signed_out">SeriesGuide Cloud에서 로그아웃함</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">trakt에 전송하고 있습니다.</string>
     <string name="checkin_success_trakt">%s을(를) trakt에 체크인하였습니다.</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Пријави се</string>
     <string name="hexagon_signout">Одјави се</string>
     <string name="hexagon_setup_incomplete">Подесувањето на SeriesGuide Cloud не е завршено.</string>
-    <string name="hexagon_setup_fail_auth">Вашата Google корисничка сметка не е валидна.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Бришење на акаунт</string>
     <string name="hexagon_remove_account_success">Корисничката смета е поништена.</string>
     <string name="hexagon_remove_account_failure">Неможе да ја избрише корисничката сметка.</string>
     <string name="hexagon_remove_account_confirmation">Отстранување на вашиот профил ќе бидат избришани сите емисии и филмови од SeriesGuide Cloud. Бидете сигурни да го отстраните како и од другите поврзани уреди.</string>
     <string name="hexagon_api_queued">Испраќање во SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Одлогирај од SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Испраќање на trakt.</string>
     <string name="checkin_success_trakt">Провери во %s на trakt.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Logg inn</string>
     <string name="hexagon_signout">Logg ut</string>
     <string name="hexagon_setup_incomplete">Oppsettet av SeriesGuide Cloud er ikke fullført.</string>
-    <string name="hexagon_setup_fail_auth">Google-kontoen sjekket ikke ut.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Fjern bruker</string>
     <string name="hexagon_remove_account_success">Konto utslettet.</string>
     <string name="hexagon_remove_account_failure">Klarte ikke fjerne kontoen.</string>
     <string name="hexagon_remove_account_confirmation">Fjerning av kontoen vil slette alle serier og filmer fra SeriesGuide Cloud. Husk å fjerne den fra andre tilkoblede enheter også.</string>
     <string name="hexagon_api_queued">Sender til SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Utlogget fra SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Feil ved Google innlogging (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Sender til trakt.</string>
     <string name="checkin_success_trakt">Sjekket inn %s på trakt.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Log in</string>
     <string name="hexagon_signout">Uitloggen</string>
     <string name="hexagon_setup_incomplete">SeriesGuide cloud instellen is niet afgerond.</string>
-    <string name="hexagon_setup_fail_auth">Uw Google-account was niet in orde</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Account verwijderen</string>
     <string name="hexagon_remove_account_success">Account vernietigd</string>
     <string name="hexagon_remove_account_failure">Kon account niet verwijderen</string>
     <string name="hexagon_remove_account_confirmation">Dit zal al uw series, lijsten en films van SeriesGuide Cloud verwijderen</string>
     <string name="hexagon_api_queued">Verzonden naar SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Afgemeld bij SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Fout tijdens Google login (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Toevoegen aan trakt.</string>
     <string name="checkin_success_trakt">Aangemeld bij %s op trakt.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">Zaloguj się</string>
     <string name="hexagon_signout">Wyloguj</string>
     <string name="hexagon_setup_incomplete">Konfiguracja chmury SeriesGuide nie została zakończona.</string>
-    <string name="hexagon_setup_fail_auth">Nie można potwierdzić Twojego konta Google.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Usuń konto</string>
     <string name="hexagon_remove_account_success">Konto zostało usunięte.</string>
     <string name="hexagon_remove_account_failure">Usuwanie konta nie powiodło się.</string>
     <string name="hexagon_remove_account_confirmation">Usunięcie konta spowoduje usunięcie wszystkich seriali i filmów z chmury SeriesGuide. Upewnij się, że dane te zostały usunięte także z pozostałych podłączonych urządzeń.</string>
     <string name="hexagon_api_queued">Wysłanie do chmury SeriesGuide.</string>
     <string name="hexagon_signed_out">Wylogowano z SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Błąd logowania przez Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Wysyłanie do trakt.</string>
     <string name="checkin_success_trakt">%s oznaczono jako oglądane na trakt.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Entrar</string>
     <string name="hexagon_signout">Sair</string>
     <string name="hexagon_setup_incomplete">Não foi possível configurar o SeriesGuide Cloud.</string>
-    <string name="hexagon_setup_fail_auth">Falha na verificação da conta do Google.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Remover conta</string>
     <string name="hexagon_remove_account_success">Conta removida</string>
     <string name="hexagon_remove_account_failure">Não foi possível remover a conta.</string>
     <string name="hexagon_remove_account_confirmation">Isto apagará suas séries, listas e filmes do SeriesGuide Cloud</string>
     <string name="hexagon_api_queued">Enviando ao SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Desconectado do SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Erro ao Fazer Login com o Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Enviando ao trakt.</string>
     <string name="checkin_success_trakt">Feito check-in de %s no trakt.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Conectar</string>
     <string name="hexagon_signout">Desconectar</string>
     <string name="hexagon_setup_incomplete">A configuração do SeriesGuide Cloud não foi concluída.</string>
-    <string name="hexagon_setup_fail_auth">Falha na verificação da conta do Google.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Remover conta</string>
     <string name="hexagon_remove_account_success">Conta suprimida.</string>
     <string name="hexagon_remove_account_failure">Não foi possível remover a conta.</string>
     <string name="hexagon_remove_account_confirmation">Ao remover a tua conta todas as séries e filmes serão removidos do servidor SeriesGuide Cloud. Certifica-te que removes a tua conta também noutros dispositivos.</string>
     <string name="hexagon_api_queued">A enviar para o SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Desconectado do SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Erro ao Iniciar Sessão com o Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">A submeter ao Trakt.</string>
     <string name="checkin_success_trakt">Deu entrada a %s no Trakt</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -291,14 +291,15 @@
     <string name="hexagon_signin">Conectare</string>
     <string name="hexagon_signout">Deconectare</string>
     <string name="hexagon_setup_incomplete">Setarea Series Guide cloud nu a putut fi finalizată.</string>
-    <string name="hexagon_setup_fail_auth">Contul dumneavoastră de Google nu poate fi verificat.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Șterge contul</string>
     <string name="hexagon_remove_account_success">Contul a fost șters.</string>
     <string name="hexagon_remove_account_failure">Nu se poate șterge contul.</string>
     <string name="hexagon_remove_account_confirmation">Ștergerea contului va rezulta în ștergerea emisiunilor și filmelor de pe SeriesGuide Cloud. Asigurați-vă că le veți șterge și de pe celelalte dispozitive.</string>
     <string name="hexagon_api_queued">Se trimite către SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Deconectat de pe SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Trimite pe trakt.</string>
     <string name="checkin_success_trakt">%s verificat pe trakt.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">Войти</string>
     <string name="hexagon_signout">Выйти</string>
     <string name="hexagon_setup_incomplete">Настройка SeriesGuide Cloud не была завершена.</string>
-    <string name="hexagon_setup_fail_auth">Ваш Google аккаунт не проверен.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Удалить аккаунт</string>
     <string name="hexagon_remove_account_success">Аккаунт уничтожен.</string>
     <string name="hexagon_remove_account_failure">Не удалось удалить аккаунт.</string>
     <string name="hexagon_remove_account_confirmation">При удалении аккаунта будут удалены все сериалы и фильмы из SeriesGuide Cloud. Также убедитесь в том, что он удалён на других подключенных устройствах.</string>
     <string name="hexagon_api_queued">Отправка в облако SeriesGuide.</string>
     <string name="hexagon_signed_out">Вышли из SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Ошибка при входе в аккаунт Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Отправка в trakt.</string>
     <string name="checkin_success_trakt">Отмечено в %s на trakt.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">Prihlásiť sa</string>
     <string name="hexagon_signout">Odhlásiť sa</string>
     <string name="hexagon_setup_incomplete">Nastavenie SeriesGuide Cloud nebolo dokončené.</string>
-    <string name="hexagon_setup_fail_auth">Váš účet Google nebol odhlásený.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Odstrániť účet</string>
     <string name="hexagon_remove_account_success">Účet odstránený.</string>
     <string name="hexagon_remove_account_failure">Účet sa nedá odstrániť.</string>
     <string name="hexagon_remove_account_confirmation">Odstránenie účtu vymaže všetky seriály a filmy zo SeriesGuide Cloudu. Uistite sa, že ste ho odstránili aj z iných pripojených zariadení.</string>
     <string name="hexagon_api_queued">Odosielanie do SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Ste odhlásený zo SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Chyba pri prihlasovaní pomocou Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Odosiela sa na trakt.</string>
     <string name="checkin_success_trakt">Práve pozeráte %s na trakt.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -291,14 +291,15 @@
     <string name="hexagon_signin">Пријави се</string>
     <string name="hexagon_signout">Одјави се</string>
     <string name="hexagon_setup_incomplete">Подешавање SeriesGuide Cloud-а није обављено.</string>
-    <string name="hexagon_setup_fail_auth">Ваш Google налог није прошао проверу.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Уклони налог</string>
     <string name="hexagon_remove_account_success">Налог обрисан.</string>
     <string name="hexagon_remove_account_failure">Налог није уклоњен.</string>
     <string name="hexagon_remove_account_confirmation">Брисање вашег налога ће обрисати све серије и филмове са SeriesGuide Cloud. Побрините се да га обришете и са осталих повезаних уређаја.</string>
     <string name="hexagon_api_queued">Слање на SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Izlogovan iz SeriesGuide Cloud-a</string>
-    <string name="hexagon_signin_fail_format">Greška sa Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Послато на тракт.</string>
     <string name="checkin_success_trakt">Пријављено гледање %s на trakt.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Logga in</string>
     <string name="hexagon_signout">Logga ut</string>
     <string name="hexagon_setup_incomplete">Inställning av SeriesGuide Cloud slutfördes inte.</string>
-    <string name="hexagon_setup_fail_auth">Ditt Google-konto stämmer inte.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Ta bort konto</string>
     <string name="hexagon_remove_account_success">Konto utplånat.</string>
     <string name="hexagon_remove_account_failure">Kunde inte ta bort konto.</string>
     <string name="hexagon_remove_account_confirmation">Att ta bort ditt konto kommer även att radera alla serier och filmer från SeriesGuide Cloud. Se till att ta bort det även på andra anslutna enheter.</string>
     <string name="hexagon_api_queued">Skickar till SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Loggat ut från SeriesGuide Cloud.</string>
-    <string name="hexagon_signin_fail_format">Fel med Google-inloggning (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Skickar till trakt.</string>
     <string name="checkin_success_trakt">Checkat in %s på trakt.</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">உள்நுழைக</string>
     <string name="hexagon_signout">வெளியில் செல்லவும்</string>
     <string name="hexagon_setup_incomplete">SeriesGuide மேகம் அமைக்கிறது நிறைவடையவில்லை.</string>
-    <string name="hexagon_setup_fail_auth">உங்கள் Google கணக்கு இட்டு சரிபார்க்க.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">கணக்கு அகற்று</string>
     <string name="hexagon_remove_account_success">கணக்கு obliterated.</string>
     <string name="hexagon_remove_account_failure">கணக்கை அகற்ற முடியவில்லை.</string>
     <string name="hexagon_remove_account_confirmation">உங்கள் கணக்கு அகற்றுவது இருக்கும் அனைத்து காட்சிகள் மற்றும் திரைப்படங்கள் இருந்து நீக்க SeriesGuide மேகம். மற்ற இணைக்கப்பட்ட சாதனங்கள் நன்றாக அதை அகற்ற உறுதி.</string>
     <string name="hexagon_api_queued">SeriesGuide மேகம் அனுப்புகிறது.</string>
     <string name="hexagon_signed_out">Signed out of SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Trakt அனுப்புகிறது.</string>
     <string name="checkin_success_trakt">%s trakt-ஐ சரிபார்க்கப்பட்டது.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">เข้าสู่ระบบ</string>
     <string name="hexagon_signout">ออกจากระบบ</string>
     <string name="hexagon_setup_incomplete">การตั้งค่า SeriesGuide Cloud ไม่เสร็จสมบูรณ์</string>
-    <string name="hexagon_setup_fail_auth">ยังไม่ได้ตรวจสอบบัญชี Google ของคุณ</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">ลบบัญชี</string>
     <string name="hexagon_remove_account_success">ลบบัญชีแล้ว</string>
     <string name="hexagon_remove_account_failure">ไม่สามารถลบบัญชี</string>
     <string name="hexagon_remove_account_confirmation">การลบบัญชีของคุณจะลบซีรีส์และภาพยนตร์ทั้งหมดออกจาก SeriesGuide Cloud ยืนยันให้แน่ใจว่าคุณต้องการลบข้อมูลออกจากอุปกรณ์ที่เชื่อมต่ออยู่ด้วยเช่นกัน</string>
     <string name="hexagon_api_queued">กำลังส่งไปยัง SeriesGuide Cloud</string>
     <string name="hexagon_signed_out">ออกจากระบบ SeriesGuide Cloud แล้ว</string>
-    <string name="hexagon_signin_fail_format">ข้อผิดพลาดในการเข้าสู่ระบบด้วย Google (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">กำลังส่งไปยัง trakt</string>
     <string name="checkin_success_trakt">เช็กอิน %s บน trakt แล้ว</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -284,14 +284,15 @@
     <string name="hexagon_signin">Giriş</string>
     <string name="hexagon_signout">Çıkış</string>
     <string name="hexagon_setup_incomplete">Series Guide Bulut kurulumu tamamlanmadı.</string>
-    <string name="hexagon_setup_fail_auth">Google hesabınız doğrulanamadı.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Hesabı kaldır</string>
     <string name="hexagon_remove_account_success">Hesap silinmiş.</string>
     <string name="hexagon_remove_account_failure">Hesap kaldırılamadı.</string>
     <string name="hexagon_remove_account_confirmation">Hesabınızı kaldırdığınızda SeriesGuide Cloud üzerindeki bütün film ve dizileriniz silinecektir. Hesabınızı diğer bağlı cihazlardan da kaldırdığınızdan emin olun.</string>
     <string name="hexagon_api_queued">SeriesGuide bulutuna gönder.</string>
     <string name="hexagon_signed_out">SeriesGuide Bulut servisinden çıkış yapıldı.</string>
-    <string name="hexagon_signin_fail_format">Google ile Giriş hatası (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">trakt\'e gönderiliyor.</string>
     <string name="checkin_success_trakt">%s Trakt üzerinde \"izliyorum\" yapıldı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -298,14 +298,15 @@
     <string name="hexagon_signin">Увійти</string>
     <string name="hexagon_signout">Вийти</string>
     <string name="hexagon_setup_incomplete">Налаштування хмари SeriesGuide не було завершено.</string>
-    <string name="hexagon_setup_fail_auth">Твій обліковий запис Google не пройшов перевірку.</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Видалити обліковий запис</string>
     <string name="hexagon_remove_account_success">Обліковий запис видалено.</string>
     <string name="hexagon_remove_account_failure">Не вдалося видалити обліковий запис.</string>
     <string name="hexagon_remove_account_confirmation">Видалення облікового запису призведе до видалення всіх серіалів та фільмів з хмари SeriesGuide. Переконайтесь що видалили його і на інших підключених пристроях.</string>
     <string name="hexagon_api_queued">Надсилання до хмари SeriesGuide.</string>
     <string name="hexagon_signed_out">Вихід з SeriesGuide хмари.</string>
-    <string name="hexagon_signin_fail_format">Помилка з Google входом (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">Надсилання до trakt.</string>
     <string name="checkin_success_trakt">Відзначено %s на trakt.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">登录</string>
     <string name="hexagon_signout">注销</string>
     <string name="hexagon_setup_incomplete">设置 SeriesGuide Cloud 未完成。</string>
-    <string name="hexagon_setup_fail_auth">处理 Google 帐户关联时出现问题！</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">删除帐户</string>
     <string name="hexagon_remove_account_success">用户数据已删除。</string>
     <string name="hexagon_remove_account_failure">无法删除帐户。</string>
     <string name="hexagon_remove_account_confirmation">删除帐户会同时删除您储存的所有数据，包括在线备份的节目和电影。一旦您在此设备上完成删除，请记得从其它已同步设备上删除相同的 SeriesGuide Cloud 帐户。</string>
     <string name="hexagon_api_queued">正在同步 SeriesGuide Cloud…</string>
     <string name="hexagon_signed_out">已登出 SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Google 登录错误（%s）</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">正在与 Trakt 同步…</string>
     <string name="checkin_success_trakt">已在 Trakt 上为 %s 签到。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -277,14 +277,15 @@
     <string name="hexagon_signin">登入</string>
     <string name="hexagon_signout">登出</string>
     <string name="hexagon_setup_incomplete">SeriesGuide Cloud未完成設置。</string>
-    <string name="hexagon_setup_fail_auth">你的Google帳戶無法使用。</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">移除帳戶</string>
     <string name="hexagon_remove_account_success">帳戶已刪除。</string>
     <string name="hexagon_remove_account_failure">無法刪除帳戶。</string>
     <string name="hexagon_remove_account_confirmation">移除你的帳戶將會刪除SeriesGuide Cloud上所有節目與電影的紀錄。請確認其他裝置上的資料也一併刪除。</string>
     <string name="hexagon_api_queued">發送至SeriesGuide Cloud。</string>
     <string name="hexagon_signed_out">已登出 SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">使用 Google 帳戶登入時發生錯誤 (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
     <!-- trakt -->
     <string name="trakt_submitqueued">正發送至trakt。</string>
     <string name="checkin_success_trakt">在trakt上打卡%s</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Note: app_name also required for Firebase AuthUI https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md#ui-customization -->
     <string name="app_name">SeriesGuide</string>
     <string name="hexagon">SeriesGuide Cloud</string>
     <string name="imdb">IMDb</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,7 +324,7 @@
     <string name="hexagon_signin">Sign In</string>
     <string name="hexagon_signout">Sign Out</string>
     <string name="hexagon_setup_incomplete">Setting up SeriesGuide Cloud was not completed</string>
-    <string name="hexagon_setup_fail_auth">Your account did not check out</string>
+    <string name="hexagon_setup_fail_auth">Your account does not have an email address</string>
     <string name="hexagon_remove_account">Delete account</string>
     <string name="hexagon_remove_account_success">Account deleted</string>
     <string name="hexagon_remove_account_failure">Could not delete account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,7 +331,8 @@
     <string name="hexagon_remove_account_confirmation">This will delete your shows, lists and movies from SeriesGuide Cloud</string>
     <string name="hexagon_api_queued">Sending to SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Signed out of SeriesGuide Cloud</string>
-    <string name="hexagon_signin_fail_format">Error with Google Sign-In (%s)</string>
+    <string name="hexagon_signin_fail_format">Error with sign-in (%s)</string>
+    <string name="hexagon_signin_google_only">Email address requires Google Sign-In</string>
 
     <!-- trakt -->
     <string name="trakt_submitqueued">Sending to Trakt.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,10 +324,10 @@
     <string name="hexagon_signin">Sign In</string>
     <string name="hexagon_signout">Sign Out</string>
     <string name="hexagon_setup_incomplete">Setting up SeriesGuide Cloud was not completed</string>
-    <string name="hexagon_setup_fail_auth">Your Google account did not check out</string>
-    <string name="hexagon_remove_account">Remove account</string>
-    <string name="hexagon_remove_account_success">Account obliterated</string>
-    <string name="hexagon_remove_account_failure">Could not remove account</string>
+    <string name="hexagon_setup_fail_auth">Your account did not check out</string>
+    <string name="hexagon_remove_account">Delete account</string>
+    <string name="hexagon_remove_account_success">Account deleted</string>
+    <string name="hexagon_remove_account_failure">Could not delete account</string>
     <string name="hexagon_remove_account_confirmation">This will delete your shows, lists and movies from SeriesGuide Cloud</string>
     <string name="hexagon_api_queued">Sending to SeriesGuide Cloud.</string>
     <string name="hexagon_signed_out">Signed out of SeriesGuide Cloud</string>


### PR DESCRIPTION
https://firebase.google.com/docs/auth/android/firebaseui
https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md

- [x] Test signing in with email + password.
  - [x] Handle "Develeper error" code 3 thrown if email address has been used with Google Sign-In already.
  - [x] Disable Google Sign-In and smart lock if no Play Services available.
  - Signing in with Google overrides existing Email + Password Sign-In :/
  - [x] Check if enabling multi-account allows email + Google accounts // No. Only supports multiple auth providers, but not combination of email + password plus auth provider.
- [x] Change theme (does not use app theme as advertised).
- [x] Rewrite `HexagonAuthError`, throwable no longer produces Google Sign-In status codes.
  - `     Caused by: java.util.concurrent.ExecutionException: com.google.android.gms.common.api.ApiException: 16: No eligible accounts can be found.` 
- [x] Test Cloud validation only change.
- [x] Update strings.