### PR TITLE
Trakt: show activity of following instead of friends

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/movies/TraktFriendsMovieHistoryLoader.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/TraktFriendsMovieHistoryLoader.kt
@@ -30,7 +30,7 @@ internal class TraktFriendsMovieHistoryLoader(context: Context) :
         val traktUsers = SgApp.getServicesComponent(context).traktUsers()!!
         val friends = SgTrakt.executeAuthenticatedCall(
             context,
-            traktUsers.friends(UserSlug.ME, Extended.FULL), "get friends"
+            traktUsers.following(UserSlug.ME, Extended.FULL), "get following"
         ) ?: return null
 
         val size = friends.size

--- a/app/src/main/java/com/battlelancer/seriesguide/shows/history/TraktFriendsEpisodeHistoryLoader.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/shows/history/TraktFriendsEpisodeHistoryLoader.kt
@@ -36,8 +36,8 @@ internal class TraktFriendsEpisodeHistoryLoader(context: Context) :
         val traktUsers = services.traktUsers()!!
         val friends = SgTrakt.executeAuthenticatedCall(
             context,
-            traktUsers.friends(UserSlug.ME, Extended.FULL),
-            "get friends"
+            traktUsers.following(UserSlug.ME, Extended.FULL),
+            "get following"
         ) ?: return null
 
         val size = friends.size


### PR DESCRIPTION
- [ ] Update headings

This currently might take a long time to load if there are many profiles in following list.

Trakt may offer an explicit API for this in the future, so not doing this for now.