### PR TITLE
Higher resolution episode images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Releases marked with 🧪 (or previously with the "beta" suffix) were released o
 ### Unreleased
 
 * 🌟 Shows: add a note to a show, synced with SeriesGuide Cloud or Trakt (VIP only).
+* 🔧 Shows: increase resolution of episode images.
 * 🔧 Shows: also use plus symbol for button on discover screen to be consistent.
 
 ### 2024.5.0 - 2024-11-06 🧪

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
@@ -21,7 +21,7 @@ object TmdbSettings {
     private const val KEY_TMDB_BASE_URL = "com.battlelancer.seriesguide.tmdb.baseurl"
     const val POSTER_SIZE_SPEC_W154 = "w154"
     const val POSTER_SIZE_SPEC_W342 = "w342"
-    private const val STILL_SIZE_SPEC_W300 = "w300"
+    private const val BACKDROP_SMALL_SIZE_SPEC = "w300"
     private const val IMAGE_SIZE_SPEC_ORIGINAL = "original"
     const val DEFAULT_BASE_URL = "https://image.tmdb.org/t/p/"
 
@@ -69,7 +69,7 @@ object TmdbSettings {
         }
     }
 
-    fun getStillUrl(context: Context, path: String): String {
-        return getImageBaseUrl(context) + STILL_SIZE_SPEC_W300 + path
+    fun buildBackdropUrl(context: Context, path: String): String {
+        return "${getImageBaseUrl(context)}$BACKDROP_SMALL_SIZE_SPEC$path"
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
@@ -21,7 +21,7 @@ object TmdbSettings {
     private const val KEY_TMDB_BASE_URL = "com.battlelancer.seriesguide.tmdb.baseurl"
     const val POSTER_SIZE_SPEC_W154 = "w154"
     const val POSTER_SIZE_SPEC_W342 = "w342"
-    private const val BACKDROP_SMALL_SIZE_SPEC = "w300"
+    const val BACKDROP_SMALL_SIZE_SPEC = "w300"
     private const val IMAGE_SIZE_SPEC_ORIGINAL = "original"
     const val DEFAULT_BASE_URL = "https://image.tmdb.org/t/p/"
 

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/TmdbSettings.kt
@@ -21,7 +21,21 @@ object TmdbSettings {
     private const val KEY_TMDB_BASE_URL = "com.battlelancer.seriesguide.tmdb.baseurl"
     const val POSTER_SIZE_SPEC_W154 = "w154"
     const val POSTER_SIZE_SPEC_W342 = "w342"
-    const val BACKDROP_SMALL_SIZE_SPEC = "w300"
+
+    /**
+     * As of 2024-11:
+     *
+     * - w300 (300 × 169 px) JPEG is around 9-16 kB
+     * - w780 (780 × 439 px) JPEG is around 30-70 kB
+     * - w1280 (1280 × 720 px) JPEG is around 60-140 KB
+     *
+     * Samples:
+     *
+     * - https://image.tmdb.org/t/p/original/8Tvnx22rzhwArofFPhmcfaBvgjN.jpg (smallest)
+     * - https://image.tmdb.org/t/p/original/j4WEC9Jh4AyXF8ynpX3pz633tse.jpg
+     * - https://image.tmdb.org/t/p/original/5Bh7EE3p6OOS0NzH22AE0N7DYO8.jpg (largest)
+     */
+    const val BACKDROP_SMALL_SIZE_SPEC = "w780"
     private const val IMAGE_SIZE_SPEC_ORIGINAL = "original"
     const val DEFAULT_BASE_URL = "https://image.tmdb.org/t/p/"
 

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodeDetailsFragment.kt
@@ -52,7 +52,6 @@ import com.battlelancer.seriesguide.ui.BaseMessageActivity.ServiceActiveEvent
 import com.battlelancer.seriesguide.ui.BaseMessageActivity.ServiceCompletedEvent
 import com.battlelancer.seriesguide.ui.FullscreenImageActivity.Companion.intent
 import com.battlelancer.seriesguide.util.ImageTools
-import com.battlelancer.seriesguide.util.ImageTools.tmdbOrTvdbStillUrl
 import com.battlelancer.seriesguide.util.LanguageTools
 import com.battlelancer.seriesguide.util.RatingsTools.initialize
 import com.battlelancer.seriesguide.util.RatingsTools.setLink
@@ -451,8 +450,8 @@ class EpisodeDetailsFragment : Fragment(), EpisodeActionsContract {
         binding.containerImage.setOnClickListener { v: View? ->
             val intent = intent(
                 requireContext(),
-                tmdbOrTvdbStillUrl(imagePath, requireContext(), false),
-                tmdbOrTvdbStillUrl(imagePath, requireContext(), true)
+                ImageTools.buildEpisodeImageUrl(imagePath, requireContext()),
+                ImageTools.buildEpisodeImageUrl(imagePath, requireContext(), true)
             )
             Utils.startActivityWithAnimation(requireActivity(), intent, v)
         }
@@ -685,7 +684,7 @@ class EpisodeDetailsFragment : Fragment(), EpisodeActionsContract {
             binding.containerImage.visibility = View.VISIBLE
             ImageTools.loadWithPicasso(
                 requireContext(),
-                tmdbOrTvdbStillUrl(imagePath, requireContext(), false)
+                ImageTools.buildEpisodeImageUrl(imagePath, requireContext())
             )
                 .error(R.drawable.ic_photo_gray_24dp)
                 .into(

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodeDetailsFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/episodes/EpisodeDetailsFragment.kt
@@ -451,7 +451,7 @@ class EpisodeDetailsFragment : Fragment(), EpisodeActionsContract {
             val intent = intent(
                 requireContext(),
                 ImageTools.buildEpisodeImageUrl(imagePath, requireContext()),
-                ImageTools.buildEpisodeImageUrl(imagePath, requireContext(), true)
+                ImageTools.buildEpisodeImageUrl(imagePath, requireContext(), originalSize = true)
             )
             Utils.startActivityWithAnimation(requireActivity(), intent, v)
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/overview/OverviewFragment.kt
@@ -60,7 +60,6 @@ import com.battlelancer.seriesguide.traktapi.TraktTools
 import com.battlelancer.seriesguide.ui.BaseMessageActivity.ServiceActiveEvent
 import com.battlelancer.seriesguide.ui.BaseMessageActivity.ServiceCompletedEvent
 import com.battlelancer.seriesguide.util.ImageTools
-import com.battlelancer.seriesguide.util.ImageTools.tmdbOrTvdbStillUrl
 import com.battlelancer.seriesguide.util.LanguageTools
 import com.battlelancer.seriesguide.util.RatingsTools.initialize
 import com.battlelancer.seriesguide.util.RatingsTools.setLink
@@ -650,7 +649,7 @@ class OverviewFragment() : Fragment(), EpisodeActionsContract {
             // Try loading image
             ImageTools.loadWithPicasso(
                 requireContext(),
-                tmdbOrTvdbStillUrl(imagePath, requireContext(), false)
+                ImageTools.buildEpisodeImageUrl(imagePath, requireContext())
             )
                 .error(R.drawable.ic_photo_gray_24dp)
                 .into(imageView,

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ImageTools.kt
@@ -123,15 +123,22 @@ object ImageTools {
         "https://seriesgui.de/demo/sitcom.jpg",
     )
 
-    private val demoStillUrl = "https://seriesgui.de/demo/episode-anime.jpg"
+    private val demoEpisodeImageUrl = "https://seriesgui.de/demo/episode-anime.jpg"
 
     private fun pickDemoPosterUrl(imagePath: String): String {
         // Map an image path always to the same image
         return demoPosterUrls[imagePath.hashCode().mod(demoPosterUrls.size)]
     }
 
-    @JvmStatic
-    fun tmdbOrTvdbStillUrl(
+    /**
+     * Builds an image cache URL, or returns null if [imagePath] is null or empty.
+     *
+     * Returns demo images if [AppSettings.isDemoModeEnabled] is enabled.
+     *
+     * If [imagePath] starts with `/` builds a TMDB episode image path with resolution depending on
+     * [originalSize]. Otherwise a legacy TVDB URL.
+     */
+    fun buildEpisodeImageUrl(
         imagePath: String?,
         context: Context,
         originalSize: Boolean = false
@@ -140,7 +147,7 @@ object ImageTools {
             null
         } else {
             if (AppSettings.isDemoModeEnabled(context)) {
-                return demoStillUrl
+                return demoEpisodeImageUrl
             }
 
             // If the path contains the legacy TVDB cache prefix, use the www subdomain as it has
@@ -159,7 +166,7 @@ object ImageTools {
                     if (originalSize) {
                         TmdbSettings.getImageOriginalUrl(context, imagePath)
                     } else {
-                        TmdbSettings.getStillUrl(context, imagePath)
+                        TmdbSettings.buildBackdropUrl(context, imagePath)
                     }
                 }
 
@@ -174,7 +181,7 @@ object ImageTools {
     /**
      * [posterUrl] must not be empty.
      */
-    fun buildImageCacheUrl(posterUrl: String): String? {
+    private fun buildImageCacheUrl(posterUrl: String): String? {
         @Suppress("SENSELESS_COMPARISON")
         if (BuildConfig.IMAGE_CACHE_URL == null) {
             return posterUrl // no cache

--- a/app/src/main/java/com/battlelancer/seriesguide/util/ImageTools.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/ImageTools.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.util
 

--- a/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
@@ -43,7 +43,7 @@ class ImageToolsTest {
                 ImageTools.buildEpisodeImageUrl(path, context)
             },
             tmdbUrlOriginalBuilder = { path ->
-                ImageTools.buildEpisodeImageUrl(path, context, true)
+                ImageTools.buildEpisodeImageUrl(path, context, originalSize = true)
             },
             tvdbUrlBuilder = { path ->
                 ImageTools.buildEpisodeImageUrl(path, context)

--- a/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
@@ -6,6 +6,7 @@ package com.battlelancer.seriesguide.util
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.battlelancer.seriesguide.EmptyTestApplication
+import com.battlelancer.seriesguide.settings.TmdbSettings
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,15 +21,51 @@ class ImageToolsTest {
 
     @Test
     fun posterUrl() {
+        assertImageUrl(
+            TmdbSettings.POSTER_SIZE_SPEC_W154,
+            tmdbUrlBuilder = { path ->
+                ImageTools.tmdbOrTvdbPosterUrl(path, context)
+            },
+            tmdbUrlOriginalBuilder = { path ->
+                ImageTools.tmdbOrTvdbPosterUrl(path, context, true)
+            },
+            tvdbUrlBuilder = { path ->
+                ImageTools.tmdbOrTvdbPosterUrl(path, context)
+            }
+        )
+    }
+
+    @Test
+    fun episodeImageUrl() {
+        assertImageUrl(
+            TmdbSettings.BACKDROP_SMALL_SIZE_SPEC,
+            tmdbUrlBuilder = { path ->
+                ImageTools.buildEpisodeImageUrl(path, context)
+            },
+            tmdbUrlOriginalBuilder = { path ->
+                ImageTools.buildEpisodeImageUrl(path, context, true)
+            },
+            tvdbUrlBuilder = { path ->
+                ImageTools.buildEpisodeImageUrl(path, context)
+            }
+        )
+    }
+
+    private fun assertImageUrl(
+        smallSize: String,
+        tmdbUrlBuilder: (String) -> String?,
+        tmdbUrlOriginalBuilder: (String) -> String?,
+        tvdbUrlBuilder: (String) -> String?
+    ) {
         // Note: TMDB image paths start with / whereas TVDB paths do not.
-        val tmdbUrl = ImageTools.tmdbOrTvdbPosterUrl("/example.jpg", context)
-        val tmdbUrlOriginal = ImageTools.tmdbOrTvdbPosterUrl("/example.jpg", context, true)
-        val tvdbUrl = ImageTools.tmdbOrTvdbPosterUrl("posters/example.jpg", context)
+        val tmdbUrl = tmdbUrlBuilder("/example.jpg")
+        val tmdbUrlOriginal = tmdbUrlOriginalBuilder("/example.jpg")
+        val tvdbUrl = tvdbUrlBuilder("posters/example.jpg")
         println("TMDB URL: $tmdbUrl")
         println("TMDB original URL: $tmdbUrlOriginal")
         println("TVDB URL: $tvdbUrl")
         assertThat(tmdbUrl).isNotEmpty()
-        assertThat(tmdbUrl).endsWith("https://image.tmdb.org/t/p/w154/example.jpg")
+        assertThat(tmdbUrl).endsWith("https://image.tmdb.org/t/p/$smallSize/example.jpg")
         assertThat(tmdbUrlOriginal).isNotEmpty()
         assertThat(tmdbUrlOriginal).endsWith("https://image.tmdb.org/t/p/original/example.jpg")
         assertThat(tvdbUrl).isNotEmpty()

--- a/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/util/ImageToolsTest.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-2024 Uwe Trottmann
 
 package com.battlelancer.seriesguide.util
 


### PR DESCRIPTION
The cache server is not using the full cache size, so make use of it.

Also refactor ImageTools a bit to de-duplicate and document code.