### PR TITLE
Fix Release 2024.3.6 (Amazon only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Version 2024.3
 * 🌟 Trakt: support to edit and delete (new) comments.
 * 🌟 Trakt: support to remove a rating.
 
+#### 2024.3.6
+*2024-07-25*
+
+* 📝 This version was released only on the Amazon Appstore.
+* 🔨 Amazon account and active purchases are correctly recognized again.
+
 #### 2024.3.5
 *2024-07-18*
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,3 +11,9 @@
 -dontobfuscate
 # Output unused code so it can be optimized
 -printusage unused.txt
+
+# Amazon Appstore SDK (3.0.5 release no longer includes ProGuard rules)
+# https://developer.amazon.com/docs/in-app-purchasing/iap-obfuscate-the-code.html
+-dontwarn com.amazon.**
+-keep class com.amazon.** {*;}
+-keepattributes *Annotation*

--- a/app/src/amazon/AndroidManifest.xml
+++ b/app/src/amazon/AndroidManifest.xml
@@ -2,6 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <queries>
+        <!-- On Android 11 (SDK 30), allow SeriesGuide to see Amazon apps. -->
+        <!-- https://developer.android.com/training/package-visibility -->
+        <!-- Amazon App Tester -->
+        <package android:name="com.amazon.sdktestclient" />
+        <!-- Amazon Appstore -->
+        <package android:name="com.amazon.venezia" />
+    </queries>
+
     <application tools:ignore="AllowBackup,GoogleAppIndexingWarning">
 
         <!-- Amazon In-App Purchasing -->

--- a/app/src/amazon/README.md
+++ b/app/src/amazon/README.md
@@ -2,5 +2,7 @@
 
 To test in-app billing see notes in [AmazonBillingActivity.kt](java/com/battlelancer/seriesguide/billing/amazon/AmazonBillingActivity.kt)
 
+As the Appstore SDK does not include ProGuard rules, [those are added manually](https://developer.amazon.com/docs/in-app-purchasing/iap-obfuscate-the-code.html).
+
 - https://developer.amazon.com/de/docs/in-app-purchasing/iap-app-tester-user-guide.html
 - https://github.com/AmazonAppDev/amazon-iap-kotlin

--- a/app/src/amazon/README.md
+++ b/app/src/amazon/README.md
@@ -1,0 +1,6 @@
+# Amazon Appstore variant
+
+To test in-app billing see notes in [AmazonBillingActivity.kt](java/com/battlelancer/seriesguide/billing/amazon/AmazonBillingActivity.kt)
+
+- https://developer.amazon.com/de/docs/in-app-purchasing/iap-app-tester-user-guide.html
+- https://github.com/AmazonAppDev/amazon-iap-kotlin

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:required="false" />
 
     <!-- On Android 11 (SDK 30), allow SeriesGuide to see apps providing extensions and the X Pass app. -->
-    <!-- https://developer.android.com/preview/privacy/package-visibility -->
+    <!-- https://developer.android.com/training/package-visibility -->
     <queries>
         <intent>
             <action android:name="com.battlelancer.seriesguide.api.SeriesGuideExtension" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,9 @@ buildscript {
     // YYYY.<release-of-year>.<build> - like 2024.1.0
     // - allows to more easily judge how old a release is
     // - allows multiple releases per month (though currently unlikely)
-    val sgVersionName by extra("2024.3.5")
+    val sgVersionName by extra("2024.3.6")
     // version 21yyrrbb -> min SDK 21, year yy, release rr, build bb
-    val sgVersionCode by extra(21240305)
+    val sgVersionCode by extra(21240306)
 
     val isCiBuild by extra { System.getenv("CI") == "true" }
 


### PR DESCRIPTION
Version 3.0.5 of the Amazon Appstore SDK (`com.amazon.device:amazon-appstore-sdk:3.0.5`) does no longer include ProGuard rules. This breaks app public key verification (`AUTH_TOKEN_VERIFICATION_FAILURE`).

Add them manually again.