### PR TITLE
Local history for multiple episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version 72
 ----------
 *in development*
 
+* 🔧 Add history entry when marking multiple episodes as watched.
 * 🔨 Android 5: use correct color for show status and stream search configure button.
 
 #### 72.0.4 🧪

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/BaseEpisodesJob.kt
@@ -131,16 +131,23 @@ abstract class BaseEpisodesJob(
 
     /**
      * Add or remove watch activity entries for episodes. Only used for watch jobs.
+     *
+     * Reverses order from [getAffectedEpisodes] to have highest number and season appear first.
      */
     protected fun updateActivity(context: Context, episodes: List<SgEpisode2Numbers>) {
         val showTmdbIdOrZero =
             SgRoomDatabase.getInstance(context).sgShow2Helper().getShowTmdbId(showId)
+
         val episodeTmdbIds = episodes.mapNotNull { it.tmdbId }
 
         if (showTmdbIdOrZero == 0 && episodeTmdbIds.isEmpty()) return
 
         if (EpisodeTools.isWatched(flagValue)) {
-            SgActivityHelper.addActivitiesForEpisodes(context, showTmdbIdOrZero, episodeTmdbIds)
+            SgActivityHelper.addActivitiesForEpisodes(
+                context,
+                showTmdbIdOrZero,
+                episodeTmdbIds.reversed()
+            )
         } else if (EpisodeTools.isUnwatched(flagValue)) {
             SgActivityHelper.removeActivitiesForEpisodes(context, episodeTmdbIds)
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeBaseJob.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeBaseJob.java
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2017, 2018, 2021-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.jobs.episodes;
 
@@ -49,7 +49,7 @@ public abstract class EpisodeBaseJob extends BaseEpisodesJob {
 
     @NonNull
     @Override
-    protected List<SgEpisode2Numbers> getEpisodesForNetworkJob(@NonNull Context context) {
+    protected List<SgEpisode2Numbers> getAffectedEpisodes(@NonNull Context context) {
         List<SgEpisode2Numbers> list = new ArrayList<>();
         list.add(episode);
         return list;

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeCollectedJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/EpisodeCollectedJob.kt
@@ -4,11 +4,15 @@ package com.battlelancer.seriesguide.jobs.episodes
 
 import android.content.Context
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
+import com.battlelancer.seriesguide.shows.database.SgEpisode2Numbers
 
 class EpisodeCollectedJob(
     episodeId: Long, private val isCollected: Boolean
 ) : EpisodeBaseJob(episodeId, if (isCollected) 1 else 0, JobAction.EPISODE_COLLECTION) {
-    override fun applyDatabaseChanges(context: Context): Boolean {
+    override fun applyDatabaseChanges(
+        context: Context,
+        episodes: List<SgEpisode2Numbers>
+    ): Boolean {
         val updated = SgRoomDatabase.getInstance(context).sgEpisode2Helper()
             .updateCollected(episodeId, isCollected)
         return updated == 1

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/JobAction.java
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/JobAction.java
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2017, 2018, 2023 Uwe Trottmann
 
 package com.battlelancer.seriesguide.jobs.episodes;
 

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonCollectedJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/SeasonCollectedJob.kt
@@ -10,13 +10,13 @@ class SeasonCollectedJob(
     seasonId: Long,
     private val isCollected: Boolean
 ) : SeasonBaseJob(seasonId, if (isCollected) 1 else 0, JobAction.EPISODE_COLLECTION) {
-    override fun applyDatabaseChanges(context: Context): Boolean {
+    override fun applyDatabaseChanges(context: Context, episodes: List<SgEpisode2Numbers>): Boolean {
         val rowsUpdated = SgRoomDatabase.getInstance(context).sgEpisode2Helper()
             .updateCollectedOfSeason(seasonId, isCollected)
         return rowsUpdated >= 0 // -1 means error.
     }
 
-    override fun getEpisodesForNetworkJob(context: Context): List<SgEpisode2Numbers> {
+    override fun getAffectedEpisodes(context: Context): List<SgEpisode2Numbers> {
         return SgRoomDatabase.getInstance(context).sgEpisode2Helper()
             .getEpisodeNumbersOfSeason(seasonId)
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowCollectedJob.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/jobs/episodes/ShowCollectedJob.kt
@@ -11,13 +11,16 @@ class ShowCollectedJob(
     private val isCollected: Boolean
 ) : ShowBaseJob(showId, if (isCollected) 1 else 0, JobAction.EPISODE_COLLECTION) {
 
-    override fun applyDatabaseChanges(context: Context): Boolean {
+    override fun applyDatabaseChanges(
+        context: Context,
+        episodes: List<SgEpisode2Numbers>
+    ): Boolean {
         val rowsUpdated = SgRoomDatabase.getInstance(context).sgEpisode2Helper()
             .updateCollectedOfShowExcludeSpecials(showId, isCollected)
         return rowsUpdated >= 0 // -1 means error.
     }
 
-    override fun getEpisodesForNetworkJob(context: Context): List<SgEpisode2Numbers> {
+    override fun getAffectedEpisodes(context: Context): List<SgEpisode2Numbers> {
         return SgRoomDatabase.getInstance(context).sgEpisode2Helper()
             .getEpisodeNumbersOfShow(showId)
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivity.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.history
 
@@ -11,6 +11,8 @@ import com.battlelancer.seriesguide.provider.SeriesGuideContract.ActivityColumns
 import com.battlelancer.seriesguide.provider.SeriesGuideDatabase.Tables
 
 /**
+ * Episode watched activity. Uses stable TMDB IDs to work when a show is removed and re-added.
+ *
  * Note: ensure to use CONFLICT_REPLACE when inserting to mimic SQLite UNIQUE x ON CONFLICT REPLACE.
  */
 @Entity(
@@ -32,6 +34,9 @@ data class SgActivity (
 )
 
 object ActivityType {
+    /**
+     * Only used for reading, new entries only added if a TMDB ID exists.
+     */
     const val TVDB_ID = 1
     const val TMDB_ID = 2
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivityHelper.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivityHelper.kt
@@ -41,7 +41,7 @@ interface SgActivityHelper {
     fun getActivityByLatest(): List<SgActivity>
 
     companion object {
-        private const val HISTORY_THRESHOLD = 30 * DateUtils.DAY_IN_MILLIS
+        private const val HISTORY_THRESHOLD = 90 * DateUtils.DAY_IN_MILLIS
 
         /**
          * Adds activity entries for the given episode TMDB IDs with the current time as timestamp.

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivityHelper.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/history/SgActivityHelper.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.history
 
@@ -9,6 +9,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import timber.log.Timber
 
@@ -19,13 +20,22 @@ import timber.log.Timber
 interface SgActivityHelper {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertActivity(activity: SgActivity)
+    fun insertActivities(activities: List<SgActivity>)
 
     @Query("DELETE FROM activity WHERE activity_time < :deleteOlderThanMs")
     fun deleteOldActivity(deleteOlderThanMs: Long): Int
 
     @Query("DELETE FROM activity WHERE activity_episode = :episodeStableId AND activity_type = :type")
     fun deleteActivity(episodeStableId: String, type: Int): Int
+
+    @Transaction
+    fun deleteActivities(episodeStableId: List<String>, type: Int): Int {
+        var deleted = 0
+        episodeStableId.forEach {
+            deleted += deleteActivity(it, type)
+        }
+        return deleted
+    }
 
     @Query("SELECT * FROM activity ORDER BY activity_time DESC")
     fun getActivityByLatest(): List<SgActivity>
@@ -34,79 +44,52 @@ interface SgActivityHelper {
         private const val HISTORY_THRESHOLD = 30 * DateUtils.DAY_IN_MILLIS
 
         /**
-         * Adds an activity entry for the given episode with the current time as timestamp.
+         * Adds activity entries for the given episode TMDB IDs with the current time as timestamp.
          * If an entry already exists it is replaced.
          *
          * Also cleans up old entries.
          */
-        @JvmStatic
-        fun addActivity(context: Context, episodeId: Long, showId: Long) {
-            // Need to use global IDs (in case a show is removed and added again).
+        fun addActivitiesForEpisodes(
+            context: Context,
+            showTmdbId: Int,
+            episodeTmdbIds: List<Int>
+        ) {
             val database = SgRoomDatabase.getInstance(context)
-
-            // Try using TMDB ID
-            var type = ActivityType.TMDB_ID
-            var showStableIdOrZero = database.sgShow2Helper().getShowTmdbId(showId)
-            var episodeStableIdOrZero = database.sgEpisode2Helper().getEpisodeTmdbId(episodeId)
-
-            // Fall back to TVDB ID
-            if (showStableIdOrZero == 0 || episodeStableIdOrZero == 0) {
-                type = ActivityType.TVDB_ID
-                showStableIdOrZero = database.sgShow2Helper().getShowTvdbId(showId)
-                episodeStableIdOrZero = database.sgEpisode2Helper().getEpisodeTvdbId(episodeId)
-                if (showStableIdOrZero == 0 || episodeStableIdOrZero == 0) {
-                    // Should never happen: have neither TMDB or TVDB ID.
-                    Timber.e(
-                        "Failed to add activity, no TMDB or TVDB ID for show %d episode %d",
-                        showId,
-                        episodeId
-                    )
-                    return
-                }
-            }
-
-            val timeMonthAgo = System.currentTimeMillis() - HISTORY_THRESHOLD
             val helper = database.sgActivityHelper()
 
             // delete all entries older than 30 days
+            val timeMonthAgo = System.currentTimeMillis() - HISTORY_THRESHOLD
             val deleted = helper.deleteOldActivity(timeMonthAgo)
             Timber.d("addActivity: removed %d outdated activities", deleted)
 
             // add new entry
             val currentTime = System.currentTimeMillis()
-            val activity = SgActivity(
-                null,
-                episodeStableIdOrZero.toString(),
-                showStableIdOrZero.toString(),
-                currentTime,
-                type
-            )
-            helper.insertActivity(activity)
-            Timber.d("addActivity: episode: %d timestamp: %d", episodeId, currentTime)
+            episodeTmdbIds.map {
+                SgActivity(
+                    null,
+                    it.toString(),
+                    showTmdbId.toString(),
+                    currentTime,
+                    ActivityType.TMDB_ID
+                )
+            }.also {
+                helper.insertActivities(it)
+                Timber.d("Added %d activities with time %d", it.size, currentTime)
+            }
         }
 
         /**
-         * Tries to remove any activity with the given episode id.
+         * Tries to remove any activity with the given episode TMDB IDs.
          */
-        @JvmStatic
-        fun removeActivity(context: Context, episodeId: Long) {
-            // Need to use global IDs (in case a show is removed and added again).
-            val database = SgRoomDatabase.getInstance(context)
-
-            // Try removal using TMDB ID.
-            var deleted = 0
-            val episodeTmdbIdOrZero = database.sgEpisode2Helper().getEpisodeTmdbId(episodeId)
-            if (episodeTmdbIdOrZero != 0) {
-                deleted += database.sgActivityHelper()
-                    .deleteActivity(episodeTmdbIdOrZero.toString(), ActivityType.TMDB_ID)
-            }
-            // Try removal using TVDB ID.
-            val episodeTvdbIdOrZero = database.sgEpisode2Helper().getEpisodeTvdbId(episodeId)
-            if (episodeTvdbIdOrZero != 0) {
-                deleted += database.sgActivityHelper()
-                    .deleteActivity(episodeTvdbIdOrZero.toString(), ActivityType.TVDB_ID)
-            }
-            Timber.d("removeActivity: deleted %d activity entries", deleted)
+        fun removeActivitiesForEpisodes(
+            context: Context,
+            episodeTmdbIds: List<Int>
+        ) {
+            SgRoomDatabase.getInstance(context).sgActivityHelper()
+                .deleteActivities(episodeTmdbIds.map { it.toString() }, ActivityType.TMDB_ID)
+                .also {
+                    Timber.d("Deleted %d activity entries for %d episodes", it, episodeTmdbIds.size)
+                }
         }
     }
 


### PR DESCRIPTION
Adding with highest number and season first (so exact opposite of how it's sent to Trakt). History view is still restricted to 50 items.

But increased number of days to keep for old entries from 30 to 90.