### PR TITLE
replace async task with java.util.concurrent #963

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/util/TaskManager.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/TaskManager.java
@@ -110,9 +110,9 @@ public class TaskManager {
     @MainThread
     public synchronized void tryNextEpisodeUpdateTask(Context context) {
         if (nextEpisodeUpdateTask == null
-                || nextEpisodeUpdateTask.getStatus() == AsyncTask.Status.FINISHED) {
+                || nextEpisodeUpdateTask.getStatus()) {
             nextEpisodeUpdateTask = new LatestEpisodeUpdateTask(context);
-            nextEpisodeUpdateTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            nextEpisodeUpdateTask.performBackgroundTask();
         }
     }
 


### PR DESCRIPTION
#963

Migration of deprecated AsyncTask usages.