### PR TITLE
Android 13: request notification permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Version 67
 ----------
 *in development*
 
+* 🔧 On Android 8 and newer, use system settings to configure notification settings.
+
 #### 67.0.0 🧪
 *2023-01-27*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version 67
 *in development*
 
 * 🔧 On Android 8 and newer, use system settings to configure notification settings.
+* 🔧 On Android 13 and newer, ask to allow notifications.
 
 #### 67.0.0 🧪
 *2023-01-27*

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,8 +22,10 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <!-- Show shortcuts -->
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
-    <!-- To schedule episode release notifications -->
+    <!-- Android 12: to schedule episode release notifications. -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <!-- Android 13: to request notification permission. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
@@ -177,7 +177,11 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             // Android 8+: use system settings to manage notifications.
             val channelsPref: Preference = findPreference(NotificationSettings.KEY_CHANNELS)!!
             if (isSupporter) {
-                channelsPref.summary = null
+                if (NotificationSettings.areNotificationsAllowed(requireContext())) {
+                    channelsPref.summary = null
+                } else {
+                    channelsPref.setSummary(R.string.notifications_allow_reason)
+                }
                 channelsPref.setOnPreferenceClickListener {
                     val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
                         .putExtra(Settings.EXTRA_APP_PACKAGE, requireActivity().packageName)

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
@@ -57,11 +57,23 @@ object NotificationSettings {
      */
     fun isNotificationsEnabled(context: Context): Boolean {
         return if (AndroidUtils.isAtLeastOreo) {
-            context.getSystemService<NotificationManager>()?.areNotificationsEnabled()
-                ?: false
+            return areNotificationsAllowed(context)
         } else {
             PreferenceManager.getDefaultSharedPreferences(context)
                 .getBoolean(KEY_ENABLED, true)
+        }
+    }
+
+    /**
+     * On Android 8+, returns if notifications are enabled in system settings.
+     * On older versions always returns true.
+     */
+    fun areNotificationsAllowed(context: Context): Boolean {
+        return if (AndroidUtils.isAtLeastOreo) {
+            context.getSystemService<NotificationManager>()?.areNotificationsEnabled()
+                ?: false
+        } else {
+            true
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
@@ -1,9 +1,11 @@
 package com.battlelancer.seriesguide.settings
 
+import android.app.NotificationManager
 import android.content.Context
 import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
 import com.battlelancer.seriesguide.R
 import com.uwetrottmann.androidutils.AndroidUtils
@@ -46,9 +48,21 @@ object NotificationSettings {
 
     private const val THRESHOLD_DEFAULT_MIN = 10
 
+    /**
+     * On Android 8+, returns if notifications are enabled in system settings.
+     * On older versions, checks if the app preference is true.
+     *
+     * Note that even if enabled, check [com.battlelancer.seriesguide.util.Utils.hasAccessToX] if
+     * the user is eligible to receive convenience notifications (for new episodes).
+     */
     fun isNotificationsEnabled(context: Context): Boolean {
-        return PreferenceManager.getDefaultSharedPreferences(context)
-            .getBoolean(KEY_ENABLED, true)
+        return if (AndroidUtils.isAtLeastOreo) {
+            context.getSystemService<NotificationManager>()?.areNotificationsEnabled()
+                ?: false
+        } else {
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(KEY_ENABLED, true)
+        }
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
@@ -12,10 +12,12 @@ import com.battlelancer.seriesguide.databinding.ViewFirstRunBinding
 import com.battlelancer.seriesguide.dataliberation.AutoBackupTools
 import com.battlelancer.seriesguide.settings.AppSettings
 import com.battlelancer.seriesguide.settings.DisplaySettings
+import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.settings.UpdateSettings
 import com.battlelancer.seriesguide.util.TaskManager
 import com.battlelancer.seriesguide.util.TextTools
 import com.battlelancer.seriesguide.util.Utils
+import com.uwetrottmann.androidutils.AndroidUtils
 
 class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     FrameLayout(context, attrs) {
@@ -25,6 +27,7 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
         fun onSignInClicked()
         fun onRestoreBackupClicked()
         fun onRestoreAutoBackupClicked()
+        fun onAllowNotificationsClicked()
         fun onDismissClicked()
     }
 
@@ -35,6 +38,12 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+
+        binding.groupAllowNotifications.isGone =
+            !AndroidUtils.isAtLeastTiramisu || NotificationSettings.areNotificationsAllowed(context)
+        binding.buttonAllowNotifications.setOnClickListener {
+            clickListener?.onAllowNotificationsClicked()
+        }
 
         binding.groupAutoBackupDetected.isGone =
             !AutoBackupTools.isAutoBackupMaybeAvailable(context)

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsAdapter.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsAdapter.kt
@@ -32,6 +32,12 @@ class ShowsAdapter(
 
     var displayFirstRunHeader: Boolean = false
 
+    fun refreshFirstRunHeader() {
+        if (displayFirstRunHeader) {
+            notifyItemChanged(0)
+        }
+    }
+
     override fun submitList(list: MutableList<ShowItem>?) {
         if (displayFirstRunHeader) {
             val modifiedList = list ?: mutableListOf()

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
@@ -1,5 +1,6 @@
 package com.battlelancer.seriesguide.shows.overview
 
+import android.Manifest
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -9,6 +10,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.os.bundleOf
 import androidx.core.widget.NestedScrollView
@@ -20,6 +22,7 @@ import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.comments.TraktCommentsActivity
 import com.battlelancer.seriesguide.people.PeopleListHelper
+import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.shows.database.SgShow2
 import com.battlelancer.seriesguide.shows.overview.OverviewActivityImpl.OverviewLayoutType.MULTI_PANE_VERTICAL
 import com.battlelancer.seriesguide.shows.search.similar.SimilarShowsActivity
@@ -27,6 +30,7 @@ import com.battlelancer.seriesguide.shows.tools.ShowStatus
 import com.battlelancer.seriesguide.tmdbapi.TmdbTools
 import com.battlelancer.seriesguide.traktapi.RateDialogFragment
 import com.battlelancer.seriesguide.traktapi.TraktTools
+import com.battlelancer.seriesguide.ui.BaseMessageActivity
 import com.battlelancer.seriesguide.ui.FullscreenImageActivity
 import com.battlelancer.seriesguide.ui.dialogs.L10nDialogFragment
 import com.battlelancer.seriesguide.util.ImageTools
@@ -42,6 +46,8 @@ import com.battlelancer.seriesguide.util.Utils
 import com.battlelancer.seriesguide.util.ViewTools
 import com.battlelancer.seriesguide.util.copyTextToClipboardOnLongClick
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.snackbar.Snackbar
+import com.uwetrottmann.androidutils.AndroidUtils
 import com.uwetrottmann.tmdb2.entities.Credits
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
@@ -228,6 +234,25 @@ class ShowFragment() : Fragment() {
         binding = null
     }
 
+    private fun showNotificationsNotAllowedMessage() {
+        (activity as BaseMessageActivity?)?.snackbarParentView
+            ?.let {
+                Snackbar
+                    .make(it, R.string.notifications_allow_reason, Snackbar.LENGTH_LONG)
+                    .show()
+            }
+    }
+
+    private val requestNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                // Re-bind show views to update notification button state.
+                populateShow(model.show.value, model.hasAccessToX.value)
+            } else {
+                showNotificationsNotAllowedMessage()
+            }
+        }
+
     private fun populateShow(show: SgShow2?, hasAccessToX: Boolean?) {
         if (show == null || hasAccessToX == null) return
         val binding = binding ?: return
@@ -289,7 +314,8 @@ class ShowFragment() : Fragment() {
         }
 
         // Notifications button, always show as disabled if user is not a sub.
-        val notify = show.notify && hasAccessToX
+        val areNotificationsAllowed = NotificationSettings.areNotificationsAllowed(requireContext())
+        val notify = show.notify && hasAccessToX && areNotificationsAllowed
         binding.buttonNotify.apply {
             contentDescription = getString(
                 if (notify) {
@@ -308,13 +334,19 @@ class ShowFragment() : Fragment() {
             )
             isEnabled = true
             setOnClickListener { v ->
-                if (hasAccessToX) {
+                if (!hasAccessToX) {
+                    Utils.advertiseSubscription(activity)
+                } else if (!areNotificationsAllowed) {
+                    if (AndroidUtils.isAtLeastTiramisu) {
+                        requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    } else {
+                        showNotificationsNotAllowedMessage()
+                    }
+                } else {
                     // disable until action is complete
                     v.isEnabled = false
                     SgApp.getServicesComponent(requireContext()).showTools()
                         .storeNotify(showId, !notify)
-                } else {
-                    Utils.advertiseSubscription(activity)
                 }
             }
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowViewModel.kt
@@ -8,7 +8,9 @@ import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.tmdbapi.TmdbTools2
+import com.battlelancer.seriesguide.util.Utils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class ShowViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -26,8 +28,27 @@ class ShowViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * This currently does not auto-update, it maybe should at some point (add global LiveData).
+     */
+    val hasAccessToX = MutableLiveData<Boolean>()
+
+    init {
+        updateUserStatus()
+    }
+
     fun setShowId(showId: Long) {
         this.showId.value = showId
+    }
+
+    fun updateUserStatus() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val currentState = hasAccessToX.value
+            val newState = Utils.hasAccessToX(getApplication())
+            if (currentState != newState) {
+                hasAccessToX.postValue(newState)
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseMessageActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseMessageActivity.kt
@@ -88,9 +88,9 @@ abstract class BaseMessageActivity : BaseActivity() {
     }
 
     /**
-     * Return a view to pass to [Snackbar.make], ideally a [CoordinatorLayout].
+     * Return a view to pass to [Snackbar.make], ideally a CoordinatorLayout.
      */
-    protected open val snackbarParentView: View
+    open val snackbarParentView: View
         get() = findViewById(android.R.id.content)
 
     private fun handleServiceActiveEvent(event: ServiceActiveEvent?) {

--- a/app/src/main/res/layout/view_first_run.xml
+++ b/app/src/main/res/layout/view_first_run.xml
@@ -36,6 +36,31 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
+            android:id="@+id/textViewAllowNotificationsExplainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="center"
+            android:text="@string/notifications_allow_reason"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewTitle" />
+
+        <Button
+            android:id="@+id/buttonAllowNotifications"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/notifications_allow"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewAllowNotificationsExplainer" />
+
+        <TextView
             android:id="@+id/textViewAutoBackupDetected"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -47,7 +72,7 @@
             android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textViewTitle" />
+            app:layout_constraintTop_toBottomOf="@id/buttonAllowNotifications" />
 
         <Button
             android:id="@+id/buttonRestoreAutoBackup"
@@ -58,7 +83,7 @@
             android:text="@string/restore_auto_backup"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textViewAutoBackupDetected" />
+            app:layout_constraintTop_toBottomOf="@id/textViewAutoBackupDetected" />
 
         <!-- Wrap CheckBox in FrameLayout to get full size selectable background. -->
         <FrameLayout
@@ -209,6 +234,12 @@
             android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/containerErrorReports" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/groupAllowNotifications"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="textViewAllowNotificationsExplainer,buttonAllowNotifications" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/groupAutoBackupDetected"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -496,6 +496,7 @@
     <string name="upcoming_display">حدد هذا الخيار لعرض المسلسلات القادمة</string>
     <string name="pref_notifications">التنبيهات</string>
     <string name="pref_notificationssummary">التنبيه عن الحلقات الجديدة</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">نغمة التنبيه</string>
     <string name="pref_vibrate">إهتزاز</string>
     <string name="pref_vibratesummary">إهتزاز عند عرض التنبيه</string>
@@ -509,6 +510,8 @@
     <string name="pref_notifications_next_episodes_only_summary">تنبيه فقط اذا الحلقة الجديدة ستشاهد تالياً</string>
     <string name="pref_notifications_battery_settings">إعدادات البطارية</string>
     <string name="pref_notifications_battery_settings_summary">الذهاب إلى إعدادات البطارية لتعطيل تحسينات البطارية للإشعارات الموثوقة</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">إخفاء الحلقات المشاهدة</string>
     <string name="pref_widget_opacity">خلفية القطعة العائمة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Изберете да се показват предстоящи сериали</string>
     <string name="pref_notifications">Известия</string>
     <string name="pref_notificationssummary">Известяване за нови епизоди</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Мелодия</string>
     <string name="pref_vibrate">Вибрация</string>
     <string name="pref_vibratesummary">Също вибриране за показване на известие</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Известява само ако новият епизод е следващият за мен</string>
     <string name="pref_notifications_battery_settings">Настройки на батерията</string>
     <string name="pref_notifications_battery_settings_summary">Изключи оптимизациите на батерията от Настройки на батерия за сигурни нотификации</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Скрий гледаните епизоди</string>
     <string name="pref_widget_opacity">Фон на уиджета</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Seleccioneu-ho per veure les sèries que han de sortir</string>
     <string name="pref_notifications">Notificacions</string>
     <string name="pref_notificationssummary">Notifica\'m de tots els episodis nous</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">To de notificació</string>
     <string name="pref_vibrate">Vibració</string>
     <string name="pref_vibratesummary">Vibra quan mostris una notificació</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Notifiqueu només si el nou episodi és el següent que es pugui veure</string>
     <string name="pref_notifications_battery_settings">Configuració de la bateria</string>
     <string name="pref_notifications_battery_settings_summary">Vés als ajustaments de la bateria per deshabilitar les optimitzacions de bateria per rebre notificacions</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Amaga els episodis vistos</string>
     <string name="pref_widget_opacity">Fons del widget</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">Vyberte pro zobrazení nadcházejících seriálů</string>
     <string name="pref_notifications">Upozornění</string>
     <string name="pref_notificationssummary">Upozorňovat na nové epizody</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Zvuk</string>
     <string name="pref_vibrate">Vibrace</string>
     <string name="pref_vibratesummary">Při upozornění také vibrovat</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Upozornit pouze v případě, že nová epizoda je další epizoda ke sledování</string>
     <string name="pref_notifications_battery_settings">Nastavení baterie</string>
     <string name="pref_notifications_battery_settings_summary">Pro spolehlivá oznámení přejděte do nastavení baterie a zakažte optimalizaci baterie.</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skrýt zhlédnuté epizody</string>
     <string name="pref_widget_opacity">Pozadí widgetu</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -496,6 +496,7 @@
     <string name="upcoming_display">Dewiswch i arddangos sioeau sydd ar ddod</string>
     <string name="pref_notifications">Hysbysiadau</string>
     <string name="pref_notificationssummary">Hysbysu am benodau newydd</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Sain</string>
     <string name="pref_vibrate">Dirgrynu</string>
     <string name="pref_vibratesummary">Dirgrynu hefyd wrth arddangos hysbysiad</string>
@@ -509,6 +510,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Peidiwch â hysbysu os mai\'r bennod newydd yw\'r un nesaf i\'w gwylio</string>
     <string name="pref_notifications_battery_settings">Gosodiadau batri</string>
     <string name="pref_notifications_battery_settings_summary">Ewch i leoliadau Batri i analluogi optimeiddiadau batri ar gyfer hysbysiadau dibynadwy</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Cuddio penodau gwylio</string>
     <string name="pref_widget_opacity">Cefndir Widget</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Vælg for at vise kommende serier</string>
     <string name="pref_notifications">Meddelelser</string>
     <string name="pref_notificationssummary">Notificér om nye episoder</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Lyd</string>
     <string name="pref_vibrate">Vibrér</string>
     <string name="pref_vibratesummary">Vibrér også ved visning af meddelelse</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Underret mig kun, hvis den nye episode er den næste på afspilningslisten</string>
     <string name="pref_notifications_battery_settings">Batteriindstillinger</string>
     <string name="pref_notifications_battery_settings_summary">Gå til Batteriindstillinger for at deaktivere batterioptimeringer for pålidelige meddelelser</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skjul sete episoder</string>
     <string name="pref_widget_opacity">Widget-baggrund</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Auswählen um kommende Serien anzuzeigen</string>
     <string name="pref_notifications">Benachrichtigungen</string>
     <string name="pref_notificationssummary">Benachrichtigung bei neuen Folgen</string>
+    <string name="pref_notifications_settings">Benachrichtigungseinstellungen</string>
     <string name="pref_ringtone">Ton</string>
     <string name="pref_vibrate">Vibrieren</string>
     <string name="pref_vibratesummary">Bei Anzeige einer Benachrichtigung vibrieren</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Nur benachrichtigen, wenn die neue Folge die nächste anzusehende ist</string>
     <string name="pref_notifications_battery_settings">Akku-Einstellungen</string>
     <string name="pref_notifications_battery_settings_summary">Zu Akku-Einstellungen gehen um Akkuverbrauch optimieren für zuverlässige Benachrichtigungen auszuschalten</string>
+    <string name="notifications_allow">Benachrichtigungen erlauben</string>
+    <string name="notifications_allow_reason">Um Benachrichtigungen für Folgen oder Fehler zu erhalten, erlauben Sie diese in den Einstellungen.</string>
     <!-- List Widget -->
     <string name="hide_watched">Angesehene Folgen verstecken</string>
     <string name="pref_widget_opacity">Widget-Hintergrund</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Επιλέξτε, για να εμφανίσετε τις επερχόμενες σειρές</string>
     <string name="pref_notifications">Ειδοποιήσεις</string>
     <string name="pref_notificationssummary">Ειδοποίηση για νέα επεισόδια</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Ήχος κλήσης</string>
     <string name="pref_vibrate">Δόνηση</string>
     <string name="pref_vibratesummary">Δόνηση και κατά την εμφάνιση ειδοποίησης</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Ειδοποίηση μόνο αν το νέο επιεσόδιο είναι το επόμενο για προβολή</string>
     <string name="pref_notifications_battery_settings">Ρυθμίσεις μπαταρίας</string>
     <string name="pref_notifications_battery_settings_summary">Πηγαίνετε στις Ρυθμίσεις μπαταρίας για να απενεργοποιήσετε τις βελτιστοποιήσεις μπαταρίας για αξιόπιστες ειδοποιήσεις</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Απόκρυψη παρακολουθημένων επεισοδίων</string>
     <string name="pref_widget_opacity">Φόντο widget</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Elekti por montri venontajn televidaĵojn</string>
     <string name="pref_notifications">Sciigoj</string>
     <string name="pref_notificationssummary">Sciigi pri novaj epizodoj</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Sono</string>
     <string name="pref_vibrate">Vibri</string>
     <string name="pref_vibratesummary">Ankaŭ vibri dum montrado de sciigo</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Nur sciigi se la nova epizodo estas la sekva por spekti</string>
     <string name="pref_notifications_battery_settings">Agordoj de baterio</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Kaŝi spektitajn epizodojn</string>
     <string name="pref_widget_opacity">Fenestraĵa fono</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -453,6 +453,7 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="upcoming_display">Seleccione esta opción para mostrar las series que vienen</string>
     <string name="pref_notifications">Notificaciones</string>
     <string name="pref_notificationssummary">Notificar sobre nuevos episodios</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Ringtone</string>
     <string name="pref_vibrate">Vibrar</string>
     <string name="pref_vibratesummary">También vibrar al mostrar una notificación</string>
@@ -466,6 +467,8 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="pref_notifications_next_episodes_only_summary">Solo notificar si el nuevo episodio es el siguiente para ver</string>
     <string name="pref_notifications_battery_settings">Ajustes de batería</string>
     <string name="pref_notifications_battery_settings_summary">Ir a la configuración de la batería para desactivar las optimizaciones de la batería para obtener notificaciones fiables</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episodios vistos</string>
     <string name="pref_widget_opacity">Fondo de widget</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">گزینش برای نشان دادن نمایش‌های پیش رو</string>
     <string name="pref_notifications">آگاهی‌ها</string>
     <string name="pref_notificationssummary">آگاهی دربارهٔ قسمت‌های جدید</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">صدا</string>
     <string name="pref_vibrate">لرزش</string>
     <string name="pref_vibratesummary">ارزش هنگام نمایش آگهی</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">آگاهی فقط در صورتی که قسمت جدید، قسمت بعدی‌ایست که باید دیده شود</string>
     <string name="pref_notifications_battery_settings">تنظیمات باتری</string>
     <string name="pref_notifications_battery_settings_summary">به منظور آگاهی‌های قابل اتّکا، برای از کار انداختن بهینه‌سازی‌های باتری به تنظیمات باتری بروید</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">نهفتن قسمت‌های تماشا شده</string>
     <string name="pref_widget_opacity">پس‌زمینهٔ ابزارک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Valitse näyttääksesi tulevat ohjelmat</string>
     <string name="pref_notifications">Ilmoitukset</string>
     <string name="pref_notificationssummary">Ilmoita uusista jaksoista</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Ääni</string>
     <string name="pref_vibrate">Värinä</string>
     <string name="pref_vibratesummary">Värise ilmoitusta näytettäessä</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Ilmoita vain, jos uusi jakso on seuraava katsottava</string>
     <string name="pref_notifications_battery_settings">Akkuasetukset</string>
     <string name="pref_notifications_battery_settings_summary">Siirry kohtaan Akku-asetukset poistaaksesi käytöstä akkuoptimoinnit luotettavien ilmoitusten saamiseksi</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Piilota katsotut jaksot</string>
     <string name="pref_widget_opacity">Widgetin tausta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Afficher les épisodes à venir</string>
     <string name="pref_notifications">Notifications</string>
     <string name="pref_notificationssummary">M\'informer des nouveaux épisodes</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Sonnerie</string>
     <string name="pref_vibrate">Vibrer</string>
     <string name="pref_vibratesummary">Vibrer aussi lors d\'un notification</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Notifier seulement si le prochain épisode sorti est celui à regarder</string>
     <string name="pref_notifications_battery_settings">Paramètres de batterie</string>
     <string name="pref_notifications_battery_settings_summary">Aller dans les paramètres de batterie pour désactiver l\'optimisation de la batterie afin de recevoir correctement les notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Masquer les épisodes vus</string>
     <string name="pref_widget_opacity">Arrière-plan du widget</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Select to display upcoming shows</string>
     <string name="pref_notifications">Notificacións</string>
     <string name="pref_notificationssummary">Notify about new episodes</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Son</string>
     <string name="pref_vibrate">Vibrar</string>
     <string name="pref_vibratesummary">Also vibrate on displaying a notification</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Só notificar se o novo episodio é o seguinte a ver</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Agochar episodios vistos</string>
     <string name="pref_widget_opacity">Fondo do widget</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -463,6 +463,7 @@
     <string name="upcoming_display">Odaberite za prikaz nadolazećih emisija</string>
     <string name="pref_notifications">Obavijesti</string>
     <string name="pref_notificationssummary">Obavijesti o novim epizodama</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Zvuk obavijesti</string>
     <string name="pref_vibrate">Vibriraj</string>
     <string name="pref_vibratesummary">Također vibriraj pri prikazu obavijesti</string>
@@ -476,6 +477,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Obavijesti samo ako je nova episode sljedeća za gledanje</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Sakrij pogledane epizode</string>
     <string name="pref_widget_opacity">Pozadina widgeta</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Válassza ki a közelgő műsorok megjelenítéséhez</string>
     <string name="pref_notifications">Értesítések</string>
     <string name="pref_notificationssummary">Értesítés új epizódoknál</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Értesítési hang</string>
     <string name="pref_vibrate">Rezgés</string>
     <string name="pref_vibratesummary">Rezgés értesítések megjelenítésekor</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Csak akkor értesítsen, ha az új epizód a következő, amelyet meg kell nézni</string>
     <string name="pref_notifications_battery_settings">Akkumulátor beállítások</string>
     <string name="pref_notifications_battery_settings_summary">Lépjen az Akkumulátorbeállítások elemre, és tiltsa le az akkumulátoroptimalizálást a megbízható értesítésekért</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Megnézett epizódok elrejtése</string>
     <string name="pref_widget_opacity">Widget háttér</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">Pilih untuk menampilkan acara yang akan datang</string>
     <string name="pref_notifications">Notifikasi</string>
     <string name="pref_notificationssummary">Beritahu tentang episode baru</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Suara</string>
     <string name="pref_vibrate">Getar</string>
     <string name="pref_vibratesummary">Juga bergetar saat menampilkan pemberitahuan</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Hanya beri tahu jika episode baru adalah yang berikutnya untuk ditonton</string>
     <string name="pref_notifications_battery_settings">Pengaturan baterai</string>
     <string name="pref_notifications_battery_settings_summary">Buka Pengaturan baterai untuk menonaktifkan pengoptimalan baterai untuk notifikasi yang dapat diandalkan</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Sembunyikan episode yang telah ditonton</string>
     <string name="pref_widget_opacity">Latar belakang widget</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Mostra le serie che stanno per essere trasmesse</string>
     <string name="pref_notifications">Notifiche</string>
     <string name="pref_notificationssummary">Notifica nuovi episodi</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Suoneria</string>
     <string name="pref_vibrate">Vibrazione</string>
     <string name="pref_vibratesummary">Vibra alla visualizzazione di una notifica</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Notifica solo se il nuovo episodio è il prossimo da guardare</string>
     <string name="pref_notifications_battery_settings">Impostazioni batteria</string>
     <string name="pref_notifications_battery_settings_summary">Vai nelle impostazioni della batteria e disattiva le ottimizzazioni per notifiche più affidabili</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Nascondi episodi già visti</string>
     <string name="pref_widget_opacity">Sfondo widget</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">בחר כדי להציג סדרות שמתקרבות</string>
     <string name="pref_notifications">התראות</string>
     <string name="pref_notificationssummary">עדכן אותי על פרקים חדשים</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">רינגטון</string>
     <string name="pref_vibrate">רטט</string>
     <string name="pref_vibratesummary">רטוט גם בזמן הצגת התראות</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">התראה רק אם הפרק החדש הוא הבא לצפייה</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">הסתר פרקים שנצפו</string>
     <string name="pref_widget_opacity">רקע ווידג\'ט</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">表示する今後の番組を選択</string>
     <string name="pref_notifications">通知</string>
     <string name="pref_notificationssummary">新しいエピソードについて通知します</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">サウンド</string>
     <string name="pref_vibrate">バイブレート</string>
     <string name="pref_vibratesummary">通知を表示する時にバイブレーションする</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">新しいエピソードが、次に視聴するエピソードである場合にのみ通知します</string>
     <string name="pref_notifications_battery_settings">バッテリー設定</string>
     <string name="pref_notifications_battery_settings_summary">バッテリー設定に移動して、バッテリーの最適化を無効にし、信頼性の高い通知を表示します</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">視聴済のエピソードを非表示</string>
     <string name="pref_widget_opacity">ウィジェットの背景</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">방영 예정인 프로그램을 표시하려면 선택하세요</string>
     <string name="pref_notifications">알림</string>
     <string name="pref_notificationssummary">새로운 에피소드를 알려줍니다.</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">벨소리</string>
     <string name="pref_vibrate">진동</string>
     <string name="pref_vibratesummary">알림 시 진동</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">배터리 설정</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">시청한 에피소드 숨기기</string>
     <string name="pref_widget_opacity">위젯 배경</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Селектирај за да се прикажат сериите што следат</string>
     <string name="pref_notifications">Нотификација</string>
     <string name="pref_notificationssummary">Покажи нотификација за нови епизоди</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Звук</string>
     <string name="pref_vibrate">Вибрирање</string>
     <string name="pref_vibratesummary">Исто вибрирај на нотификација на дисплејот</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Сокриј веќе гледани епизоди</string>
     <string name="pref_widget_opacity">Widget позадина</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Velg for å vise kommende serier</string>
     <string name="pref_notifications">Varsler</string>
     <string name="pref_notificationssummary">Varsle om nye episoder</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Ringetone</string>
     <string name="pref_vibrate">Vibrer</string>
     <string name="pref_vibratesummary">Vibrer også ved visning av varsel</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Bare varsle hvis den nye episoden er den neste jeg skal se</string>
     <string name="pref_notifications_battery_settings">Innstillinger for batteri</string>
     <string name="pref_notifications_battery_settings_summary">Gå til Batteriinnstillinger for å deaktivere batterioptimalisering for pålitelige varsler</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skjul sette episoder</string>
     <string name="pref_widget_opacity">Modulbakgrunn</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Selecteer om toekomstige series weer te geven</string>
     <string name="pref_notifications">Meldingen</string>
     <string name="pref_notificationssummary">Verwittigen bij nieuwe afleveringen</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Geluid</string>
     <string name="pref_vibrate">Trillen</string>
     <string name="pref_vibratesummary">Ook trillen als melding wordt weergegeven</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Meld alleen als de nieuwe aflevering de eerstvolgende is om te kijken</string>
     <string name="pref_notifications_battery_settings">Batterij instellingen</string>
     <string name="pref_notifications_battery_settings_summary">Ga naar Batterij instellingen om batterij optimalisaties uit te schakelen voor betrouwbare meldingen</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Bekeken afleveringen verbergen</string>
     <string name="pref_widget_opacity">Widget achtergrond</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">Wyświetl informacje o nadchodzących odcinkach</string>
     <string name="pref_notifications">Powiadomienia</string>
     <string name="pref_notificationssummary">Informuj o nowych odcinkach</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Dzwonek</string>
     <string name="pref_vibrate">Wibracja</string>
     <string name="pref_vibratesummary">Wibruj również przy wyświetlaniu powiadomienia</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Powiadamiaj tylko gdy nowy odcinek jest następnym do obejrzenia</string>
     <string name="pref_notifications_battery_settings">Ustawienia baterii</string>
     <string name="pref_notifications_battery_settings_summary">Przejdź do ustawień baterii, aby wyłączyć jej optymalizację, aby otrzymywać powiadomienia na bieżąco</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ukryj obejrzane odcinki</string>
     <string name="pref_widget_opacity">Tło widżetu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Selecione para mostrar próximas séries</string>
     <string name="pref_notifications">Notificações</string>
     <string name="pref_notificationssummary">Notificar sobre novos episódios</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Toque</string>
     <string name="pref_vibrate">Vibrar</string>
     <string name="pref_vibratesummary">Também vibrar ao exibir uma notificação</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Notificar se o novo episódio for o próximo a ser assistido</string>
     <string name="pref_notifications_battery_settings">Configurações de bateria</string>
     <string name="pref_notifications_battery_settings_summary">Vá até Configurações de bateria para desativar sua otimização e receber notificações corretamente</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episódios assistidos</string>
     <string name="pref_widget_opacity">Plano de fundo do widget</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Seleciona para exibir as próximas séries</string>
     <string name="pref_notifications">Notificações</string>
     <string name="pref_notificationssummary">Notificar sobre novos episódios</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Toque de Notificação</string>
     <string name="pref_vibrate">Vibrar</string>
     <string name="pref_vibratesummary">Também vibrará quando surgir uma notificação</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Notificar apenas se o novo episódio for o próximo a ser visto</string>
     <string name="pref_notifications_battery_settings">Definições da Bateria</string>
     <string name="pref_notifications_battery_settings_summary">Vai às Definições da Bateria para desativar a otimização e receber notificações corretamente</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episódios vistos</string>
     <string name="pref_widget_opacity">Plano de fundo do widget</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -463,6 +463,7 @@
     <string name="upcoming_display">Selectați să se afișeze serialele următoare</string>
     <string name="pref_notifications">Notificări</string>
     <string name="pref_notificationssummary">Anunță-mă despre episoadele noi</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Sunet</string>
     <string name="pref_vibrate">Vibrează</string>
     <string name="pref_vibratesummary">Vibrează și la afişarea unei notificări</string>
@@ -476,6 +477,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ascundeți episoadele vizionate</string>
     <string name="pref_widget_opacity">Widget fundal</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">Выберите, чтобы показать предстоящие передачи</string>
     <string name="pref_notifications">Уведомления</string>
     <string name="pref_notificationssummary">Уведомлять о новых эпизодах</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Звуковое уведомление</string>
     <string name="pref_vibrate">Вибросигнал</string>
     <string name="pref_vibratesummary">Вибрация при уведомлении</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Уведомлять только если новая серия следующая для просмотра</string>
     <string name="pref_notifications_battery_settings">Параметры батареи</string>
     <string name="pref_notifications_battery_settings_summary">Перейдите в настройки батареи, чтобы отключить оптимизацию батареи для надежных уведомлений</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Скрывать просмотренные эпизоды</string>
     <string name="pref_widget_opacity">Фон виджета</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">Vyberte pre zobrazenie nadchádzajúcich seriálov</string>
     <string name="pref_notifications">Upozornenia</string>
     <string name="pref_notificationssummary">Upozorňovať na nové epizódy</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Tón upozornenia</string>
     <string name="pref_vibrate">Vibrovať</string>
     <string name="pref_vibratesummary">Pri upozornení vibrovať</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Upozorniť len v prípade, že nová epizóda je ďalšia na videnie</string>
     <string name="pref_notifications_battery_settings">Nastavenia batérie</string>
     <string name="pref_notifications_battery_settings_summary">Prejdite na Nastavenia batérie a deaktivujte optimalizáciu batérie pre spoľahlivé oznámenia</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skryť videné epizódy</string>
     <string name="pref_widget_opacity">Pozadie miniaplikácie</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -463,6 +463,7 @@
     <string name="upcoming_display">Одабери долазеће серије за приказивање</string>
     <string name="pref_notifications">Обавештења</string>
     <string name="pref_notificationssummary">Обавести ме само о новим епизодама</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Звоно</string>
     <string name="pref_vibrate">Вибрирање</string>
     <string name="pref_vibratesummary">Такође вибрирај при обавештењима</string>
@@ -476,6 +477,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Сакриј одгледане епизоде</string>
     <string name="pref_widget_opacity">Позадина виџета</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Välj för att visa kommande serier</string>
     <string name="pref_notifications">Aviseringar</string>
     <string name="pref_notificationssummary">Meddela om nya avsnitt</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Ringsignal</string>
     <string name="pref_vibrate">Vibrera</string>
     <string name="pref_vibratesummary">Vibrerar även när aviseringar visas</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Meddela bara om det nya avsnittet är det nästa att titta på</string>
     <string name="pref_notifications_battery_settings">Batteriinställningar</string>
     <string name="pref_notifications_battery_settings_summary">Gå till Batteriinställningar för att inaktivera batterioptimeringar för tillförlitliga aviseringar</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Dölj sedda avsnitt</string>
     <string name="pref_widget_opacity">Widgetbakgrund</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">வரவிருக்கும் காட்சிகள் காண்பிக்க தேர்ந்தெடு</string>
     <string name="pref_notifications">அறிவிப்புகள்</string>
     <string name="pref_notificationssummary">புதிய episodes பற்றி</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">ஒலி</string>
     <string name="pref_vibrate">அதிர்வு</string>
     <string name="pref_vibratesummary">மேலும் vibrate அறிவிக்கை காண்பிப்பதில் உள்ள</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">பார்த்த episodes மறை</string>
     <string name="pref_widget_opacity">விட்ஜெட் பின்னணி</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">เลือกเพื่อแสดงซีรีส์ที่กำลังมา</string>
     <string name="pref_notifications">การแจ้งเตือน</string>
     <string name="pref_notificationssummary">แจ้งเตือนเกี่ยวกับตอนใหม่</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">เสียง</string>
     <string name="pref_vibrate">สั่น</string>
     <string name="pref_vibratesummary">สั่นเมื่อแสดงการแจ้งเตือนด้วย</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">แจ้งเตือนเฉพาะเมื่อตอนใหม่เป็นตอนที่จะดูต่อเท่านั้น</string>
     <string name="pref_notifications_battery_settings">การตั้งค่าแบตเตอรี่</string>
     <string name="pref_notifications_battery_settings_summary">ไปยังการตั้งค่าแบตเตอรี่ จากนั้นปิดใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่ เพื่อการแจ้งเตือนที่เสถียรขึ้น</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">ซ่อนตอนที่ดูแล้ว</string>
     <string name="pref_widget_opacity">พื้นหลังวิตเจ็ต</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -452,6 +452,7 @@
     <string name="upcoming_display">Gelecek bölümleri görüntülemek için seçin</string>
     <string name="pref_notifications">Bildirimler</string>
     <string name="pref_notificationssummary">Yeni bölümler için bildirim gönder</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Zil sesi</string>
     <string name="pref_vibrate">Titreşim</string>
     <string name="pref_vibratesummary">Uyarırken aynı zamanda titret</string>
@@ -465,6 +466,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Sadece yeni bölüm bir sonraki izlenecek ise uyarı gönder</string>
     <string name="pref_notifications_battery_settings">Pil ayarları</string>
     <string name="pref_notifications_battery_settings_summary">Güvenilir bildirimler almak için Pil ayarlarına giderek, pil optimizasyonlarını devre dışı bırakın</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">İzlenmiş bölümleri gizle</string>
     <string name="pref_widget_opacity">Widget arka planı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -474,6 +474,7 @@
     <string name="upcoming_display">Виберіть для відображення найближчих серіалів</string>
     <string name="pref_notifications">Сповіщення</string>
     <string name="pref_notificationssummary">Повідомляти про нові серії</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Рингтон</string>
     <string name="pref_vibrate">Вібрація</string>
     <string name="pref_vibratesummary">Вібрувати при відображенні сповіщення</string>
@@ -487,6 +488,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Сповіщати лише якщо нова серія буде наступною для перегляду</string>
     <string name="pref_notifications_battery_settings">Налаштування акумулятора</string>
     <string name="pref_notifications_battery_settings_summary">Перейдіть до налаштувань акумулятора, щоб вимкнути оптимізацію живлення для надійних сповіщень</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Приховати переглянуті серії</string>
     <string name="pref_widget_opacity">Фон віджета</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">点按即可显示即将播出的节目</string>
     <string name="pref_notifications">通知</string>
     <string name="pref_notificationssummary">剧集更新通知</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">铃声</string>
     <string name="pref_vibrate">振动</string>
     <string name="pref_vibratesummary">显示通知时振动</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">只在新的剧集是接下来要看的一集时通知</string>
     <string name="pref_notifications_battery_settings">电池设置</string>
     <string name="pref_notifications_battery_settings_summary">转到电池设置，停用电池优化以获取可靠稳定的通知</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">隐藏看过的剧集</string>
     <string name="pref_widget_opacity">微件背景</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -441,6 +441,7 @@
     <string name="upcoming_display">選擇以顯示即將撥出的節目</string>
     <string name="pref_notifications">提示信息</string>
     <string name="pref_notificationssummary">當有新的集數時進行通知</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">提示音</string>
     <string name="pref_vibrate">震動</string>
     <string name="pref_vibratesummary">顯示通知的同時震動</string>
@@ -454,6 +455,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">電池用量設定</string>
     <string name="pref_notifications_battery_settings_summary">前往系統設定停用電池效能最佳化以提升通知可靠性</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">隱藏已看過集數</string>
     <string name="pref_widget_opacity">小工具背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,6 +513,7 @@
     <string name="upcoming_display">Select to display upcoming shows</string>
     <string name="pref_notifications">Notifications</string>
     <string name="pref_notificationssummary">Notify about new episodes</string>
+    <string name="pref_notifications_settings">Notification settings</string>
     <string name="pref_ringtone">Sound</string>
     <string name="pref_vibrate">Vibrate</string>
     <string name="pref_vibratesummary">Also vibrate on displaying a notification</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -527,6 +527,8 @@
     <string name="pref_notifications_next_episodes_only_summary">Only notify if the new episode is the next one to watch</string>
     <string name="pref_notifications_battery_settings">Battery settings</string>
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
+    <string name="notifications_allow">Allow notifications</string>
+    <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
 
     <!-- List Widget -->
     <string name="hide_watched">Hide watched episodes</string>

--- a/app/src/main/res/xml-v26/settings_notifications.xml
+++ b/app/src/main/res/xml-v26/settings_notifications.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <SwitchPreferenceCompat
-        app:defaultValue="true"
+    <Preference
         app:iconSpaceReserved="false"
-        app:key="com.battlelancer.seriesguide.notifications"
-        app:summary="@string/pref_notificationssummary"
-        app:title="@string/pref_notifications" />
+        app:key="com.battlelancer.seriesguide.notifications.channels"
+        app:title="@string/pref_notifications_settings" />
 
     <Preference
         app:iconSpaceReserved="false"
@@ -31,11 +29,6 @@
         app:key="com.uwetrottmann.seriesguide.notifications.nextonly"
         app:summary="@string/pref_notifications_next_episodes_only_summary"
         app:title="@string/pref_notifications_next_episodes_only" />
-
-    <Preference
-        app:iconSpaceReserved="false"
-        app:key="com.battlelancer.seriesguide.notifications.channels"
-        app:title="@string/preferences" />
 
     <Preference
         app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/settings_notifications.xml
+++ b/app/src/main/res/xml/settings_notifications.xml
@@ -8,6 +8,19 @@
         app:summary="@string/pref_notificationssummary"
         app:title="@string/pref_notifications" />
 
+    <CheckBoxPreference
+        app:defaultValue="false"
+        app:iconSpaceReserved="false"
+        app:key="com.battlelancer.seriesguide.notifications.vibrate"
+        app:summary="@string/pref_vibratesummary"
+        app:title="@string/pref_vibrate" />
+
+    <Preference
+        app:defaultValue="content://settings/system/notification_sound"
+        app:iconSpaceReserved="false"
+        app:key="com.battlelancer.seriesguide.notifications.ringtone"
+        app:title="@string/pref_ringtone" />
+
     <Preference
         app:iconSpaceReserved="false"
         app:key="com.battlelancer.seriesguide.notifications.threshold"
@@ -31,19 +44,6 @@
         app:key="com.uwetrottmann.seriesguide.notifications.nextonly"
         app:summary="@string/pref_notifications_next_episodes_only_summary"
         app:title="@string/pref_notifications_next_episodes_only" />
-
-    <CheckBoxPreference
-        app:defaultValue="false"
-        app:iconSpaceReserved="false"
-        app:key="com.battlelancer.seriesguide.notifications.vibrate"
-        app:summary="@string/pref_vibratesummary"
-        app:title="@string/pref_vibrate" />
-
-    <Preference
-        app:defaultValue="content://settings/system/notification_sound"
-        app:iconSpaceReserved="false"
-        app:key="com.battlelancer.seriesguide.notifications.ringtone"
-        app:title="@string/pref_ringtone" />
 
     <Preference
         app:iconSpaceReserved="false"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 buildscript {
     val sgCompileSdk by extra(33) // Android 13 (T)
     val sgMinSdk by extra(21) // Android 5 (L)
-    val sgTargetSdk by extra(31) // Android 12 (S)
+    val sgTargetSdk by extra(33) // Android 13 (T)
 
     // version 21xxxyy -> min SDK 21, release xxx, build yy
     val sgVersionCode by extra(2106700)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,11 +89,7 @@ play-services-auth = "com.google.android.gms:play-services-auth:20.4.0"
 retrofit2-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit2" }
 retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
 # https://github.com/robolectric/robolectric/releases/
-# Note: 4.6.1 pulls in bcprov-jdk15on code targeting newer Java breaking Jetifier
-# Not fixed until Android Plugin 7 release. Ignore listed in gradle.properties.
-# https://github.com/robolectric/robolectric/issues/6521
-# https://issuetracker.google.com/issues/159151549
-robolectric = "org.robolectric:robolectric:4.8.1"
+robolectric = "org.robolectric:robolectric:4.9.2"
 systembartint = "com.readystatesoftware.systembartint:systembartint:1.0.4"
 taptargetview = "com.getkeepsafe.taptargetview:taptargetview:1.13.3"
 threetenabp = "com.jakewharton.threetenabp:threetenabp:1.4.4" # https://github.com/JakeWharton/ThreeTenABP/blob/master/CHANGELOG.md


### PR DESCRIPTION
#910

This also targets Android 13.

This also makes changes to turn on/off notifications using system settings on Android 8+.

This also changes the show notification button to display as disabled if a user is not supporter (all versions) or if notifications are not allowed (Android 8+).