### PR TITLE
Switch to using Zulu as the new jdk distribution.

### DIFF
--- a/.github/workflows/assemble-test-lint.yml
+++ b/.github/workflows/assemble-test-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
           cache: gradle
 
       - name: Gradle Info


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/ 
:-)
