### PR TITLE
Use navigation rail on 590dp+ wide screens

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/ui/BaseTopActivity.kt
@@ -30,7 +30,7 @@ import com.battlelancer.seriesguide.ui.ShowsActivity
 import com.battlelancer.seriesguide.util.SupportTheDev
 import com.battlelancer.seriesguide.util.SupportTheDev.buildSnackbar
 import com.battlelancer.seriesguide.util.Utils
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.snackbar.Snackbar
 import timber.log.Timber
 
@@ -72,7 +72,7 @@ abstract class BaseTopActivity : BaseMessageActivity() {
     }
 
     fun setupBottomNavigation(@IdRes selectedItemId: Int) {
-        val bottomNav = findViewById<BottomNavigationView>(R.id.bottomNavigation)
+        val bottomNav = findViewById<NavigationBarView>(R.id.bottomNavigation)
         bottomNav.selectedItemId = selectedItemId
         // Disable hideous bold font for active item.
         bottomNav.setItemTextAppearanceActiveBoldEnabled(false)

--- a/app/src/main/res/layout-w600dp/activity_shows.xml
+++ b/app/src/main/res/layout-w600dp/activity_shows.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright 2023 Uwe Trottmann -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/rootLayoutShows"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
+
+    <com.google.android.material.navigationrail.NavigationRailView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/bottom_navigation_menu" />
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinatorLayoutShows"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+
+        <include layout="@layout/top_app_bar_scrolling_tabs_progress" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPagerTabs"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/buttonShowsAdd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_marginStart="0dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginEnd="@dimen/fab_margin"
+            android:layout_marginBottom="@dimen/fab_margin"
+            android:contentDescription="@string/action_shows_add"
+            app:srcCompat="@drawable/ic_add_white_24dp" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Uwe Trottmann -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Text styles -->
@@ -243,6 +246,11 @@
 
     <!-- BottomNavigationView -->
     <style name="Widget.SeriesGuide.BottomNavigationView" parent="Widget.Material3.BottomNavigationView">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.SeriesGuide.BottomNavigationView</item>
+    </style>
+
+    <!-- NavigationRailView -->
+    <style name="Widget.SeriesGuide.NavigationRailView" parent="Widget.Material3.NavigationRailView">
         <item name="materialThemeOverlay">@style/ThemeOverlay.SeriesGuide.BottomNavigationView</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Uwe Trottmann -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- ####################################### -->
@@ -71,6 +74,7 @@
         <item name="preferenceTheme">@style/ThemeOverlay.SeriesGuide.Preference</item>
 
         <item name="bottomNavigationStyle">@style/Widget.SeriesGuide.BottomNavigationView</item>
+        <item name="navigationRailStyle">@style/Widget.SeriesGuide.NavigationRailView</item>
 
         <item name="textAppearanceButton">@style/TextAppearance.SeriesGuide.Button</item>
 
@@ -143,6 +147,7 @@
         <item name="preferenceTheme">@style/ThemeOverlay.SeriesGuide.Preference</item>
 
         <item name="bottomNavigationStyle">@style/Widget.SeriesGuide.BottomNavigationView</item>
+        <item name="navigationRailStyle">@style/Widget.SeriesGuide.NavigationRailView</item>
 
         <item name="textAppearanceButton">@style/TextAppearance.SeriesGuide.Button</item>
 


### PR DESCRIPTION
https://github.com/material-components/material-components-android/blob/1.10.0/docs/components/NavigationRail.md

This won't work without significant adjustments to the layout, e.g. the app bar is supposed to sit on top. But that will break hiding on scroll, tabs. And all the padding adjustments/insets for the system nav bar are also broken.

Putting this on hold as it has little benefit and is a lot of work.