### PR TITLE
Cloud: fix detection of sign in errors, get Tasks API cause directly.

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/backend/HexagonAuthError.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/HexagonAuthError.kt
@@ -23,22 +23,14 @@ class HexagonAuthError(
     companion object {
 
         /**
-         * Extracts info from Tasks API exceptions with ApiException cause, FirebaseUiException.
+         * Extracts status code from ApiException, FirebaseUiException.
          */
         @JvmStatic
         fun build(action: String, throwable: Throwable): HexagonAuthError {
-            // Prefer ApiException message.
-            // Note: when using the Tasks API, ApiException is wrapped in an ExecutionException.
-            val cause = throwable.cause
-            val causeMessage = cause?.message
-            val message = if (causeMessage != null && cause is ApiException) {
-                causeMessage
-            } else {
-                throwable.message ?: ""
-            }
-            val statusCode = when {
-                throwable is FirebaseUiException -> throwable.errorCode
-                cause is ApiException -> cause.statusCode
+            val message = throwable.message ?: ""
+            val statusCode = when (throwable) {
+                is FirebaseUiException -> throwable.errorCode
+                is ApiException -> throwable.statusCode
                 else -> null
             }
             return HexagonAuthError(action, message, throwable, statusCode)

--- a/app/src/main/java/com/battlelancer/seriesguide/util/Errors.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/Errors.kt
@@ -274,6 +274,9 @@ fun Throwable.isRetryError(): Boolean {
     }
 }
 
+/**
+ * Returns the bottom most cause, or this if there is no cause.
+ */
 private fun Throwable.getUltimateCause(): Throwable {
     return cause?.getUltimateCause() ?: this
 }

--- a/app/src/test/java/com/battlelancer/seriesguide/backend/HexagonAuthErrorTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/backend/HexagonAuthErrorTest.kt
@@ -1,0 +1,22 @@
+package com.battlelancer.seriesguide.backend
+
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.api.Status
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class HexagonAuthErrorTest {
+
+    @Test
+    fun isSignInRequiredError() {
+        val testException = ApiException(Status(CommonStatusCodes.SIGN_IN_REQUIRED))
+        val hexagonError = HexagonAuthError.build("Test action", testException)
+
+        // Status code is extracted.
+        assertThat(hexagonError.statusCode).isEqualTo(CommonStatusCodes.SIGN_IN_REQUIRED)
+        assertThat(hexagonError.action).isEqualTo("Test action")
+        // Detects ApiException with sign-in required code.
+        assertThat(hexagonError.isSignInRequiredError()).isTrue()
+    }
+}


### PR DESCRIPTION
Follow-up to #856 to actually not report sign-in required errors.

Also simplified auth error builder by passing the actual cause directly (so it doesn't need to know about how the Tasks API wraps these).