### PR TITLE
Android 14: ask for exact alarm permission when enabling show notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version 69
 *in development*
 
 * 🔧 Calendar: change calendar settings symbol from eye to a filter to hopefully be more intuitive.
+* 🔧 Notifications: on Android 12 and newer, ask for permission to set precise alarm.
 
 #### 69.0.1 🧪
 *2023-08-10*

--- a/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/notifications/NotificationService.kt
@@ -257,15 +257,6 @@ class NotificationService(context: Context) {
         return true
     }
 
-    private fun AlarmManager.canScheduleExactAlarmsCompat(): Boolean {
-        // https://developer.android.com/training/scheduling/alarms#exact-permission-check
-        return if (AndroidUtils.isAtLeastS) {
-            canScheduleExactAlarms()
-        } else {
-            true
-        }
-    }
-
     /**
      * Get episodes which released 12 hours ago until in 14 days (to avoid
      * loading too much data), excludes some episodes based on user settings.
@@ -631,6 +622,20 @@ class NotificationService(context: Context) {
                 // Never show the cleared episode(s) again
                 Timber.d("Notification cleared, setting last cleared episode time: %d", clearedTime)
                 NotificationSettings.setLastCleared(context, clearedTime)
+            }
+        }
+
+        // Note: do not move to NotificationSettings as ScheduleExactAlarm Lint check will fail.
+        /**
+         * On Android 12+, returns if scheduling of exact alarms is allowed.
+         * On older versions always returns true.
+         */
+        fun AlarmManager.canScheduleExactAlarmsCompat(): Boolean {
+            // https://developer.android.com/training/scheduling/alarms#exact-permission-check
+            return if (AndroidUtils.isAtLeastS) {
+                canScheduleExactAlarms()
+            } else {
+                true
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
@@ -157,6 +157,18 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             }
             true
         }
+        findPreference<Preference>(KEY_PRECISE_NOTIFICATION_SETTINGS)?.setOnPreferenceClickListener {
+            // Note: the preference is only shown on Android 12+.
+            if (AndroidUtils.isAtLeastS) {
+                // Try to open the exact alarm settings.
+                Utils.tryStartActivity(
+                    activity,
+                    NotificationSettings.buildRequestExactAlarmSettingsIntent(requireContext()),
+                    true
+                )
+            }
+            true
+        }
     }
 
     private fun updateNotificationSettings() {
@@ -541,6 +553,8 @@ class SgPreferencesFragment : BasePreferencesFragment(),
         //    public static final String KEY_TAPE_INTERVAL = "com.battlelancer.seriesguide.tapeinterval";
         private const val KEY_BATTERY_SETTINGS =
             "com.battlelancer.seriesguide.notifications.battery"
+        private const val KEY_PRECISE_NOTIFICATION_SETTINGS =
+            "com.battlelancer.seriesguide.notifications.notifications.precise"
 
         // links
         private const val LINK_BASE_KEY = "com.battlelancer.seriesguide.settings."

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/NotificationSettings.kt
@@ -1,13 +1,19 @@
 package com.battlelancer.seriesguide.settings
 
+import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
 import android.provider.Settings
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.preference.PreferenceManager
 import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.notifications.NotificationService.Companion.canScheduleExactAlarmsCompat
 import com.uwetrottmann.androidutils.AndroidUtils
 import timber.log.Timber
 
@@ -76,6 +82,29 @@ object NotificationSettings {
             true
         }
     }
+
+    /**
+     * On Android 12+, returns if scheduling of exact alarms is allowed.
+     * On older versions always returns true.
+     */
+    fun canScheduleExactAlarms(context: Context): Boolean {
+        // https://developer.android.com/training/scheduling/alarms
+        return if (AndroidUtils.isAtLeastS) {
+            context.getSystemService<AlarmManager>()?.canScheduleExactAlarmsCompat() == true
+        } else {
+            true
+        }
+    }
+
+    /**
+     * For Android 12+, builds an intent to open the settings screen to allow alarms and reminders.
+     * See [Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM].
+     */
+    @RequiresApi(Build.VERSION_CODES.S)
+    fun buildRequestExactAlarmSettingsIntent(context: Context) =
+        Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+            .setData(Uri.parse("package:" + context.packageName))
+
 
     /**
      * How far into the future to include upcoming episodes in minutes.

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/FirstRunView.kt
@@ -28,6 +28,7 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
         fun onRestoreBackupClicked()
         fun onRestoreAutoBackupClicked()
         fun onAllowNotificationsClicked()
+        fun onAllowPreciseNotificationsClicked()
         fun onDismissClicked()
     }
 
@@ -43,6 +44,12 @@ class FirstRunView @JvmOverloads constructor(context: Context, attrs: AttributeS
             !AndroidUtils.isAtLeastTiramisu || NotificationSettings.areNotificationsAllowed(context)
         binding.buttonAllowNotifications.setOnClickListener {
             clickListener?.onAllowNotificationsClicked()
+        }
+
+        binding.groupAllowPreciseNotifications.isGone =
+            NotificationSettings.canScheduleExactAlarms(context)
+        binding.buttonAllowPreciseNotifications.setOnClickListener {
+            clickListener?.onAllowPreciseNotificationsClicked()
         }
 
         binding.groupAutoBackupDetected.isGone =

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsFragment.kt
@@ -32,6 +32,7 @@ import com.battlelancer.seriesguide.appwidget.ListWidgetProvider.Companion.notif
 import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity
 import com.battlelancer.seriesguide.preferences.MoreOptionsActivity
 import com.battlelancer.seriesguide.settings.AdvancedSettings
+import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.shows.ShowsAdapter.ShowItem
 import com.battlelancer.seriesguide.shows.ShowsDistillationFragment.Companion.show
 import com.battlelancer.seriesguide.shows.ShowsDistillationSettings.ShowFilter
@@ -235,12 +236,12 @@ class ShowsFragment : Fragment() {
             // set filter icon state
             menu.findItem(R.id.menu_action_shows_filter)
                 .setIcon(
-                if (showFilter.isAnyFilterEnabled()) {
-                    R.drawable.ic_filter_selected_white_24dp
-                } else {
-                    R.drawable.ic_filter_white_24dp
-                }
-            )
+                    if (showFilter.isAnyFilterEnabled()) {
+                        R.drawable.ic_filter_selected_white_24dp
+                    } else {
+                        R.drawable.ic_filter_white_24dp
+                    }
+                )
         }
 
         override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
@@ -249,10 +250,12 @@ class ShowsFragment : Fragment() {
                     startActivityAddShows()
                     true
                 }
+
                 R.id.menu_action_shows_filter -> {
                     show(parentFragmentManager)
                     true
                 }
+
                 else -> false
             }
         }
@@ -302,7 +305,7 @@ class ShowsFragment : Fragment() {
             }
         }
 
-    private val requestPermissionLauncher =
+    private val requestNotificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
             if (isGranted) {
                 adapter.refreshFirstRunHeader()
@@ -314,6 +317,12 @@ class ShowsFragment : Fragment() {
                             .show()
                     }
             }
+        }
+
+    private val requestPreciseNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { _ ->
+            // Regardless if granted or not, refresh to reflect current state.
+            adapter.refreshFirstRunHeader()
         }
 
     private val firstRunClickListener = object : FirstRunView.FirstRunClickListener {
@@ -339,7 +348,15 @@ class ShowsFragment : Fragment() {
 
         override fun onAllowNotificationsClicked() {
             if (AndroidUtils.isAtLeastTiramisu) {
-                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+
+        override fun onAllowPreciseNotificationsClicked() {
+            if (AndroidUtils.isAtLeastS) {
+                requestPreciseNotificationPermissionLauncher.launch(
+                    NotificationSettings.buildRequestExactAlarmSettingsIntent(requireContext())
+                )
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
@@ -1,6 +1,7 @@
 package com.battlelancer.seriesguide.shows.overview
 
 import android.Manifest
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +21,7 @@ import androidx.lifecycle.whenStarted
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.comments.TraktCommentsActivity
+import com.battlelancer.seriesguide.notifications.NotificationService
 import com.battlelancer.seriesguide.people.PeopleListHelper
 import com.battlelancer.seriesguide.settings.NotificationSettings
 import com.battlelancer.seriesguide.shows.database.SgShow2
@@ -264,6 +266,15 @@ class ShowFragment() : Fragment() {
             }
         }
 
+    private val requestPreciseNotificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            // RESULT_OK = permission enabled
+            if (result.resultCode == Activity.RESULT_OK) {
+                // Re-schedule with exact alarm (if this shows episode is next)
+                NotificationService.trigger(requireContext())
+            }
+        }
+
     private fun populateShow(showForUi: ShowViewModel.ShowForUi?, hasAccessToX: Boolean?) {
         if (showForUi == null || hasAccessToX == null) return
         val binding = binding ?: return
@@ -330,6 +341,14 @@ class ShowFragment() : Fragment() {
                         showNotificationsNotAllowedMessage()
                     }
                 } else {
+                    // On Android 12+, ask for exact alarm permission, but still enable
+                    // notifications right away. If granted, will just re-run notifications service.
+                    if (!notify && !NotificationSettings.canScheduleExactAlarms(requireContext())) {
+                        requestPreciseNotificationPermissionLauncher.launch(
+                            @Suppress("NewApi") // Can never be here if not Android 12+
+                            NotificationSettings.buildRequestExactAlarmSettingsIntent(requireContext())
+                        )
+                    }
                     // disable until action is complete
                     v.isEnabled = false
                     SgApp.getServicesComponent(requireContext()).showTools()

--- a/app/src/main/res/layout/view_first_run.xml
+++ b/app/src/main/res/layout/view_first_run.xml
@@ -61,6 +61,31 @@
             app:layout_constraintTop_toBottomOf="@id/textViewAllowNotificationsExplainer" />
 
         <TextView
+            android:id="@+id/textViewAllowPreciseNotificationsExplainer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="center"
+            android:text="@string/precise_notifications_allow_reason"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonAllowNotifications" />
+
+        <Button
+            android:id="@+id/buttonAllowPreciseNotifications"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="@string/precise_notifications_allow"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewAllowPreciseNotificationsExplainer" />
+
+        <TextView
             android:id="@+id/textViewAutoBackupDetected"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -72,7 +97,7 @@
             android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Accent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/buttonAllowNotifications" />
+            app:layout_constraintTop_toBottomOf="@id/buttonAllowPreciseNotifications" />
 
         <Button
             android:id="@+id/buttonRestoreAutoBackup"
@@ -240,6 +265,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="textViewAllowNotificationsExplainer,buttonAllowNotifications" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/groupAllowPreciseNotifications"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="textViewAllowPreciseNotificationsExplainer,buttonAllowPreciseNotifications" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/groupAutoBackupDetected"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -516,6 +516,8 @@
     <string name="pref_notifications_battery_settings_summary">الذهاب إلى إعدادات البطارية لتعطيل تحسينات البطارية للإشعارات الموثوقة</string>
     <string name="notifications_allow">السماح بالإشعارات</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">إخفاء الحلقات المشاهدة</string>
     <string name="pref_widget_opacity">خلفية القطعة العائمة</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Изключи оптимизациите на батерията от Настройки на батерия за сигурни нотификации</string>
     <string name="notifications_allow">Разрешаване на известията</string>
     <string name="notifications_allow_reason">Известията за епизоди и грешки трябва да бъдат разрешени в меню Настройки.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Скрий гледаните епизоди</string>
     <string name="pref_widget_opacity">Фон на уиджета</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Vés als ajustaments de la bateria per deshabilitar les optimitzacions de bateria per rebre notificacions</string>
     <string name="notifications_allow">Permet les notificacions</string>
     <string name="notifications_allow_reason">Per rebre notificacions d\'episodis i d\'errors, ves a Configuració i dona\'ls-hi permís</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Amaga els episodis vistos</string>
     <string name="pref_widget_opacity">Fons del widget</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Pro spolehlivá oznámení přejděte do nastavení baterie a zakažte optimalizaci baterie.</string>
     <string name="notifications_allow">Povolit oznámení</string>
     <string name="notifications_allow_reason">Chcete-li přijímat oznámení o epizodách a chybách, přejděte do Nastavení a povolte je.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skrýt zhlédnuté epizody</string>
     <string name="pref_widget_opacity">Pozadí widgetu</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -516,6 +516,8 @@
     <string name="pref_notifications_battery_settings_summary">Ewch i leoliadau Batri i analluogi optimeiddiadau batri ar gyfer hysbysiadau dibynadwy</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Cuddio penodau gwylio</string>
     <string name="pref_widget_opacity">Cefndir Widget</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Gå til Batteriindstillinger for at deaktivere batterioptimeringer for pålidelige meddelelser</string>
     <string name="notifications_allow">Tillad meddelelser</string>
     <string name="notifications_allow_reason">Gå til Indstillinger for at tillade modtagelse af episode- og fejlmeddelelser.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skjul sete episoder</string>
     <string name="pref_widget_opacity">Widget-baggrund</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Zu Akku-Einstellungen gehen um Akkuverbrauch optimieren für zuverlässige Benachrichtigungen auszuschalten</string>
     <string name="notifications_allow">Benachrichtigungen erlauben</string>
     <string name="notifications_allow_reason">Um Benachrichtigungen für Folgen oder Fehler zu erhalten, erlauben Sie diese in den Einstellungen.</string>
+    <string name="precise_notifications_allow">Präzise Benachrichtigungen erlauben</string>
+    <string name="precise_notifications_allow_reason">Um präzise Benachrichtigungen für Folgen zu erhalten, erlauben Sie diese in den Einstellungen.</string>
     <!-- List Widget -->
     <string name="hide_watched">Angesehene Folgen verstecken</string>
     <string name="pref_widget_opacity">Widget-Hintergrund</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Πηγαίνετε στις Ρυθμίσεις μπαταρίας για να απενεργοποιήσετε τις βελτιστοποιήσεις μπαταρίας για αξιόπιστες ειδοποιήσεις</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Απόκρυψη παρακολουθημένων επεισοδίων</string>
     <string name="pref_widget_opacity">Φόντο widget</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Kaŝi spektitajn epizodojn</string>
     <string name="pref_widget_opacity">Fenestraĵa fono</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -473,6 +473,8 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="pref_notifications_battery_settings_summary">Ir a la configuración de la batería para desactivar las optimizaciones de la batería para obtener notificaciones fiables</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episodios vistos</string>
     <string name="pref_widget_opacity">Fondo de widget</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">به منظور آگاهی‌های قابل اتّکا، برای از کار انداختن بهینه‌سازی‌های باتری به تنظیمات باتری بروید</string>
     <string name="notifications_allow">اجازه به آگاهی‌ها</string>
     <string name="notifications_allow_reason">برای گرفتن آگاهی‌های خطا و قسمت‌ها به تنظمیات رفته و اجازه بدهید.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">نهفتن قسمت‌های تماشا شده</string>
     <string name="pref_widget_opacity">پس‌زمینهٔ ابزارک</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Siirry kohtaan Akku-asetukset poistaaksesi käytöstä akkuoptimoinnit luotettavien ilmoitusten saamiseksi</string>
     <string name="notifications_allow">Salli ilmoitukset</string>
     <string name="notifications_allow_reason">Jos haluat saada jakso- ja virheilmoituksia, siirry asetuksiin ja salli ne.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Piilota katsotut jaksot</string>
     <string name="pref_widget_opacity">Widgetin tausta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Aller dans les paramètres de batterie pour désactiver l\'optimisation de la batterie afin de recevoir correctement les notifications</string>
     <string name="notifications_allow">Autoriser les notifications</string>
     <string name="notifications_allow_reason">Pour recevoir des notifications d\'épisode et d\'erreur, autorisez-les via les paramètres.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Masquer les épisodes vus</string>
     <string name="pref_widget_opacity">Arrière-plan du widget</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Agochar episodios vistos</string>
     <string name="pref_widget_opacity">Fondo do widget</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -483,6 +483,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Sakrij pogledane epizode</string>
     <string name="pref_widget_opacity">Pozadina widgeta</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Lépjen az Akkumulátorbeállítások elemre, és tiltsa le az akkumulátoroptimalizálást a megbízható értesítésekért</string>
     <string name="notifications_allow">Értesítések engedélyezése</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Megnézett epizódok elrejtése</string>
     <string name="pref_widget_opacity">Widget háttér</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">Buka Pengaturan baterai untuk menonaktifkan pengoptimalan baterai untuk notifikasi yang dapat diandalkan</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Sembunyikan episode yang telah ditonton</string>
     <string name="pref_widget_opacity">Latar belakang widget</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Vai nelle impostazioni della batteria e disattiva le ottimizzazioni per notifiche più affidabili</string>
     <string name="notifications_allow">Consenti notifiche</string>
     <string name="notifications_allow_reason">Per ricevere notifiche su episodi ed errori, attivale nelle impostazioni.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Nascondi episodi già visti</string>
     <string name="pref_widget_opacity">Sfondo widget</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">הסתר פרקים שנצפו</string>
     <string name="pref_widget_opacity">רקע ווידג\'ט</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">バッテリー設定に移動して、バッテリーの最適化を無効にし、信頼性の高い通知を表示します</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">視聴済のエピソードを非表示</string>
     <string name="pref_widget_opacity">ウィジェットの背景</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">시청한 에피소드 숨기기</string>
     <string name="pref_widget_opacity">위젯 배경</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Сокриј веќе гледани епизоди</string>
     <string name="pref_widget_opacity">Widget позадина</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Gå til Batteriinnstillinger for å deaktivere batterioptimalisering for pålitelige varsler</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skjul sette episoder</string>
     <string name="pref_widget_opacity">Modulbakgrunn</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Ga naar Batterij instellingen om batterij optimalisaties uit te schakelen voor betrouwbare meldingen</string>
     <string name="notifications_allow">Meldingen toestaan</string>
     <string name="notifications_allow_reason">Om aflevering- en foutmeldingen te ontvangen, ga naar Instellingen en sta ze toe.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Bekeken afleveringen verbergen</string>
     <string name="pref_widget_opacity">Widget achtergrond</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Przejdź do ustawień baterii, aby wyłączyć jej optymalizację, aby otrzymywać powiadomienia na bieżąco</string>
     <string name="notifications_allow">Zezwalaj na powiadomienia</string>
     <string name="notifications_allow_reason">Aby otrzymywać powiadomienia o odcinkach oraz o błędach, włącz powiadomienia w ustawieniach.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ukryj obejrzane odcinki</string>
     <string name="pref_widget_opacity">Tło widżetu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Vá até Configurações de bateria para desativar sua otimização e receber notificações corretamente</string>
     <string name="notifications_allow">Permitir notificações</string>
     <string name="notifications_allow_reason">Para receber notificações sobre episódios e erros, vá em configurações para permiti-las.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episódios assistidos</string>
     <string name="pref_widget_opacity">Plano de fundo do widget</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Vai às Definições da Bateria para desativar a otimização e receber notificações corretamente</string>
     <string name="notifications_allow">Permitir notificações</string>
     <string name="notifications_allow_reason">Para receberes notificações de episódios e de erros, vai às Definições para ativar a permissão.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ocultar episódios vistos</string>
     <string name="pref_widget_opacity">Plano de fundo do widget</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -483,6 +483,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Ascundeți episoadele vizionate</string>
     <string name="pref_widget_opacity">Widget fundal</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Перейдите в настройки батареи, чтобы отключить оптимизацию батареи для надежных уведомлений</string>
     <string name="notifications_allow">Разрешить уведомления</string>
     <string name="notifications_allow_reason">Чтобы получать уведомления о выпусках и ошибках, перейдите в настройки и разрешите их.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Скрывать просмотренные эпизоды</string>
     <string name="pref_widget_opacity">Фон виджета</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Prejdite na Nastavenia batérie a deaktivujte optimalizáciu batérie pre spoľahlivé oznámenia</string>
     <string name="notifications_allow">Povoliť oznámenia</string>
     <string name="notifications_allow_reason">Ak chcete dostávať upozornenia o epizódach a chybách, prejdite do Nastavenia a povoľte ich.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Skryť videné epizódy</string>
     <string name="pref_widget_opacity">Pozadie miniaplikácie</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -483,6 +483,8 @@
     <string name="pref_notifications_battery_settings_summary">За поуздана обавештења, идите на Подешавања батерије да бисте онемогућили оптимизацију батерије</string>
     <string name="notifications_allow">Дозволи обавештавања</string>
     <string name="notifications_allow_reason">Да бисте примали обавештења о епизодама и грешкама, идите у Подешавања и дозволите их.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Сакриј одгледане епизоде</string>
     <string name="pref_widget_opacity">Позадина виџета</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Gå till Batteriinställningar för att inaktivera batterioptimeringar för tillförlitliga aviseringar</string>
     <string name="notifications_allow">Tillåt aviseringar</string>
     <string name="notifications_allow_reason">För att ta emot avsnitts- och felmeddelanden, gå till Inställningar och tillåt dem.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Dölj sedda avsnitt</string>
     <string name="pref_widget_opacity">Widgetbakgrund</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">பார்த்த episodes மறை</string>
     <string name="pref_widget_opacity">விட்ஜெட் பின்னணி</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">ไปยังการตั้งค่าแบตเตอรี่ จากนั้นปิดใช้งานการเพิ่มประสิทธิภาพแบตเตอรี่ เพื่อการแจ้งเตือนที่เสถียรขึ้น</string>
     <string name="notifications_allow">เปิดการแจ้งเตือน</string>
     <string name="notifications_allow_reason">เพื่อรับการแจ้งเตือนตอนใหม่และข้อผิดพลาด ไปที่การตั้งค่าเพื่ออนุญาตการแจ้งเตือน</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">ซ่อนตอนที่ดูแล้ว</string>
     <string name="pref_widget_opacity">พื้นหลังวิตเจ็ต</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -472,6 +472,8 @@
     <string name="pref_notifications_battery_settings_summary">Güvenilir bildirimler almak için Pil ayarlarına giderek, pil optimizasyonlarını devre dışı bırakın</string>
     <string name="notifications_allow">Bildirimlere izin ver</string>
     <string name="notifications_allow_reason">Bölüm ve hata bildirimleri almak için Ayarlar\'a gidin ve onlara izin verin.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">İzlenmiş bölümleri gizle</string>
     <string name="pref_widget_opacity">Widget arka planı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -494,6 +494,8 @@
     <string name="pref_notifications_battery_settings_summary">Перейдіть до налаштувань акумулятора, щоб вимкнути оптимізацію живлення для надійних сповіщень</string>
     <string name="notifications_allow">Дозволити сповіщення</string>
     <string name="notifications_allow_reason">Щоб отримувати повідомлення про епізоди та помилки, перейдіть до Налаштувань та дозвольте їх.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">Приховати переглянуті серії</string>
     <string name="pref_widget_opacity">Фон віджета</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">转到电池设置，停用电池优化以获取可靠稳定的通知</string>
     <string name="notifications_allow">允许通知</string>
     <string name="notifications_allow_reason">要接收剧集和错误通知，请前往设置并允许它们。</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">隐藏看过的剧集</string>
     <string name="pref_widget_opacity">微件背景</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -461,6 +461,8 @@
     <string name="pref_notifications_battery_settings_summary">前往系統設定停用電池效能最佳化以提升通知可靠性</string>
     <string name="notifications_allow">允許通知</string>
     <string name="notifications_allow_reason">如要接收劇集和錯誤通知，請前往設定並允許它們。</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
     <!-- List Widget -->
     <string name="hide_watched">隱藏已看過集數</string>
     <string name="pref_widget_opacity">小工具背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,8 @@
     <string name="pref_notifications_battery_settings_summary">Go to Battery settings to disable battery optimizations for reliable notifications</string>
     <string name="notifications_allow">Allow notifications</string>
     <string name="notifications_allow_reason">To receive episode and error notifications, go to Settings and allow them.</string>
+    <string name="precise_notifications_allow">Allow precise notifications</string>
+    <string name="precise_notifications_allow_reason">To receive precise episode notifications, go to Settings and allow them.</string>
 
     <!-- List Widget -->
     <string name="hide_watched">Hide watched episodes</string>

--- a/app/src/main/res/xml-v31/settings_notifications.xml
+++ b/app/src/main/res/xml-v31/settings_notifications.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <!-- Android 8+: removed in-app notification vibrate and sound settings. -->
+    <!-- Android 12+: precise notification setting. -->
 
     <Preference
         app:iconSpaceReserved="false"
@@ -31,6 +31,12 @@
         app:key="com.uwetrottmann.seriesguide.notifications.nextonly"
         app:summary="@string/pref_notifications_next_episodes_only_summary"
         app:title="@string/pref_notifications_next_episodes_only" />
+
+    <Preference
+        app:iconSpaceReserved="false"
+        app:key="com.battlelancer.seriesguide.notifications.notifications.precise"
+        app:summary="@string/precise_notifications_allow_reason"
+        app:title="@string/precise_notifications_allow" />
 
     <Preference
         app:iconSpaceReserved="false"


### PR DESCRIPTION
New installs [on Android 14 won't have](https://developer.android.com/about/versions/14/changes/schedule-exact-alarms?hl=en) the [SCHEDULE_EXACT_ALARM](https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM) permission by default.

It's not possible to request the permission. It's required to redirect the user to the alarms and reminders settings.

- [x] User can grant notification permission from Getting Started view. Then notifications are enabled by default. Those users will never see the exact alarm request. Somehow integrate there as well (probably will need yet another button and text after all).