### PR TITLE
Migrate setHasOptionsMenu to MenuProvider in fragments

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/appwidget/ListWidgetPreferenceFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/appwidget/ListWidgetPreferenceFragment.kt
@@ -5,10 +5,13 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
 import androidx.annotation.ArrayRes
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
 import androidx.preference.CheckBoxPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -33,11 +36,6 @@ class ListWidgetPreferenceFragment : PreferenceFragmentCompat() {
     private lateinit var isInfinitePref: CheckBoxPreference
     private lateinit var themePref: ListPreference
     private lateinit var backgroundPref: ListPreference
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
 
     override fun onCreatePreferences(
         savedInstanceState: Bundle?,
@@ -174,24 +172,36 @@ class ListWidgetPreferenceFragment : PreferenceFragmentCompat() {
         }
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
+    }
+
     override fun onResume() {
         super.onResume()
         // Trigger listener to update pref states based on current type.
         preferenceChangeListener.onPreferenceChange(typePref, typePref.value)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.widget_config_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.widget_config_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_save -> {
-                saveAllPreferences() // Persistence is disabled, save manually.
-                (activity as ListWidgetPreferenceActivity).updateWidget()
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_save -> {
+                    saveAllPreferences() // Persistence is disabled, save manually.
+                    (activity as ListWidgetPreferenceActivity).updateWidget()
+                    true
+                }
+                else -> false
             }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/comments/TraktCommentsFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/comments/TraktCommentsFragment.java
@@ -17,7 +17,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.app.LoaderManager.LoaderCallbacks;
 import androidx.loader.content.Loader;
@@ -108,7 +110,11 @@ public class TraktCommentsFragment extends Fragment {
                         commentsLoaderCallbacks);
 
         // enable menu
-        setHasOptionsMenu(true);
+        requireActivity().addMenuProvider(
+                optionsMenuProvider,
+                getViewLifecycleOwner(),
+                Lifecycle.State.RESUMED
+        );
     }
 
     private void comment() {
@@ -175,20 +181,22 @@ public class TraktCommentsFragment extends Fragment {
         binding = null;
     }
 
-    @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.comments_menu, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int itemId = item.getItemId();
-        if (itemId == R.id.menu_action_comments_refresh) {
-            refreshCommentsWithNetworkCheck();
-            return true;
+    private final MenuProvider optionsMenuProvider = new MenuProvider() {
+        @Override
+        public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+            menuInflater.inflate(R.menu.comments_menu, menu);
         }
-        return super.onOptionsItemSelected(item);
-    }
+
+        @Override
+        public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+            int itemId = menuItem.getItemId();
+            if (itemId == R.id.menu_action_comments_refresh) {
+                refreshCommentsWithNetworkCheck();
+                return true;
+            }
+            return false;
+        }
+    };
 
     private final AdapterView.OnItemClickListener onItemClickListener
             = (parent, v, position, id) -> onListItemClick((ListView) parent, v, position);

--- a/app/src/main/java/com/battlelancer/seriesguide/history/StreamFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/history/StreamFragment.kt
@@ -8,17 +8,19 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.MenuProvider
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.FragmentStreamBinding
 import com.battlelancer.seriesguide.history.TraktEpisodeHistoryLoader.HistoryItem
 import com.battlelancer.seriesguide.traktapi.TraktCredentials
 import com.battlelancer.seriesguide.ui.AutoGridLayoutManager
+import com.battlelancer.seriesguide.ui.widgets.SgFastScroller
 import com.battlelancer.seriesguide.util.Utils
 import com.battlelancer.seriesguide.util.ViewTools
-import com.battlelancer.seriesguide.ui.widgets.SgFastScroller
 import com.uwetrottmann.androidutils.AndroidUtils
 
 /**
@@ -84,20 +86,26 @@ abstract class StreamFragment : Fragment() {
 
         initializeStream()
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.stream_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.stream_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_action_stream_refresh -> {
-                refreshStreamWithNetworkCheck()
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_action_stream_refresh -> {
+                    refreshStreamWithNetworkCheck()
+                    true
+                }
+                else -> false
             }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesBaseFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesBaseFragment.kt
@@ -3,15 +3,13 @@ package com.battlelancer.seriesguide.movies
 import android.database.Cursor
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.GridView
 import android.widget.TextView
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.loader.app.LoaderManager
 import androidx.loader.content.Loader
@@ -40,7 +38,6 @@ abstract class MoviesBaseFragment : Fragment(), LoaderManager.LoaderCallbacks<Cu
         super.onCreate(savedInstanceState)
 
         EventBus.getDefault().register(this)
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -77,6 +74,12 @@ abstract class MoviesBaseFragment : Fragment(), LoaderManager.LoaderCallbacks<Cu
         )
         gridView.adapter = adapter
 
+        requireActivity().addMenuProvider(
+            MoviesOptionsMenu(requireActivity()),
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
+
         LoaderManager.getInstance(this).initLoader(loaderId, null, this)
     }
 
@@ -84,26 +87,6 @@ abstract class MoviesBaseFragment : Fragment(), LoaderManager.LoaderCallbacks<Cu
         super.onDestroy()
 
         EventBus.getDefault().unregister(this)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-
-        // guard against not attached to activity
-        if (!isAdded) {
-            return
-        }
-
-        MoviesOptionsMenu(requireContext()).create(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val menu = MoviesOptionsMenu(requireContext())
-        return if (menu.onItemSelected(item, requireActivity())) {
-            true
-        } else {
-            super.onOptionsItemSelected(item)
-        }
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesDiscoverFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesDiscoverFragment.java
@@ -11,7 +11,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -91,7 +93,11 @@ public class MoviesDiscoverFragment extends Fragment {
 
         LoaderManager.getInstance(this).initLoader(0, null, nowPlayingLoaderCallbacks);
 
-        setHasOptionsMenu(true);
+        requireActivity().addMenuProvider(
+                optionsMenuProvider,
+                getViewLifecycleOwner(),
+                Lifecycle.State.RESUMED
+        );
     }
 
     @Override
@@ -112,21 +118,22 @@ public class MoviesDiscoverFragment extends Fragment {
         binding = null;
     }
 
-    @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
-        inflater.inflate(R.menu.movies_discover_menu, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int itemId = item.getItemId();
-        if (itemId == R.id.menu_action_movies_search_change_language) {
-            MovieLocalizationDialogFragment.show(getParentFragmentManager());
-            return true;
+    private final MenuProvider optionsMenuProvider = new MenuProvider() {
+        @Override
+        public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+            menuInflater.inflate(R.menu.movies_discover_menu, menu);
         }
-        return super.onOptionsItemSelected(item);
-    }
+
+        @Override
+        public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+            int itemId = menuItem.getItemId();
+            if (itemId == R.id.menu_action_movies_search_change_language) {
+                MovieLocalizationDialogFragment.show(getParentFragmentManager());
+                return true;
+            }
+            return false;
+        }
+    };
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventLanguageChanged(

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesNowFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesNowFragment.java
@@ -12,7 +12,9 @@ import android.view.animation.AnimationUtils;
 import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -135,7 +137,11 @@ public class MoviesNowFragment extends Fragment {
                     traktFriendsHistoryCallbacks);
         }
 
-        setHasOptionsMenu(true);
+        requireActivity().addMenuProvider(
+                optionsMenuProvider,
+                getViewLifecycleOwner(),
+                Lifecycle.State.RESUMED
+        );
     }
 
     @Override
@@ -144,27 +150,22 @@ public class MoviesNowFragment extends Fragment {
         binding = null;
     }
 
-    @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
-
-        // guard against not attached to activity
-        if (!isAdded()) {
-            return;
+    private final MenuProvider optionsMenuProvider = new MenuProvider() {
+        @Override
+        public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+            menuInflater.inflate(R.menu.movies_now_menu, menu);
         }
 
-        inflater.inflate(R.menu.movies_now_menu, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int itemId = item.getItemId();
-        if (itemId == R.id.menu_action_movies_now_refresh) {
-            refreshStream();
-            return true;
+        @Override
+        public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+            int itemId = menuItem.getItemId();
+            if (itemId == R.id.menu_action_movies_now_refresh) {
+                refreshStream();
+                return true;
+            }
+            return false;
         }
-        return super.onOptionsItemSelected(item);
-    }
+    };
 
     private void refreshStream() {
         showProgressBar(true);

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesOptionsMenu.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesOptionsMenu.kt
@@ -1,38 +1,37 @@
 package com.battlelancer.seriesguide.movies
 
 import android.app.Activity
-import android.content.Context
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import androidx.core.view.MenuProvider
 import androidx.preference.PreferenceManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.movies.MoviesDistillationSettings.MoviesSortOrder
 import com.battlelancer.seriesguide.settings.DisplaySettings
 import org.greenrobot.eventbus.EventBus
 
-class MoviesOptionsMenu(val context: Context) {
+class MoviesOptionsMenu(val activity: Activity) : MenuProvider {
 
-    fun create(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.movies_lists_menu, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.movies_lists_menu, menu)
         menu.findItem(R.id.menu_action_movies_sort_ignore_articles).isChecked =
-            DisplaySettings.isSortOrderIgnoringArticles(context)
+            DisplaySettings.isSortOrderIgnoringArticles(activity)
     }
 
-    fun onItemSelected(item: MenuItem, activity: Activity): Boolean {
-        val itemId = item.itemId
-        when (itemId) {
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        when (menuItem.itemId) {
             R.id.menu_action_movies_sort_title -> {
-                if (MoviesDistillationSettings.getSortOrderId(context) == MoviesSortOrder.TITLE_ALPHABETICAL_ID) {
-                    changeSortOrder(MoviesDistillationSettings.MoviesSortOrder.TITLE_REVERSE_ALHPABETICAL_ID)
+                if (MoviesDistillationSettings.getSortOrderId(activity) == MoviesSortOrder.TITLE_ALPHABETICAL_ID) {
+                    changeSortOrder(MoviesSortOrder.TITLE_REVERSE_ALHPABETICAL_ID)
                 } else {
                     // was sorted title reverse or by release date
-                    changeSortOrder(MoviesDistillationSettings.MoviesSortOrder.TITLE_ALPHABETICAL_ID)
+                    changeSortOrder(MoviesSortOrder.TITLE_ALPHABETICAL_ID)
                 }
                 return true
             }
             R.id.menu_action_movies_sort_release -> {
-                if (MoviesDistillationSettings.getSortOrderId(context) == MoviesSortOrder.RELEASE_DATE_NEWEST_FIRST_ID) {
+                if (MoviesDistillationSettings.getSortOrderId(activity) == MoviesSortOrder.RELEASE_DATE_NEWEST_FIRST_ID) {
                     changeSortOrder(MoviesSortOrder.RELEASE_DATE_OLDEST_FIRST_ID)
                 } else {
                     // was sorted by oldest first or by title
@@ -42,7 +41,7 @@ class MoviesOptionsMenu(val context: Context) {
             }
             R.id.menu_action_movies_sort_ignore_articles -> {
                 changeSortIgnoreArticles(
-                    !DisplaySettings.isSortOrderIgnoringArticles(context),
+                    !DisplaySettings.isSortOrderIgnoringArticles(activity),
                     activity
                 )
                 return true
@@ -52,7 +51,7 @@ class MoviesOptionsMenu(val context: Context) {
     }
 
     private fun changeSortOrder(sortOrderId: Int) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
+        PreferenceManager.getDefaultSharedPreferences(activity).edit()
             .putInt(MoviesDistillationSettings.KEY_SORT_ORDER, sortOrderId)
             .apply()
 
@@ -60,7 +59,7 @@ class MoviesOptionsMenu(val context: Context) {
     }
 
     private fun changeSortIgnoreArticles(value: Boolean, activity: Activity) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
+        PreferenceManager.getDefaultSharedPreferences(activity).edit()
             .putBoolean(DisplaySettings.KEY_SORT_IGNORE_ARTICLE, value)
             .apply()
 

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesWatchedFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MoviesWatchedFragment.kt
@@ -2,14 +2,12 @@ package com.battlelancer.seriesguide.movies
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.battlelancer.seriesguide.R
@@ -39,7 +37,6 @@ class MoviesWatchedFragment : Fragment() {
         super.onCreate(savedInstanceState)
         // note: fragment is in static view pager tab so will never be destroyed if swiped away
         EventBus.getDefault().register(this)
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -66,6 +63,12 @@ class MoviesWatchedFragment : Fragment() {
             SgFastScroller(requireContext(), it)
         }
 
+        requireActivity().addMenuProvider(
+            MoviesOptionsMenu(requireActivity()),
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
+
         ViewModelProvider(requireActivity()).get(MoviesActivityViewModel::class.java)
             .scrollTabToTopLiveData
             .observe(viewLifecycleOwner) {
@@ -91,19 +94,6 @@ class MoviesWatchedFragment : Fragment() {
             model.items.collectLatest {
                 adapter.submitData(it)
             }
-        }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        MoviesOptionsMenu(requireContext()).create(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (MoviesOptionsMenu(requireContext()).onItemSelected(item, requireActivity())) {
-            true
-        } else {
-            super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/people/PersonFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/people/PersonFragment.kt
@@ -12,8 +12,10 @@ import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.FragmentPersonBinding
 import com.battlelancer.seriesguide.tmdbapi.TmdbTools
@@ -44,7 +46,6 @@ class PersonFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         personTmdbId = arguments?.getInt(ARG_PERSON_TMDB_ID) ?: 0
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -82,22 +83,32 @@ class PersonFragment : Fragment() {
             populatePersonViews(it)
         }
         model.languageCode.value = PeopleSettings.getPersonLanguage(requireContext())
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.person_menu, menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.menu_action_person_language) {
-            L10nDialogFragment.show(
-                parentFragmentManager,
-                model.languageCode.value,
-                "person-language-dialog"
-            )
-            return true
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.person_menu, menu)
         }
-        return super.onOptionsItemSelected(item)
+
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_action_person_language -> {
+                    L10nDialogFragment.show(
+                        parentFragmentManager,
+                        model.languageCode.value,
+                        "person-language-dialog"
+                    )
+                    true
+                }
+                else -> false
+            }
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.widget.PopupMenu
 import android.widget.TextView
 import androidx.core.content.edit
+import androidx.core.view.MenuProvider
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -65,7 +66,6 @@ class CalendarFragment2 : Fragment() {
             CalendarType.RECENT.id -> CalendarType.RECENT
             else -> throw IllegalArgumentException("Unknown calendar type $argType")
         }
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -148,6 +148,12 @@ class CalendarFragment2 : Fragment() {
                 }
             }
         }
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     private fun updateEmptyView(isEmpty: Boolean) {
@@ -165,54 +171,54 @@ class CalendarFragment2 : Fragment() {
             .unregisterOnSharedPreferenceChangeListener(prefChangeListener)
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.calendar_menu, menu)
 
-        inflater.inflate(R.menu.calendar_menu, menu)
+            // set menu items to current values
+            val context = requireContext()
+            menu.findItem(R.id.menu_action_calendar_onlyfavorites).isChecked =
+                CalendarSettings.isOnlyFavorites(context)
+            menu.findItem(R.id.menu_action_calendar_onlypremieres).isChecked =
+                CalendarSettings.isOnlyPremieres(context)
+            menu.findItem(R.id.menu_action_calendar_onlycollected).isChecked =
+                CalendarSettings.isOnlyCollected(context)
+            menu.findItem(R.id.menu_action_calendar_nospecials).isChecked =
+                DisplaySettings.isHidingSpecials(context)
+            menu.findItem(R.id.menu_action_calendar_nowatched).isChecked =
+                CalendarSettings.isHidingWatchedEpisodes(context)
+            menu.findItem(R.id.menu_action_calendar_infinite).isChecked =
+                CalendarSettings.isInfiniteScrolling(context)
+        }
 
-        // set menu items to current values
-        val context = requireContext()
-        menu.findItem(R.id.menu_action_calendar_onlyfavorites).isChecked =
-            CalendarSettings.isOnlyFavorites(context)
-        menu.findItem(R.id.menu_action_calendar_onlypremieres).isChecked =
-            CalendarSettings.isOnlyPremieres(context)
-        menu.findItem(R.id.menu_action_calendar_onlycollected).isChecked =
-            CalendarSettings.isOnlyCollected(context)
-        menu.findItem(R.id.menu_action_calendar_nospecials).isChecked =
-            DisplaySettings.isHidingSpecials(context)
-        menu.findItem(R.id.menu_action_calendar_nowatched).isChecked =
-            CalendarSettings.isHidingWatchedEpisodes(context)
-        menu.findItem(R.id.menu_action_calendar_infinite).isChecked =
-            CalendarSettings.isInfiniteScrolling(context)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_action_calendar_onlyfavorites -> {
-                toggleFilterSetting(item, CalendarSettings.KEY_ONLY_FAVORITE_SHOWS)
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_action_calendar_onlyfavorites -> {
+                    toggleFilterSetting(menuItem, CalendarSettings.KEY_ONLY_FAVORITE_SHOWS)
+                    true
+                }
+                R.id.menu_action_calendar_onlypremieres -> {
+                    toggleFilterSetting(menuItem, CalendarSettings.KEY_ONLY_PREMIERES)
+                    true
+                }
+                R.id.menu_action_calendar_onlycollected -> {
+                    toggleFilterSetting(menuItem, CalendarSettings.KEY_ONLY_COLLECTED)
+                    true
+                }
+                R.id.menu_action_calendar_nospecials -> {
+                    toggleFilterSetting(menuItem, DisplaySettings.KEY_HIDE_SPECIALS)
+                    true
+                }
+                R.id.menu_action_calendar_nowatched -> {
+                    toggleFilterSetting(menuItem, CalendarSettings.KEY_HIDE_WATCHED_EPISODES)
+                    true
+                }
+                R.id.menu_action_calendar_infinite -> {
+                    toggleFilterSetting(menuItem, CalendarSettings.KEY_INFINITE_SCROLLING_2)
+                    true
+                }
+                else -> false
             }
-            R.id.menu_action_calendar_onlypremieres -> {
-                toggleFilterSetting(item, CalendarSettings.KEY_ONLY_PREMIERES)
-                true
-            }
-            R.id.menu_action_calendar_onlycollected -> {
-                toggleFilterSetting(item, CalendarSettings.KEY_ONLY_COLLECTED)
-                true
-            }
-            R.id.menu_action_calendar_nospecials -> {
-                toggleFilterSetting(item, DisplaySettings.KEY_HIDE_SPECIALS)
-                true
-            }
-            R.id.menu_action_calendar_nowatched -> {
-                toggleFilterSetting(item, CalendarSettings.KEY_HIDE_WATCHED_EPISODES)
-                true
-            }
-            R.id.menu_action_calendar_infinite -> {
-                toggleFilterSetting(item, CalendarSettings.KEY_INFINITE_SCROLLING_2)
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodesFragment.kt
@@ -9,15 +9,17 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.FragmentEpisodesBinding
 import com.battlelancer.seriesguide.ui.dialogs.SingleChoiceDialogFragment
-import com.battlelancer.seriesguide.util.safeShow
 import com.battlelancer.seriesguide.ui.widgets.SgFastScroller
+import com.battlelancer.seriesguide.util.safeShow
 
 /**
  * Displays a list of episodes of a season.
@@ -123,7 +125,11 @@ class EpisodesFragment : Fragment() {
             model.updateCounts()
         }
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     /**
@@ -149,18 +155,19 @@ class EpisodesFragment : Fragment() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.episodelist_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.episodelist_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_epsorting -> {
-                showSortDialog()
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_epsorting -> {
+                    showSortDialog()
+                    true
+                }
+                else -> false
             }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/history/ShowsNowFragment.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/history/ShowsNowFragment.java
@@ -14,7 +14,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -140,7 +142,11 @@ public class ShowsNowFragment extends Fragment {
                     traktFriendsHistoryCallbacks);
         }
 
-        setHasOptionsMenu(true);
+        requireActivity().addMenuProvider(
+                optionsMenuProvider,
+                getViewLifecycleOwner(),
+                Lifecycle.State.RESUMED
+        );
     }
 
     @Override
@@ -187,27 +193,22 @@ public class ShowsNowFragment extends Fragment {
         binding = null;
     }
 
-    @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
-
-        // guard against not attached to activity
-        if (!isAdded()) {
-            return;
+    private final MenuProvider optionsMenuProvider = new MenuProvider() {
+        @Override
+        public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater menuInflater) {
+            menuInflater.inflate(R.menu.shows_now_menu, menu);
         }
 
-        inflater.inflate(R.menu.shows_now_menu, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        int itemId = item.getItemId();
-        if (itemId == R.id.menu_action_shows_now_refresh) {
-            refreshStream();
-            return true;
+        @Override
+        public boolean onMenuItemSelected(@NonNull MenuItem menuItem) {
+            int itemId = menuItem.getItemId();
+            if (itemId == R.id.menu_action_shows_now_refresh) {
+                refreshStream();
+                return true;
+            }
+            return false;
         }
-        return super.onOptionsItemSelected(item);
-    }
+    };
 
     private void refreshStream() {
         showProgressBar(true);

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/SeasonsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/SeasonsFragment.kt
@@ -12,8 +12,10 @@ import android.widget.PopupMenu
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.os.bundleOf
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.battlelancer.seriesguide.R
@@ -55,8 +57,6 @@ class SeasonsFragment() : Fragment() {
         arguments?.run {
             showId = getLong(ARG_LONG_SHOW_ROW_ID)
         } ?: throw IllegalArgumentException("Missing arguments")
-
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -99,6 +99,12 @@ class SeasonsFragment() : Fragment() {
         PreferenceManager.getDefaultSharedPreferences(requireContext()).apply {
             registerOnSharedPreferenceChangeListener(onSortOrderChangedListener)
         }
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     override fun onStart() {
@@ -129,18 +135,21 @@ class SeasonsFragment() : Fragment() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.seasons_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.seasons_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val itemId = item.itemId
-        return if (itemId == R.id.menu_sesortby) {
-            showSortDialog()
-            true
-        } else {
-            super.onOptionsItemSelected(item)
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_sesortby -> {
+                    showSortDialog()
+                    true
+                }
+                else -> {
+                    false
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/search/discover/ShowsDiscoverFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/search/discover/ShowsDiscoverFragment.kt
@@ -8,7 +8,9 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.FragmentShowsDiscoverBinding
@@ -56,8 +58,6 @@ class ShowsDiscoverFragment : BaseAddShowsFragment() {
             )
             queryEvent?.query ?: ""
         }
-
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateView(
@@ -123,6 +123,12 @@ class ShowsDiscoverFragment : BaseAddShowsFragment() {
         model.watchProviderIds.observe(viewLifecycleOwner) {
             loadResults()
         }
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     private val discoverItemClickListener = object : ShowsDiscoverAdapter.OnItemClickListener {
@@ -199,26 +205,28 @@ class ShowsDiscoverFragment : BaseAddShowsFragment() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.shows_discover_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.shows_discover_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_action_shows_search_clear_history -> {
-                // tell the hosting activity to clear the search view history
-                EventBus.getDefault().post(SearchActivityImpl.ClearSearchHistoryEvent())
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_action_shows_search_clear_history -> {
+                    // tell the hosting activity to clear the search view history
+                    EventBus.getDefault().post(SearchActivityImpl.ClearSearchHistoryEvent())
+                    true
+                }
+                R.id.menu_action_shows_search_filter -> {
+                    DiscoverFilterFragment.showForShows(parentFragmentManager)
+                    true
+                }
+                R.id.menu_action_shows_search_change_language -> {
+                    displayLanguageSettings()
+                    true
+                }
+                else -> false
             }
-            R.id.menu_action_shows_search_filter -> {
-                DiscoverFilterFragment.showForShows(parentFragmentManager)
-                true
-            }
-            R.id.menu_action_shows_search_change_language -> {
-                displayLanguageSettings()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/search/popular/ShowsPopularFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/search/popular/ShowsPopularFragment.kt
@@ -7,7 +7,9 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.LoadState
 import com.battlelancer.seriesguide.R
@@ -33,11 +35,6 @@ class ShowsPopularFragment : BaseAddShowsFragment() {
 
     private val model: ShowsPopularViewModel by viewModels()
     private lateinit var adapter: ShowsPopularAdapter
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -94,20 +91,27 @@ class ShowsPopularFragment : BaseAddShowsFragment() {
                 }
             }
         }
+
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.shows_popular_menu, menu)
-    }
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.shows_popular_menu, menu)
+        }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.menu_action_shows_popular_filter -> {
-                DiscoverFilterFragment.showForShows(parentFragmentManager)
-                true
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                R.id.menu_action_shows_popular_filter -> {
+                    DiscoverFilterFragment.showForShows(parentFragmentManager)
+                    true
+                }
+                else -> false
             }
-            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/search/similar/SimilarShowsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/search/similar/SimilarShowsFragment.kt
@@ -8,8 +8,10 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.MenuProvider
 import androidx.core.view.isGone
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.shows.search.discover.BaseAddShowsFragment
@@ -90,7 +92,11 @@ class SimilarShowsFragment : BaseAddShowsFragment() {
             swipeRefreshLayout.isRefreshing = false
         }
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     private fun loadSimilarShows() {
@@ -103,26 +109,26 @@ class SimilarShowsFragment : BaseAddShowsFragment() {
         (activity as AppCompatActivity).supportActionBar?.subtitle = showTitle
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-
-        menu.add(0, MENU_ITEM_SEARCH_ID, 0, R.string.search).apply {
-            setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
-            setIcon(R.drawable.ic_search_white_24dp)
-        }
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            MENU_ITEM_SEARCH_ID -> {
-                startActivity(
-                    SearchActivity.newIntent(
-                        requireContext()
-                    )
-                )
-                true
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menu.add(0, MENU_ITEM_SEARCH_ID, 0, R.string.search).apply {
+                setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+                setIcon(R.drawable.ic_search_white_24dp)
             }
-            else -> super.onOptionsItemSelected(item)
+        }
+
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            return when (menuItem.itemId) {
+                MENU_ITEM_SEARCH_ID -> {
+                    startActivity(
+                        SearchActivity.newIntent(
+                            requireContext()
+                        )
+                    )
+                    true
+                }
+                else -> false
+            }
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/stats/StatsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/stats/StatsFragment.kt
@@ -8,9 +8,11 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuProvider
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.FragmentStatsBinding
@@ -84,7 +86,11 @@ class StatsFragment : Fragment() {
 
         model.statsData.observe(viewLifecycleOwner) { this.handleStatsUpdate(it) }
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(
+            optionsMenuProvider,
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
     }
 
     override fun onDestroyView() {
@@ -93,36 +99,32 @@ class StatsFragment : Fragment() {
         binding = null
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.stats_menu, menu)
 
-        // guard against not attached to activity
-        if (!isAdded) {
-            return
+            menu.findItem(R.id.menu_action_stats_filter_specials).isChecked =
+                DisplaySettings.isHidingSpecials(requireContext())
         }
 
-        inflater.inflate(R.menu.stats_menu, menu)
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            when (menuItem.itemId) {
+                R.id.menu_action_stats_share -> {
+                    shareStats()
+                    return true
+                }
+                R.id.menu_action_stats_filter_specials -> {
+                    PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
+                        .putBoolean(DisplaySettings.KEY_HIDE_SPECIALS, !menuItem.isChecked)
+                        .apply()
 
-        menu.findItem(R.id.menu_action_stats_filter_specials).isChecked =
-            DisplaySettings.isHidingSpecials(requireContext())
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val itemId = item.itemId
-        if (itemId == R.id.menu_action_stats_share) {
-            shareStats()
-            return true
+                    requireActivity().invalidateOptionsMenu()
+                    loadStats()
+                    return true
+                }
+                else -> return false
+            }
         }
-        if (itemId == R.id.menu_action_stats_filter_specials) {
-            PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
-                .putBoolean(DisplaySettings.KEY_HIDE_SPECIALS, !item.isChecked)
-                .apply()
-
-            requireActivity().invalidateOptionsMenu()
-            loadStats()
-            return true
-        }
-        return super.onOptionsItemSelected(item)
     }
 
     private fun loadStats() {


### PR DESCRIPTION
https://developer.android.com/jetpack/androidx/releases/activity#1.4.0-alpha01

Not touching activities, as they may just override `onOptionsItemSelected` to react to the `android.R.id.home` button press. Also not deprecated, so not sure this should be changed at all.