### PR TITLE
Custom time: apply corrections if NOT using it on episodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Version 69
 ----------
 *in development*
 
+* 🔨 Do not apply corrections (e.g. for US timezones) on episodes when a custom time is set and the 
+  other way around.
+
 #### 69.0.0 🧪
 *2023-08-04*
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/tools/AddUpdateShowTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/tools/AddUpdateShowTools.kt
@@ -342,7 +342,7 @@ class AddUpdateShowTools @Inject constructor(
                 releaseInfo.releaseCountry,
                 releaseInfo.network,
                 deviceTimeZone,
-                applyCorrections = usingCustomTime
+                applyCorrections = !usingCustomTime
             )
 
             val guestStars = tmdbEpisode.guest_stars?.mapNotNull { it.name } ?: emptyList()


### PR DESCRIPTION
Will also add this to a bugfix release for version 68.