### PR TITLE
Use in-app browser only for websites related to the app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Release notes
 
 Releases marked with 🧪 were released on [the beta program](https://github.com/UweTrottmann/SeriesGuide/wiki/Beta) only.
 
+Version 68
+----------
+*in development*
+
+* 🔧 Use in-app browser only for websites related to the app.
+
 Version 67
 ----------
 *2023-03-01*

--- a/app/src/main/java/com/battlelancer/seriesguide/billing/BillingActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/billing/BillingActivity.kt
@@ -130,17 +130,16 @@ class BillingActivity : BaseActivity() {
         buttonManageSubs = findViewById<Button>(R.id.buttonBillingManageSubscription).also {
             it.setOnClickListener { v ->
                 // URL may change depending on active sub, so get it on demand.
-                WebTools.openAsCustomTab(v.context, manageSubscriptionUrl)
+                WebTools.openInApp(v.context, manageSubscriptionUrl)
             }
         }
 
         buttonPass = findViewById(R.id.buttonBillingGetPass)
         ViewTools.openUriOnClick(buttonPass, getString(R.string.url_x_pass))
 
-        ViewTools.openUriOnClick(
-            findViewById(R.id.textViewBillingMoreInfo),
-            getString(R.string.url_whypay)
-        )
+        findViewById<View>(R.id.textViewBillingMoreInfo).setOnClickListener {
+            WebTools.openInCustomTab(this, getString(R.string.url_whypay))
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/battlelancer/seriesguide/comments/TraktCommentsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/comments/TraktCommentsFragment.kt
@@ -207,7 +207,7 @@ class TraktCommentsFragment : Fragment() {
     private val onItemClickListener =
         object : TraktCommentsAdapter.OnItemClickListener {
             override fun onOpenWebsite(commentId: Int) {
-                WebTools.openAsCustomTab(requireContext(), TraktLink.comment(commentId))
+                WebTools.openInApp(requireContext(), TraktLink.comment(commentId))
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/extensions/ExtensionsConfigurationFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/extensions/ExtensionsConfigurationFragment.kt
@@ -259,7 +259,7 @@ class ExtensionsConfigurationFragment : Fragment() {
         popupMenu.setOnMenuItemClickListener { item: MenuItem ->
             if (item.itemId == 0) {
                 // special item: search for more extensions
-                WebTools.openAsCustomTab(
+                WebTools.openInApp(
                     requireContext(),
                     getString(R.string.url_extensions_search)
                 )

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/details/MovieDetailsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/details/MovieDetailsFragment.kt
@@ -279,11 +279,11 @@ class MovieDetailsFragment : Fragment(), MovieActionsContract {
                     true
                 }
                 R.id.menu_open_tmdb -> {
-                    WebTools.openAsCustomTab(requireContext(), TmdbTools.buildMovieUrl(tmdbId))
+                    WebTools.openInApp(requireContext(), TmdbTools.buildMovieUrl(tmdbId))
                     true
                 }
                 R.id.menu_open_trakt -> {
-                    WebTools.openAsCustomTab(requireContext(), TraktTools.buildMovieUrl(tmdbId))
+                    WebTools.openInApp(requireContext(), TraktTools.buildMovieUrl(tmdbId))
                     true
                 }
                 else -> false

--- a/app/src/main/java/com/battlelancer/seriesguide/people/PersonFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/people/PersonFragment.kt
@@ -148,7 +148,7 @@ class PersonFragment : Fragment() {
 
             buttonPersonTmdbLink.setOnClickListener {
                 person?.id?.let {
-                    WebTools.openAsCustomTab(requireContext(), TmdbTools.buildPersonUrl(it))
+                    WebTools.openInApp(requireContext(), TmdbTools.buildPersonUrl(it))
                 }
             }
             buttonPersonTmdbLink.setOnLongClickListener {

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/AboutPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/AboutPreferencesFragment.kt
@@ -67,6 +67,6 @@ class AboutPreferencesFragment : Fragment() {
     }
 
     private fun viewUrl(@StringRes urlResId: Int) {
-        WebTools.openAsCustomTab(requireContext(), getString(urlResId))
+        WebTools.openInApp(requireContext(), getString(urlResId))
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/MoreOptionsActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/MoreOptionsActivity.kt
@@ -71,7 +71,7 @@ class MoreOptionsActivity : BaseTopActivity() {
             startActivity(Intent(this, SeriesGuidePreferences::class.java))
         }
         binding.buttonHelp.setOnClickListener {
-            WebTools.openAsCustomTab(this, getString(R.string.help_url))
+            WebTools.openInCustomTab(this, getString(R.string.help_url))
         }
         ViewTools.openUriOnClick(binding.buttonCommunity, getString(R.string.url_community))
         ViewTools.openUriOnClick(binding.buttonTwitter, getString(R.string.url_twitter))

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
@@ -16,7 +16,7 @@ import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.settings.UpdateSettings
 import com.battlelancer.seriesguide.util.TaskManager
 import com.battlelancer.seriesguide.util.TextTools
-import com.battlelancer.seriesguide.util.ViewTools
+import com.battlelancer.seriesguide.util.WebTools
 import com.uwetrottmann.androidutils.AndroidUtils
 
 class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
@@ -111,10 +111,9 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
             R.style.TextAppearance_SeriesGuide_Subtitle1_Secondary
         )
 
-        ViewTools.openUriOnClick(
-            binding.textViewPolicyLink,
-            context.getString(R.string.url_privacy)
-        )
+        binding.textViewPolicyLink.setOnClickListener {
+            WebTools.openInCustomTab(context, context.getString(R.string.url_privacy))
+        }
     }
 
     private fun setFirstRunDismissed() {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsActivityImpl.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsActivityImpl.kt
@@ -80,7 +80,7 @@ open class ShowsActivityImpl : BaseTopActivity(), AddShowDialogFragment.OnAddSho
             // Let the user know the app has updated.
             Snackbar.make(snackbarParentView, R.string.updated, Snackbar.LENGTH_LONG)
                 .setAction(R.string.updated_details) {
-                    WebTools.openAsCustomTab(
+                    WebTools.openInApp(
                         this@ShowsActivityImpl,
                         getString(R.string.url_release_notes)
                     )

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/OverviewFragment.kt
@@ -734,7 +734,7 @@ class OverviewFragment() : Fragment(), EpisodeActionsContract {
             feedbackView = it
             it.setCallback(object : FeedbackView.Callback {
                 override fun onRate() {
-                    if (WebTools.openAsCustomTab(
+                    if (WebTools.openInApp(
                             requireContext(),
                             getString(R.string.url_store_page)
                         )) {

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/BaseOAuthActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/BaseOAuthActivity.kt
@@ -83,7 +83,7 @@ abstract class BaseOAuthActivity : BaseActivity() {
     private fun launchBrowser() {
         val authorizationUrl = authorizationUrl
         if (authorizationUrl != null) {
-            WebTools.openAsCustomTab(this, authorizationUrl)
+            WebTools.openInCustomTab(this, authorizationUrl)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/util/Metacritic.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/Metacritic.kt
@@ -10,7 +10,7 @@ object Metacritic {
      */
     fun searchForMovie(context: Context, title: String) {
         val url = "https://www.metacritic.com/search/movie/${Uri.encode(title)}/results"
-        WebTools.openAsCustomTab(context, url)
+        WebTools.openInApp(context, url)
     }
 
     /**
@@ -18,7 +18,7 @@ object Metacritic {
      */
     fun searchForTvShow(context: Context, title: String) {
         val url = "https://www.metacritic.com/search/tv/${Uri.encode(title)}/results"
-        WebTools.openAsCustomTab(context, url)
+        WebTools.openInApp(context, url)
     }
 
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ServiceUtils.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ServiceUtils.kt
@@ -62,7 +62,7 @@ object ServiceUtils {
             .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
         if (!Utils.tryStartActivity(context, intent, false)) {
             // If the app is not available, open website instead.
-            WebTools.openAsCustomTab(context, imdbLink(imdbId))
+            WebTools.openInApp(context, imdbLink(imdbId))
         }
     }
 
@@ -135,7 +135,7 @@ object ServiceUtils {
      * Opens the YouTube app or web page for the given video.
      */
     fun openYoutube(videoId: String, context: Context) {
-        WebTools.openAsCustomTab(context, YOUTUBE_BASE_URL + videoId)
+        WebTools.openInApp(context, YOUTUBE_BASE_URL + videoId)
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ViewTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ViewTools.kt
@@ -110,12 +110,18 @@ object ViewTools {
         }, 200) // have to add a little delay (http://stackoverflow.com/a/27540921/1000543)
     }
 
+    /**
+     * Opens URL in external app, see [WebTools.openInApp].
+     */
     fun openUriOnClick(button: View?, uri: String?) {
         button?.setOnClickListener { v: View ->
-            if (uri != null) WebTools.openAsCustomTab(v.context, uri)
+            if (uri != null) WebTools.openInApp(v.context, uri)
         }
     }
 
+    /**
+     * Opens URL in external app, see [WebTools.openInApp].
+     */
     fun openUrlOnClickAndCopyOnLongPress(button: View, uri: String) {
         openUriOnClick(button, uri)
         button.copyTextToClipboardOnLongClick(uri)

--- a/app/src/main/java/com/battlelancer/seriesguide/util/WebTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/WebTools.kt
@@ -1,6 +1,7 @@
 package com.battlelancer.seriesguide.util
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
@@ -15,9 +16,11 @@ object WebTools {
      *
      * Returns false (and shows an error toast) if there is no app available to handle the view
      * intent, see [Utils.tryStartActivity].
+     *
+     * See also [openInApp].
      */
     @JvmStatic
-    fun openAsCustomTab(context: Context, url: String): Boolean {
+    fun openInCustomTab(context: Context, url: String): Boolean {
         val darkParams = CustomTabColorSchemeParams.Builder()
             .setToolbarColor(
                 ContextCompat.getColor(context, R.color.sg_background_app_bar_dark)
@@ -36,6 +39,23 @@ object WebTools {
             .build().intent
             .apply { data = Uri.parse(url) }
         return Utils.tryStartActivity(context, customTabsIntent, true)
+    }
+
+    /**
+     * Opens in a supporting app, typically a browser or an app registered for a deep link, if one
+     * is installed.
+     *
+     * Returns false (and shows an error toast) if there is no app available to handle the view
+     * intent, see [Utils.tryStartActivity].
+     *
+     * See also [openInCustomTab].
+     */
+    fun openInApp(context: Context, url: String): Boolean {
+        return Utils.tryStartActivity(
+            context,
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)),
+            true
+        )
     }
 
 }


### PR DESCRIPTION
This partially undoes #917. Custom tabs are now only used for app-related websites that should appear as part of the app (e.g. the help page, connecting Trakt, ...).

Through user feedback: having a full browser offers more tools, makes switching back and forth from the app to the browser easier.