### PR TITLE
Migrate launchWhen and whenStateAtLeast Coroutine helpers

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/lists/ListManageDialogFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/lists/ListManageDialogFragment.kt
@@ -4,12 +4,15 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.DialogListManageBinding
 import com.battlelancer.seriesguide.provider.SeriesGuideContract
 import com.battlelancer.seriesguide.util.safeShow
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.launch
 
 /**
  * Dialog to rename or remove a list.
@@ -52,8 +55,11 @@ class ListManageDialogFragment : AppCompatDialogFragment() {
             dismiss()
         }
 
-        lifecycleScope.launchWhenCreated {
-            configureViews()
+        // Delay loading data for views to after this function
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                configureViews()
+            }
         }
 
         return MaterialAlertDialogBuilder(requireContext())

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/search/MoviesSearchActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/search/MoviesSearchActivity.kt
@@ -10,7 +10,6 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import android.widget.TextView.OnEditorActionListener
-import androidx.lifecycle.lifecycleScope
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.ActivityMoviesSearchBinding
 import com.battlelancer.seriesguide.movies.MovieLocalizationDialogFragment
@@ -81,7 +80,7 @@ class MoviesSearchActivity : BaseMessageActivity(), MoviesSearchFragment.OnSearc
         HighlightTools.highlightSgToolbarItem(
             HighlightTools.Feature.MOVIE_FILTER,
             this,
-            lifecycleScope,
+            lifecycle,
             R.id.menu_action_movies_search_filter,
             R.string.action_movies_filter
         ) {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/ShowsFragment.kt
@@ -23,7 +23,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.whenStateAtLeast
+import androidx.lifecycle.withStarted
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -139,11 +139,11 @@ class ShowsFragment : Fragment() {
             // release time has passed).
             scheduledUpdateJob?.cancel()
             scheduledUpdateJob = viewLifecycleOwner.lifecycleScope.launch {
+                Timber.d("Scheduled query update.")
+                delay(DateUtils.MINUTE_IN_MILLIS + Random.nextLong(DateUtils.SECOND_IN_MILLIS))
                 // Use STARTED as in multi-window this might be visible, but not RESUMED.
                 // On the downside this runs even if the tab is not visible (tied to RESUMED).
-                viewLifecycleOwner.lifecycle.whenStateAtLeast(Lifecycle.State.STARTED) {
-                    Timber.d("Scheduled query update")
-                    delay(DateUtils.MINUTE_IN_MILLIS + Random.nextLong(DateUtils.SECOND_IN_MILLIS))
+                viewLifecycleOwner.lifecycle.withStarted {
                     updateShowsQuery()
                 }
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
@@ -16,8 +16,6 @@ import androidx.core.os.bundleOf
 import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.whenStarted
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.comments.TraktCommentsActivity
@@ -48,7 +46,6 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import com.uwetrottmann.androidutils.AndroidUtils
 import com.uwetrottmann.tmdb2.entities.Credits
-import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -536,17 +533,12 @@ class ShowFragment() : Fragment() {
         // create the shortcut
         show?.also { show ->
             if (show.tmdbId != null && show.posterSmall != null) {
-                val shortcutLiveData = ShortcutCreator(
+                ShortcutCreator(
                     requireContext(),
                     show.title,
                     show.posterSmall,
                     show.tmdbId
-                )
-                viewLifecycleOwner.lifecycleScope.launch {
-                    whenStarted {
-                        shortcutLiveData.prepareAndPinShortcut()
-                    }
-                }
+                ).prepareAndPinShortcut(viewLifecycleOwner)
             }
         }
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/search/SearchActivityImpl.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/search/SearchActivityImpl.kt
@@ -144,7 +144,7 @@ open class SearchActivityImpl : BaseMessageActivity(), AddShowDialogFragment.OnA
         HighlightTools.highlightSgToolbarItem(
             HighlightTools.Feature.SHOW_FILTER,
             this,
-            lifecycleScope,
+            lifecycle,
             R.id.menu_action_shows_search_filter,
             R.string.action_shows_filter
         ) {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/search/discover/BaseAddShowsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/search/discover/BaseAddShowsFragment.kt
@@ -2,6 +2,7 @@ package com.battlelancer.seriesguide.shows.search.discover
 
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.battlelancer.seriesguide.enums.NetworkResult
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
@@ -10,6 +11,7 @@ import com.battlelancer.seriesguide.shows.tools.ShowTools2
 import com.battlelancer.seriesguide.ui.OverviewActivity
 import com.battlelancer.seriesguide.util.TaskManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -66,12 +68,14 @@ abstract class BaseAddShowsFragment : Fragment() {
             if (item.state != SearchResult.STATE_ADDING) {
                 if (item.state == SearchResult.STATE_ADDED) {
                     // Already in library, open it.
-                    lifecycleScope.launchWhenStarted {
+                    lifecycleScope.launch {
                         val showId = withContext(Dispatchers.IO) {
                             SgRoomDatabase.getInstance(requireContext()).sgShow2Helper()
                                 .getShowIdByTmdbId(item.tmdbId)
                         }
-                        startActivity(OverviewActivity.intentShow(requireContext(), showId))
+                        if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                            startActivity(OverviewActivity.intentShow(requireContext(), showId))
+                        }
                     }
                 } else {
                     // Display more details in a dialog.

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/GenericCheckInDialogFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/GenericCheckInDialogFragment.kt
@@ -6,12 +6,14 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.withStarted
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.DialogCheckinBinding
 import com.battlelancer.seriesguide.traktapi.TraktTask.TraktActionCompleteEvent
 import com.battlelancer.seriesguide.traktapi.TraktTask.TraktCheckInBlockedEvent
 import com.battlelancer.seriesguide.util.Utils
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import kotlin.math.max
@@ -57,14 +59,20 @@ abstract class GenericCheckInDialogFragment : AppCompatDialogFragment() {
 
         setProgressLock(false)
 
-        lifecycleScope.launchWhenStarted {
-            // immediately start to check-in if the user has opted to skip entering a check-in message
+        lifecycleScope.launch {
+            // Proceed to check in if the user has opted to skip entering a message
             if (TraktSettings.useQuickCheckin(requireContext())) {
-                checkIn()
+                // Wait until STARTED (or cancel if DESTROYED)
+                withStarted {
+                    checkIn()
+                }
             }
         }
 
-        return MaterialAlertDialogBuilder(requireContext(), R.style.Theme_SeriesGuide_Dialog_CheckIn)
+        return MaterialAlertDialogBuilder(
+            requireContext(),
+            R.style.Theme_SeriesGuide_Dialog_CheckIn
+        )
             .setView(binding.root)
             .create()
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/util/HighlightTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/HighlightTools.kt
@@ -7,12 +7,15 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.edit
-import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.withResumed
 import androidx.preference.PreferenceManager
 import com.battlelancer.seriesguide.R
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Helps highlight a toolbar item.
@@ -26,53 +29,62 @@ object HighlightTools {
         MOVIE_FILTER(2)
     }
 
-    fun shouldHighlight(context: Context, feature: Feature): Boolean {
-        return !PreferenceManager.getDefaultSharedPreferences(context)
+    private fun hasSeen(context: Context, feature: Feature): Boolean {
+        return PreferenceManager.getDefaultSharedPreferences(context)
             .getBoolean(BASE_PREF_KEY + feature.index, false)
     }
 
-    fun setSeen(context: Context, feature: Feature) {
+    private fun setSeen(context: Context, feature: Feature) {
         PreferenceManager.getDefaultSharedPreferences(context).edit {
             putBoolean(BASE_PREF_KEY + feature.index, true)
         }
     }
 
+    /**
+     * If [condition] is met, waits until the [lifecycle] state is at least RESUMED,
+     * then looks for and highlights the toolbar item.
+     */
     fun highlightSgToolbarItem(
         feature: Feature,
         activity: AppCompatActivity,
-        scope: LifecycleCoroutineScope,
+        lifecycle: Lifecycle,
         @IdRes menuItemId: Int,
         @StringRes textRes: Int,
         condition: () -> Boolean
     ) {
-        if (shouldHighlight(activity, feature)) {
-            scope.launchWhenResumed {
-                if (!condition()) {
-                    return@launchWhenResumed
-                }
-                // Instead of a complicated global layout listener setup,
-                // just check a few times for the menu item to exist.
-                val toolbar = activity.findViewById<Toolbar>(R.id.sgToolbar)
-                var menuItem: View? = null
-                for (i in 0 until 10) {
-                    menuItem = toolbar.findViewById(menuItemId)
-                    if (menuItem != null) break
-                    delay(100)
-                }
-                menuItem?.let {
-                    TapTargetView.showFor(
-                        activity,
-                        TapTarget.forView(it, activity.getString(textRes)),
-                        object : TapTargetView.Listener() {
-                            override fun onTargetDismissed(
-                                view: TapTargetView?,
-                                userInitiated: Boolean
-                            ) {
-                                setSeen(activity, feature)
-                            }
+        if (hasSeen(activity, feature)) {
+            return
+        }
+        if (!condition()) {
+            return
+        }
+        lifecycle.coroutineScope.launch {
+            lifecycle.withResumed {} // Wait until RESUMED (or cancel if DESTROYED)
+
+            // Instead of a complicated global layout listener setup,
+            // just check a few times for the menu item to exist.
+            val toolbar = activity.findViewById<Toolbar>(R.id.sgToolbar)
+            var menuItem: View? = null
+            for (i in 0 until 10) {
+                menuItem = toolbar.findViewById(menuItemId)
+                if (menuItem != null) break
+                delay(100)
+                // During delay state might have dropped, so check again and wait if necessary.
+                lifecycle.withResumed {}
+            }
+            menuItem?.let {
+                TapTargetView.showFor(
+                    activity,
+                    TapTarget.forView(it, activity.getString(textRes)),
+                    object : TapTargetView.Listener() {
+                        override fun onTargetDismissed(
+                            view: TapTargetView?,
+                            userInitiated: Boolean
+                        ) {
+                            setSeen(activity, feature)
                         }
-                    )
-                }
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
- https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.0
- https://issuetracker.google.com/issues/270049505#comment2

The deprecated launchWhen and whenStateAtLeast APIs do suspend and not cancel a running block if state dropped below the initial guaranteed state. If the state is never reached again, this leaves the block suspended (and any resources in use) until the Lifecycle reaches the destroyed state.