### PR TITLE
Handle missing SCHEDULE_EXACT_ALARM permission, improve notification service wake-up alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Version 64
 
 * 🔨 Do not crash if permission to set alarms and reminders has been removed, schedule inexact
   episode notifications instead.
+* 🔧 Improve when the app wakes the device to notify about upcoming episodes.
 
 #### 64.0.4*
 *2022-05-06*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Version 64
 ----------
 *in development*
 
+#### next
+
+* 🔨 Do not crash if permission to set alarms and reminders has been removed, schedule inexact
+  episode notifications instead.
+
 #### 64.0.4*
 *2022-05-06*
 

--- a/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
@@ -32,6 +32,7 @@ import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.shows.ShowsActivityImpl
 import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.shows.episodes.EpisodesActivity.Companion.intentEpisode
+import com.battlelancer.seriesguide.sync.SgSyncAdapter
 import com.battlelancer.seriesguide.traktapi.QuickCheckInActivity
 import com.battlelancer.seriesguide.ui.ShowsActivity
 import com.battlelancer.seriesguide.util.ImageTools.tmdbOrTvdbPosterUrl
@@ -155,11 +156,13 @@ class NotificationService(context: Context) {
             nextWakeUpTime = plannedWakeUpTime
         }
 
-        // Set a default wake-up time if there are no future episodes for now
         if (nextWakeUpTime <= 0) {
-            nextWakeUpTime = System.currentTimeMillis() + 6 * DateUtils.HOUR_IN_MILLIS
+            // Set a default wake-up time if there are currently no future episodes,
+            // schedule after the default sync interval as sync likely wakes this up already.
+            nextWakeUpTime = System.currentTimeMillis() +
+                    SgSyncAdapter.SYNC_INTERVAL_SECONDS * DateUtils.SECOND_IN_MILLIS
             needExactAlarm = false
-            Timber.d("No future episodes found, wake up in 6 hours")
+            Timber.d("No future episodes found, wake up after next sync")
         }
 
         if (DEBUG) {

--- a/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
@@ -246,11 +246,14 @@ class NotificationService(context: Context) {
                     // removed or notifications for a show have been disabled.
                     true
                 } else {
+                    // Next to notify about is the planned one, continue sleeping until then.
                     false
                 }
             }
         }
-        return false // Continue sleeping until planned wake-up time.
+
+        // No episodes to notify about now or later, find new wake-up time.
+        return true
     }
 
     private fun AlarmManager.canScheduleExactAlarmsCompat(): Boolean {

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/AccountUtils.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/AccountUtils.java
@@ -13,7 +13,6 @@ import timber.log.Timber;
 
 public class AccountUtils {
 
-    public static final int SYNC_FREQUENCY = 24 * 60 * 60; // 1 day (in seconds)
 
     private static final String ACCOUNT_NAME = "SeriesGuide Sync";
 
@@ -48,7 +47,7 @@ public class AccountUtils {
             // may modify this based
             // on other scheduled syncs and network utilization.
             ContentResolver.addPeriodicSync(account, SgApp.CONTENT_AUTHORITY,
-                    new Bundle(), SYNC_FREQUENCY);
+                    new Bundle(), SgSyncAdapter.SYNC_INTERVAL_SECONDS);
         }
 
         Timber.d("Setting up account...DONE");

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.kt
@@ -15,14 +15,14 @@ import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.backend.HexagonTools
 import com.battlelancer.seriesguide.backend.settings.HexagonSettings
-import com.battlelancer.seriesguide.provider.SeriesGuideDatabase
+import com.battlelancer.seriesguide.lists.ListsTools2.migrateTvdbShowListItemsToTmdbIds
+import com.battlelancer.seriesguide.movies.tools.MovieTools
 import com.battlelancer.seriesguide.notifications.NotificationService
+import com.battlelancer.seriesguide.provider.SeriesGuideDatabase
 import com.battlelancer.seriesguide.settings.UpdateSettings
 import com.battlelancer.seriesguide.shows.tools.ShowSync
 import com.battlelancer.seriesguide.sync.SyncOptions.SyncType
 import com.battlelancer.seriesguide.traktapi.TraktCredentials
-import com.battlelancer.seriesguide.lists.ListsTools2.migrateTvdbShowListItemsToTmdbIds
-import com.battlelancer.seriesguide.movies.tools.MovieTools
 import com.battlelancer.seriesguide.util.TaskManager
 import com.uwetrottmann.androidutils.AndroidUtils
 import com.uwetrottmann.tmdb2.services.ConfigurationService
@@ -229,6 +229,9 @@ class SgSyncAdapter(context: Context) : AbstractThreadedSyncAdapter(context, tru
     }
 
     companion object {
+        /** Used when registering the SyncAdapter, see [AccountUtils.createAccount]. */
+        const val SYNC_INTERVAL_SECONDS = 24 * 60 * 60 // 1 day (in seconds)
+
         /** Should never be outside 4-32 so back-off works as expected.  */
         private const val SYNC_INTERVAL_MINIMUM_MINUTES = 5
 

--- a/app/src/test/java/com/battlelancer/seriesguide/notifications/NotificationServiceTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/notifications/NotificationServiceTest.kt
@@ -1,0 +1,112 @@
+package com.battlelancer.seriesguide.notifications
+
+import android.content.Context
+import android.text.format.DateUtils
+import androidx.test.core.app.ApplicationProvider
+import com.battlelancer.seriesguide.EmptyTestApplication
+import com.battlelancer.seriesguide.settings.NotificationSettings
+import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
+import com.battlelancer.seriesguide.shows.episodes.EpisodeFlags
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = EmptyTestApplication::class)
+class NotificationServiceTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun shouldCheckToNotify() {
+        val service = NotificationService(context)
+
+        val currentTime = System.currentTimeMillis()
+        val nextRelease = currentTime + 1 * DateUtils.HOUR_IN_MILLIS
+        val lastNotifiedAbout = nextRelease - 6 * DateUtils.HOUR_IN_MILLIS;
+        NotificationSettings.setLastNotifiedAbout(context, lastNotifiedAbout)
+        val episodes = listOf(
+            // 12 hours before is max returned by upcoming episodes query
+            sgEpisode2WithShow(1, lastNotifiedAbout),
+            sgEpisode2WithShow(2, nextRelease - 2 * DateUtils.HOUR_IN_MILLIS),
+            sgEpisode2WithShow(3, nextRelease),
+            sgEpisode2WithShow(4, nextRelease + 10 * DateUtils.HOUR_IN_MILLIS),
+            // 14 days in the future is max returned by upcoming episodes query
+            sgEpisode2WithShow(5, nextRelease + 14 * DateUtils.DAY_IN_MILLIS)
+        )
+
+        // Running for the first time = default values
+        assertThat(service.shouldCheckToNotify(0, 0, episodes)).isTrue()
+
+        // Woken at or after planned time
+        assertThat(service.shouldCheckToNotify(currentTime, nextRelease, episodes)).isTrue()
+        assertThat(
+            service.shouldCheckToNotify(
+                currentTime + 5 * DateUtils.MINUTE_IN_MILLIS,
+                nextRelease,
+                episodes
+            )
+        ).isTrue()
+
+        // Woken up earlier
+        val beforeNextRelease = nextRelease - 5 * DateUtils.MINUTE_IN_MILLIS
+        //   No upcoming episodes at all
+        assertThat(
+            service.shouldCheckToNotify(beforeNextRelease, nextRelease, emptyList())
+        ).isTrue()
+        //   New upcoming episode released before planned one to notify about.
+        assertThat(
+            service.shouldCheckToNotify(beforeNextRelease, nextRelease, episodes)
+        ).isTrue()
+        //   No new upcoming episodes to notify about, but planned one was removed.
+        assertThat(
+            service.shouldCheckToNotify(
+                beforeNextRelease, nextRelease,
+                listOf(
+                    sgEpisode2WithShow(1, lastNotifiedAbout - DateUtils.HOUR_IN_MILLIS),
+                    sgEpisode2WithShow(2, lastNotifiedAbout),
+                    sgEpisode2WithShow(4, nextRelease + 10 * DateUtils.HOUR_IN_MILLIS),
+                    sgEpisode2WithShow(5, nextRelease + 14 * DateUtils.DAY_IN_MILLIS)
+                )
+            )
+        ).isTrue()
+
+        //   No earlier upcoming episodes, should continue sleeping.
+        assertThat(
+            service.shouldCheckToNotify(
+                beforeNextRelease, nextRelease,
+                listOf(
+                    sgEpisode2WithShow(3, nextRelease),
+                    sgEpisode2WithShow(4, nextRelease + 10 * DateUtils.HOUR_IN_MILLIS),
+                    sgEpisode2WithShow(5, nextRelease + 14 * DateUtils.DAY_IN_MILLIS)
+                )
+            )
+        ).isFalse()
+        //   Earlier upcoming episodes already notified about, should continue sleeping.
+        assertThat(
+            service.shouldCheckToNotify(
+                beforeNextRelease, nextRelease,
+                listOf(
+                    sgEpisode2WithShow(1, lastNotifiedAbout - DateUtils.HOUR_IN_MILLIS),
+                    sgEpisode2WithShow(2, lastNotifiedAbout)
+                )
+            )
+        ).isFalse()
+    }
+
+    private fun sgEpisode2WithShow(idAndNumber: Int, releaseTime: Long) = SgEpisode2WithShow(
+        id = idAndNumber.toLong(),
+        episodetitle = null,
+        episodenumber = idAndNumber,
+        season = 1,
+        episode_firstairedms = releaseTime,
+        watched = EpisodeFlags.UNWATCHED,
+        episode_collected = false,
+        overview = null,
+        seriestitle = "That Show",
+        network = null,
+        series_poster_small = null
+    )
+}

--- a/app/src/test/java/com/battlelancer/seriesguide/notifications/NotificationServiceTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/notifications/NotificationServiceTest.kt
@@ -72,8 +72,18 @@ class NotificationServiceTest {
                 )
             )
         ).isTrue()
+        //   Earlier episodes already notified about, no new ones, find new wake-up time.
+        assertThat(
+            service.shouldCheckToNotify(
+                beforeNextRelease, nextRelease,
+                listOf(
+                    sgEpisode2WithShow(1, lastNotifiedAbout - DateUtils.HOUR_IN_MILLIS),
+                    sgEpisode2WithShow(2, lastNotifiedAbout)
+                )
+            )
+        ).isTrue()
 
-        //   No earlier upcoming episodes, should continue sleeping.
+        //   Next one to notify about is the planned one, continue sleeping until then.
         assertThat(
             service.shouldCheckToNotify(
                 beforeNextRelease, nextRelease,
@@ -81,16 +91,6 @@ class NotificationServiceTest {
                     sgEpisode2WithShow(3, nextRelease),
                     sgEpisode2WithShow(4, nextRelease + 10 * DateUtils.HOUR_IN_MILLIS),
                     sgEpisode2WithShow(5, nextRelease + 14 * DateUtils.DAY_IN_MILLIS)
-                )
-            )
-        ).isFalse()
-        //   Earlier upcoming episodes already notified about, should continue sleeping.
-        assertThat(
-            service.shouldCheckToNotify(
-                beforeNextRelease, nextRelease,
-                listOf(
-                    sgEpisode2WithShow(1, lastNotifiedAbout - DateUtils.HOUR_IN_MILLIS),
-                    sgEpisode2WithShow(2, lastNotifiedAbout)
                 )
             )
         ).isFalse()


### PR DESCRIPTION
- Do not crash if permission to set alarms and reminders has been removed, schedule inexact episode notifications instead. #843
- Re-calculate wake-up time if next to notify about episode has been removed/time has changed/show notifications were disabled.