### PR TITLE
Android 14: work around sync always marked as pending by the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Version 70
 ----------
 *in development*
 
+* 🔨 Android 14: fix automatic syncing.
+
 #### 70.0.1 🧪
 *2023-10-20*
 


### PR DESCRIPTION
Quick fix for #953: instead of checking for a pending sync, check if a sync is active. This still should prevent scheduling too many syncs.

Also add some log messages to diagnose.