### PR TITLE
Calendar: enable placeholders to not re-set scroll position on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Version 73
 *2024-04-05*
 
 * 🌟 Year and original language filter for popular shows screen.
+* 🔧 Calendar: avoid changing scroll position after viewing details or refreshing data.
 
 Version 72
 ----------

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarAdapter2.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarAdapter2.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.calendar
 
@@ -9,8 +9,8 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.shows.calendar.CalendarFragment2ViewModel.CalendarItem
+import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.ui.AutoGridLayoutManager
 
 class CalendarAdapter2(
@@ -32,7 +32,7 @@ class CalendarAdapter2(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val currentItem = getItem(position)!! // not using placeholders
+        val currentItem = getItem(position)
         val previousPosition = position - 1
         val previousItem = if (previousPosition >= 0) getItem(previousPosition) else null
         when (holder) {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.calendar
 
@@ -83,7 +83,9 @@ abstract class CalendarFragment2 : Fragment() {
             .observe(viewLifecycleOwner) { position: Int? ->
                 if (position != null) {
                     if (position == tabPosition) {
-                        recyclerView.smoothScrollToPosition(0)
+                        // The calendar list can get rather long,
+                        // so do not use smooth scrolling as it can take quite some time.
+                        recyclerView.scrollToPosition(0)
                     }
                 }
             }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2ViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarFragment2ViewModel.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.calendar
 
@@ -15,8 +15,8 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import androidx.sqlite.db.SimpleSQLiteQuery
-import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
+import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.util.TimeTools
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -31,8 +31,9 @@ class CalendarFragment2ViewModel(application: Application) : AndroidViewModel(ap
     private val queryLiveData = MutableLiveData<String>()
 
     private val calendarItemPagingConfig = PagingConfig(
-        pageSize = 50,
-        enablePlaceholders = false /* some items may have a header, so their height differs */
+        pageSize = 25,
+        enablePlaceholders = true, /* To properly restore scroll position on refresh */
+        jumpThreshold = 50 /* For fast scrolling to avoid ANRs */
     )
     val items: Flow<PagingData<CalendarItem>> =
         queryLiveData.asFlow().flatMapLatest {

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarItemViewHolder.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/calendar/CalendarItemViewHolder.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.shows.calendar
 
@@ -15,11 +15,12 @@ import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.RecyclerView
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.settings.DisplaySettings
+import com.battlelancer.seriesguide.shows.episodes.EpisodeFlags
 import com.battlelancer.seriesguide.shows.episodes.EpisodeTools
+import com.battlelancer.seriesguide.shows.episodes.WatchedBox
 import com.battlelancer.seriesguide.util.ImageTools
 import com.battlelancer.seriesguide.util.TextTools
 import com.battlelancer.seriesguide.util.TimeTools
-import com.battlelancer.seriesguide.shows.episodes.WatchedBox
 import java.util.Date
 
 class CalendarItemViewHolder(
@@ -71,11 +72,28 @@ class CalendarItemViewHolder(
 
     fun bind(
         context: Context,
-        item: CalendarFragment2ViewModel.CalendarItem,
+        item: CalendarFragment2ViewModel.CalendarItem?,
         previousItem: CalendarFragment2ViewModel.CalendarItem?,
         multiColumn: Boolean
     ) {
         this.item = item
+
+        if (item == null) {
+            if (multiColumn) {
+                headerTextView.isInvisible = true
+            } else {
+                headerTextView.isGone = true
+            }
+            showTextView.text = null
+            episodeTextView.text = null
+            collected.isGone = true
+            watchedBox.episodeFlag = EpisodeFlags.UNWATCHED
+            watchedBox.isEnabled = false
+            info.text = null
+            timestamp.text = null
+            poster.setImageResource(R.drawable.ic_photo_gray_24dp)
+            return
+        }
 
         // optional header
         val isShowingHeader = previousItem == null || previousItem.headerTime != item.headerTime
@@ -126,6 +144,7 @@ class CalendarItemViewHolder(
         info.text = TextTools.dotSeparate(episode.network, time)
 
         // watched box
+        watchedBox.isEnabled = true
         val episodeFlag = episode.watched
         watchedBox.episodeFlag = episodeFlag
         val watched = EpisodeTools.isWatched(episodeFlag)


### PR DESCRIPTION
At the downside that the RecyclerView will know of all items and therefore the fast scroller is harder to use and will lag quite a bit when jumping far. Though slowly scrolling through items still works as expected.

If that will cause ANRs, think about removing the fast scroller or somehow adding a debounce when scrolling (likely requiring a lot of effort).