### PR TITLE
Sustain future updates

### DIFF
--- a/app/src/amazon/java/com/battlelancer/seriesguide/billing/amazon/AmazonBillingActivity.kt
+++ b/app/src/amazon/java/com/battlelancer/seriesguide/billing/amazon/AmazonBillingActivity.kt
@@ -1,5 +1,5 @@
-// Copyright 2014 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2014-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.billing.amazon
 
@@ -21,7 +21,7 @@ import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
 
 /**
- * Offers a single subscription and in-app purchase using the Amazon in-app purchasing library.
+ * Offers a single subscription using the Amazon in-app purchasing library.
  *
  * To debug: install on device with Amazon App Store and download App Tester app, put
  * `amazon.sdktester.json` onto `sdcard`.
@@ -65,9 +65,6 @@ class AmazonBillingActivity : BaseActivity() {
         binding.buttonAmazonBillingSubscribe.isEnabled = false
         binding.buttonAmazonBillingSubscribe.setOnClickListener { subscribe() }
 
-        binding.buttonAmazonBillingGetPass.isEnabled = false
-        binding.buttonAmazonBillingGetPass.setOnClickListener { purchasePass() }
-
         ViewTools.openUriOnClick(
             binding.textViewAmazonBillingMoreInfo,
             getString(R.string.url_whypay)
@@ -108,13 +105,6 @@ class AmazonBillingActivity : BaseActivity() {
         Timber.d("subscribe: requestId (%s)", requestId)
     }
 
-    private fun purchasePass() {
-        val requestId = PurchasingService.purchase(
-            AmazonSku.SERIESGUIDE_PASS.sku
-        )
-        Timber.d("purchasePass: requestId (%s)", requestId)
-    }
-
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: AmazonIapMessageEvent) {
         Toast.makeText(this, event.messageResId, Toast.LENGTH_LONG).show()
@@ -127,16 +117,13 @@ class AmazonBillingActivity : BaseActivity() {
         // enable or disable purchase buttons based on what can be purchased
         binding.buttonAmazonBillingSubscribe.isEnabled =
             event.subscriptionAvailable && !event.userHasActivePurchase
-        binding.buttonAmazonBillingGetPass.isEnabled =
-            event.passAvailable && !event.userHasActivePurchase
 
         // status text
-        if (!event.subscriptionAvailable && !event.passAvailable) {
+        if (!event.subscriptionAvailable) {
             // neither purchase available, probably not signed in
             binding.textViewAmazonBillingExisting.setText(R.string.subscription_not_signed_in)
         } else {
-            // subscription or pass available
-            // show message if either one is active
+            // subscription available
             binding.textViewAmazonBillingExisting.text =
                 if (event.userHasActivePurchase) getString(R.string.upgrade_success) else null
         }
@@ -155,9 +142,6 @@ class AmazonBillingActivity : BaseActivity() {
             val trialInfo = getString(R.string.billing_sub_description)
             val finalPriceString = "$priceString\n$trialInfo"
             binding.textViewAmazonBillingSubPrice.text = finalPriceString
-        } else if (AmazonSku.SERIESGUIDE_PASS.sku == product.sku) {
-            binding.textViewAmazonBillingPricePass.text =
-                String.format("%s\n%s", price, getString(R.string.billing_price_pass))
         }
     }
 }

--- a/app/src/amazon/res/layout/activity_amazon_billing.xml
+++ b/app/src/amazon/res/layout/activity_amazon_billing.xml
@@ -22,18 +22,20 @@
 
             <TextView
                 android:id="@+id/textViewAmazonBillingTitle"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentTop="true"
-                android:paddingBottom="@dimen/inline_padding"
+                android:drawablePadding="4dp"
                 android:text="@string/action_upgrade"
-                android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5" />
+                android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5"
+                app:drawableStartCompat="@drawable/ic_awesome_black_24dp" />
 
             <TextView
                 android:id="@+id/textViewAmazonBillingDescription"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/textViewAmazonBillingTitle"
+                android:layout_marginTop="4dp"
                 android:text="@string/upgrade_description"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Body2" />
 

--- a/app/src/amazon/res/layout/activity_amazon_billing.xml
+++ b/app/src/amazon/res/layout/activity_amazon_billing.xml
@@ -76,36 +76,14 @@
                 android:maxWidth="250dp"
                 android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Italic"
                 android:textStyle="italic"
-                tools:text="1.99 €/year\ntry for 30 days" />
-
-            <Button
-                android:id="@+id/buttonAmazonBillingGetPass"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/textViewAmazonBillingSubPrice"
-                android:layout_centerHorizontal="true"
-                android:layout_marginTop="@dimen/large_padding"
-                android:enabled="false"
-                android:text="@string/billing_action_pass" />
-
-            <TextView
-                android:id="@+id/textViewAmazonBillingPricePass"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/buttonAmazonBillingGetPass"
-                android:layout_centerHorizontal="true"
-                android:gravity="center_horizontal"
-                android:maxWidth="250dp"
-                android:text="@string/billing_price_pass"
-                android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Italic"
-                android:textStyle="italic" />
+                tools:text="6.99 €/year\ntry for 30 days" />
 
             <Button
                 android:id="@+id/textViewAmazonBillingMoreInfo"
                 style="@style/Widget.SeriesGuide.Button.Outlined"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/textViewAmazonBillingPricePass"
+                android:layout_below="@+id/textViewAmazonBillingSubPrice"
                 android:layout_centerHorizontal="true"
                 android:layout_marginTop="@dimen/large_padding"
                 android:text="@string/billing_learn_more" />

--- a/app/src/amazon/res/values/donottranslate.xml
+++ b/app/src/amazon/res/values/donottranslate.xml
@@ -2,7 +2,6 @@
 
     <string name="url_store_page">http://www.amazon.com/gp/mas/dl/android?p=com.uwetrottmann.seriesguide.amzn</string>
     <!-- Remove Google Play links (not used in-app) -->
-    <string name="url_x_pass"/>
     <string name="url_extensions_search"/>
     <string name="url_movies_search"/>
 

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/CloudSetupFragment.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.backend
 
@@ -29,6 +29,7 @@ import com.firebase.ui.auth.AuthMethodPickerLayout
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.ErrorCodes
 import com.firebase.ui.auth.IdpResponse
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -72,12 +73,17 @@ class CloudSetupFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding!!.apply {
             ThemeUtils.applyBottomPaddingForNavigationBar(scrollViewCloud)
-            buttonCloudSignIn.setOnClickListener {
-                // restrict access to supporters
-                if (Utils.hasAccessToX(activity)) {
-                    startHexagonSetup()
-                } else {
-                    Utils.advertiseSubscription(activity)
+            buttonCloudSignIn.apply {
+                if (!Utils.hasAccessToX(activity)) {
+                    (buttonCloudSignIn as MaterialButton).setIconResource(R.drawable.ic_awesome_black_24dp)
+                }
+                setOnClickListener {
+                    // restrict access to supporters
+                    if (Utils.hasAccessToX(activity)) {
+                        startHexagonSetup()
+                    } else {
+                        Utils.advertiseSubscription(activity)
+                    }
                 }
             }
             buttonCloudSignOut.setOnClickListener { signOut() }
@@ -195,10 +201,12 @@ class CloudSetupFragment : Fragment() {
                             ErrorCodes.NO_NETWORK -> {
                                 errorMessage = getString(R.string.offline)
                             }
+
                             ErrorCodes.PLAY_SERVICES_UPDATE_CANCELLED -> {
                                 // user cancelled, show no error message
                                 errorMessage = null
                             }
+
                             else -> {
                                 if (ex.errorCode == ErrorCodes.DEVELOPER_ERROR
                                     && !hexagonTools.isGoogleSignInAvailable) {

--- a/app/src/main/java/com/battlelancer/seriesguide/billing/BillingActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/billing/BillingActivity.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.billing
 
@@ -24,7 +24,6 @@ import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.ui.BaseActivity
 import com.battlelancer.seriesguide.util.ThemeUtils
 import com.battlelancer.seriesguide.util.Utils
-import com.battlelancer.seriesguide.util.ViewTools
 import com.battlelancer.seriesguide.util.WebTools
 import com.google.android.material.snackbar.Snackbar
 import com.uwetrottmann.seriesguide.billing.BillingViewModel
@@ -40,7 +39,6 @@ class BillingActivity : BaseActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: SkuDetailsAdapter
     private lateinit var buttonManageSubs: Button
-    private lateinit var buttonPass: Button
     private lateinit var textViewHasUpgrade: View
     private lateinit var textViewBillingUnlockDetected: View
     private lateinit var textViewBillingError: TextView
@@ -136,9 +134,6 @@ class BillingActivity : BaseActivity() {
                 WebTools.openInApp(v.context, manageSubscriptionUrl)
             }
         }
-
-        buttonPass = findViewById(R.id.buttonBillingGetPass)
-        ViewTools.openUriOnClick(buttonPass, getString(R.string.url_x_pass))
 
         findViewById<View>(R.id.textViewBillingMoreInfo).setOnClickListener {
             WebTools.openInCustomTab(this, getString(R.string.url_whypay))

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/ShowFragment.kt
@@ -99,7 +99,7 @@ class ShowFragment() : Fragment() {
         val buttonNotify: MaterialButton
         val buttonHidden: MaterialButton
         val buttonEditReleaseTime: Button
-        val buttonShortcut: Button
+        val buttonShortcut: MaterialButton
         val buttonLanguage: Button
         val buttonTrailer: Button
         val buttonSimilar: Button
@@ -195,9 +195,6 @@ class ShowFragment() : Fragment() {
 
         // share button
         binding.buttonShare.setOnClickListener { shareShow() }
-
-        // shortcut button
-        binding.buttonShortcut.setOnClickListener { createShortcut() }
 
         setCastVisibility(binding, false)
         setCrewVisibility(binding, false)
@@ -320,7 +317,9 @@ class ShowFragment() : Fragment() {
             )
             TooltipCompat.setTooltipText(this, contentDescription)
             setIconResource(
-                if (notify) {
+                if (!hasAccessToX) {
+                    R.drawable.ic_awesome_black_24dp
+                } else if (notify) {
                     R.drawable.ic_notifications_active_black_24dp
                 } else {
                     R.drawable.ic_notifications_off_black_24dp
@@ -444,6 +443,12 @@ class ShowFragment() : Fragment() {
             if (show.title.isNotEmpty()) Metacritic.searchForTvShow(requireContext(), show.title)
         }
 
+        // shortcut button
+        binding.buttonShortcut.apply {
+            setIconResource(if (hasAccessToX) R.drawable.ic_add_to_home_screen_black_24dp else R.drawable.ic_awesome_black_24dp)
+            setOnClickListener { createShortcut(hasAccessToX) }
+        }
+
         // web search button
         ServiceUtils.setUpWebSearchButton(show.title, binding.buttonWebSearch)
 
@@ -531,8 +536,8 @@ class ShowFragment() : Fragment() {
         changeShowLanguage(event.selectedLanguageCode)
     }
 
-    private fun createShortcut() {
-        if (!Utils.hasAccessToX(activity)) {
+    private fun createShortcut(hasAccessToX: Boolean) {
+        if (!hasAccessToX) {
             Utils.advertiseSubscription(activity)
             return
         }

--- a/app/src/main/res/drawable/ic_awesome_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_awesome_black_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,9l1.25,-2.75L23,5l-2.75,-1.25L19,1l-1.25,2.75L15,5l2.75,1.25L19,9zM11.5,9.5L9,4 6.5,9.5 1,12l5.5,2.5L9,20l2.5,-5.5L17,12l-5.5,-2.5zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15z" />
+
+</vector>

--- a/app/src/main/res/layout/activity_billing.xml
+++ b/app/src/main/res/layout/activity_billing.xml
@@ -99,24 +99,6 @@
                     android:text="@string/billing_action_manage_subscriptions" />
 
                 <Button
-                    android:id="@+id/buttonBillingGetPass"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="@dimen/large_padding"
-                    android:text="@string/billing_action_pass" />
-
-                <TextView
-                    android:id="@+id/textViewBillingPricePass"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/inline_padding"
-                    android:gravity="center_horizontal"
-                    android:text="@string/billing_price_pass"
-                    android:textAppearance="@style/TextAppearance.SeriesGuide.Body2.Italic"
-                    android:textStyle="italic" />
-
-                <Button
                     android:id="@+id/textViewBillingMoreInfo"
                     style="@style/Widget.SeriesGuide.Button.Outlined"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_billing.xml
+++ b/app/src/main/res/layout/activity_billing.xml
@@ -30,14 +30,16 @@
                     android:id="@+id/textViewBillingTitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingBottom="@dimen/inline_padding"
+                    android:drawablePadding="4dp"
                     android:text="@string/action_upgrade"
-                    android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5" />
+                    android:textAppearance="@style/TextAppearance.SeriesGuide.Headline5"
+                    app:drawableStartCompat="@drawable/ic_awesome_black_24dp" />
 
                 <TextView
                     android:id="@+id/textViewBillingDescription"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
                     android:layout_marginBottom="@dimen/default_padding"
                     android:text="@string/upgrade_description"
                     android:textAppearance="@style/TextAppearance.SeriesGuide.Body2" />

--- a/app/src/main/res/layout/activity_more_options.xml
+++ b/app/src/main/res/layout/activity_more_options.xml
@@ -117,7 +117,7 @@
                     android:layout_height="48dp"
                     android:layout_marginTop="16dp"
                     android:text="@string/action_upgrade"
-                    app:icon="@drawable/ic_star_black_24dp"
+                    app:icon="@drawable/ic_awesome_black_24dp"
                     app:iconGravity="start"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -53,7 +53,6 @@
 
     <!-- Google Play links -->
     <string name="url_store_page">https://play.google.com/store/apps/details?id=com.battlelancer.seriesguide</string>
-    <string name="url_x_pass">https://play.google.com/store/apps/details?id=com.battlelancer.seriesguide.x</string>
     <string name="url_extensions_search">https://play.google.com/store/search?q=SeriesGuide%20Extension&amp;c=apps</string>
     <string name="url_movies_search">https://play.google.com/store/search?q=%s&amp;c=movies</string>
 


### PR DESCRIPTION
- [ ] ~Allow to subscribe on Amazon even if pass purchased, add info message like for Play~ Not with this.
- [ ] ~Add explicit list of subscription features in-app (no one visits the website)~ Not with this. Also not sure, main purpose is to support me.
- [x] Display star icon in more places, like Cloud sign-in (check where `Utils.advertiseSubscription()` is called)

Not with this, but: think about introducing a new in-app one-time purchase that does not include Cloud (which has the highest recurring costs).