### PR TITLE
Cloud and Trakt: do not skip adding a movie if download fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Releases marked with 🧪 (or previously with the "beta" suffix) were released o
 
 ## Next release
 
+* 🔨 Movies: when connecting Cloud or Trakt, movies might not have been added if downloading them
+  failed. Any missing movies will be added on the next sync.
 * 📝 Devices running Android 5.0 and 5.1 will receive no more updates in the future.
 * 📝 Import latest user interface translations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Releases marked with 🧪 (or previously with the "beta" suffix) were released o
 
 * 🔨 Movies: when connecting Cloud or Trakt, movies might not have been added if downloading them
   failed. Any missing movies will be added on the next sync.
+* 🔨 Movies: prefer translated title when viewing details.
 * 📝 Devices running Android 5.0 and 5.1 will receive no more updates in the future.
 * 📝 Import latest user interface translations.
 

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -89,6 +89,8 @@ class SgApp : Application() {
 
         const val RELEASE_VERSION_2024_3_5 = 21240305
 
+        const val RELEASE_VERSION_2025_1_1 = 21250102
+
         /**
          * The content authority used to identify the SeriesGuide [android.content.ContentProvider].
          */

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.kt
@@ -138,16 +138,6 @@ object HexagonSettings {
     }
 
     /**
-     * Like [resetSyncState], but only for movies.
-     */
-    fun resetMovieSyncState(context: Context) {
-        PreferenceManager.getDefaultSharedPreferences(context).edit {
-            putBoolean(KEY_MERGED_MOVIES, false)
-            remove(KEY_LAST_SYNC_MOVIES)
-        }
-    }
-
-    /**
      * Whether shows in the local database have been merged with those on Hexagon.
      */
     fun hasMergedShows(context: Context): Boolean {
@@ -222,13 +212,27 @@ object HexagonSettings {
         }
     }
 
-    fun getLastMoviesSyncTime(context: Context): Long {
-        return getLastSyncTime(context, KEY_LAST_SYNC_MOVIES)
+    fun getLastMoviesSyncTime(context: Context): Long? {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        if (!prefs.contains(KEY_LAST_SYNC_MOVIES)) return null
+        return prefs.getLong(
+            KEY_LAST_SYNC_MOVIES,
+            0 /* Never returned, returning null above if it does not exist */
+        )
     }
 
     fun setLastMoviesSyncTime(context: Context, timeInMs: Long) {
         PreferenceManager.getDefaultSharedPreferences(context).edit {
             putLong(KEY_LAST_SYNC_MOVIES, timeInMs)
+        }
+    }
+
+    /**
+     * Sets [getLastMoviesSyncTime] so that all movies are downloaded on the next sync.
+     */
+    fun resetLastMoviesSyncTime(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            remove(KEY_LAST_SYNC_MOVIES)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/backend/settings/HexagonSettings.kt
@@ -138,6 +138,16 @@ object HexagonSettings {
     }
 
     /**
+     * Like [resetSyncState], but only for movies.
+     */
+    fun resetMovieSyncState(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putBoolean(KEY_MERGED_MOVIES, false)
+            remove(KEY_LAST_SYNC_MOVIES)
+        }
+    }
+
+    /**
      * Whether shows in the local database have been merged with those on Hexagon.
      */
     fun hasMergedShows(context: Context): Boolean {

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MovieLoader.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MovieLoader.kt
@@ -11,6 +11,7 @@ import com.battlelancer.seriesguide.provider.SgRoomDatabase.Companion.getInstanc
 import com.uwetrottmann.androidutils.GenericSimpleLoader
 import com.uwetrottmann.tmdb2.entities.Movie
 import com.uwetrottmann.trakt5.entities.Ratings
+import kotlinx.coroutines.runBlocking
 
 /**
  * Tries to load current movie details from trakt and TMDb, if failing tries to fall back to local
@@ -24,7 +25,10 @@ internal class MovieLoader(
     override fun loadInBackground(): MovieDetails {
         // try loading from trakt and tmdb, this might return a cached response
         val movieTools = getServicesComponent(context).movieTools()
-        val details = movieTools.getMovieDetailsWithDefaults(tmdbId, true).movieDetails
+        // No need to handle InterruptedException as ModernAsyncTask does (see its constructor)
+        val details = runBlocking {
+            movieTools.getMovieDetailsWithDefaults(tmdbId, true).movieDetails
+        }
 
         // Update local database (no-op if movie not in database).
         movieTools.updateMovie(details, tmdbId)

--- a/app/src/main/java/com/battlelancer/seriesguide/movies/MovieLoader.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/movies/MovieLoader.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.movies
 
@@ -24,7 +24,7 @@ internal class MovieLoader(
     override fun loadInBackground(): MovieDetails {
         // try loading from trakt and tmdb, this might return a cached response
         val movieTools = getServicesComponent(context).movieTools()
-        val details = movieTools.getMovieDetails(tmdbId, true)
+        val details = movieTools.getMovieDetailsWithDefaults(tmdbId, true).movieDetails
 
         // Update local database (no-op if movie not in database).
         movieTools.updateMovie(details, tmdbId)

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/SgSyncAdapter.kt
@@ -124,6 +124,8 @@ class SgSyncAdapter(context: Context) : AbstractThreadedSyncAdapter(context, tru
      *
      * - [TmdbSync.updateConfigurationAndWatchProviders]
      * - [ShowSync.sync]
+     * - [TmdbSync.updateMovies]
+     * - [HexagonSync.sync]
      * - [TraktSync.sync]
      *
      * which may throw [InterruptedException].

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/TmdbSync.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/TmdbSync.kt
@@ -87,7 +87,11 @@ class TmdbSync internal constructor(
     /**
      * Regularly updates current and future movies (or those without a release date) with data from
      * themoviedb.org. All other movies are updated rarely.
+     *
+     * Note: this uses [runBlocking], so if the calling thread is interrupted this will throw
+     * [InterruptedException].
      */
+    @Throws(InterruptedException::class)
     fun updateMovies(progress: SyncProgress): Boolean {
         val currentTimeMillis = System.currentTimeMillis()
         // update movies released 6 months ago or newer, should cover most edits
@@ -112,9 +116,9 @@ class TmdbSync internal constructor(
             }
 
             // try loading details from tmdb
-            val detailsResult = movieTools.getMovieDetails(
-                languageCode, regionCode, movie.tmdbId, false
-            )
+            val detailsResult = runBlocking {
+                movieTools.getMovieDetails(languageCode, regionCode, movie.tmdbId, false)
+            }
             val details = detailsResult.movieDetails
             if (details.tmdbMovie() != null) {
                 // update local database

--- a/app/src/main/java/com/battlelancer/seriesguide/sync/TmdbSync.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/sync/TmdbSync.kt
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2018-2020, 2022, 2024 Uwe Trottmann
+// Copyright 2018-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.sync
 
 import android.content.Context
 import android.text.format.DateUtils
+import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.SgApp
 import com.battlelancer.seriesguide.movies.MoviesSettings
 import com.battlelancer.seriesguide.movies.tools.MovieTools
@@ -111,9 +112,10 @@ class TmdbSync internal constructor(
             }
 
             // try loading details from tmdb
-            val details = movieTools.getMovieDetails(
+            val detailsResult = movieTools.getMovieDetails(
                 languageCode, regionCode, movie.tmdbId, false
             )
+            val details = detailsResult.movieDetails
             if (details.tmdbMovie() != null) {
                 // update local database
                 movieTools.updateMovie(details, movie.tmdbId)
@@ -121,12 +123,19 @@ class TmdbSync internal constructor(
                 // Treat as failure if updating at least one fails.
                 result = false
 
-                val movieTitle = SgRoomDatabase.getInstance(context)
-                    .movieHelper()
-                    .getMovieTitle(movie.tmdbId)
-                val message = "Failed to update movie ('${movieTitle}', TMDB id ${movie.tmdbId})."
-                progress.setImportantErrorIfNone(message)
-                Timber.e(message)
+                if (detailsResult.isNotFoundOnTmdb) {
+                    val movieTitle = SgRoomDatabase.getInstance(context)
+                        .movieHelper()
+                        .getMovieTitle(movie.tmdbId)
+                    val notFoundMessage = context.getString(R.string.error_movie_not_found)
+                    // To be replaced with a properly localized message. Currently looks out of
+                    // place for RTL languages, but want to avoid giving translators a string with
+                    // placeholders.
+                    val message = "'${movieTitle}' (TMDB ID ${movie.tmdbId}) - $notFoundMessage"
+
+                    progress.setImportantErrorIfNone(message)
+                    Timber.e(message)
+                }
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/tmdbapi/TmdbTools3.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/tmdbapi/TmdbTools3.kt
@@ -22,6 +22,9 @@ import com.uwetrottmann.tmdb2.enumerations.ExternalSource
 
 /**
  * Uses third-party [Result] API for result handling. Errors are [TmdbError].
+ *
+ * New code should use [TmdbTools4] design patterns. The [Result] API might block future Kotlin
+ * version updates or enforce new patterns.
  */
 object TmdbTools3 {
 

--- a/app/src/main/java/com/battlelancer/seriesguide/tmdbapi/TmdbTools4.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/tmdbapi/TmdbTools4.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.tmdbapi
+
+import com.battlelancer.seriesguide.util.Errors
+import com.uwetrottmann.tmdb2.entities.AppendToResponse
+import com.uwetrottmann.tmdb2.entities.Movie
+import com.uwetrottmann.tmdb2.enumerations.AppendToResponseItem
+import com.uwetrottmann.tmdb2.services.MoviesService
+import retrofit2.Call
+import retrofit2.awaitResponse
+
+/**
+ * Uses response classes inheriting from a Kotlin sealed interface.
+ *
+ * Removes any Android specific classes and no longer relies on a third-party library to handle
+ * results.
+ */
+object TmdbTools4 {
+
+    sealed interface TmdbNonNullResponse<T> {
+        data class Success<T>(val data: T) : TmdbNonNullResponse<T>
+    }
+
+    sealed interface TmdbErrorResponse {
+        class IsNotFound<T> : TmdbNonNullResponse<T>
+        class Other<T> : TmdbNonNullResponse<T>
+    }
+
+    /**
+     * Get movie [MoviesService.summary] from TMDB, optionally [includeReleaseDates].
+     *
+     * Pass a `null` [language] to get the default language (English).
+     *
+     * [action] is used for logging and error reporting.
+     */
+    suspend fun getMovieSummary(
+        tmdbMovies: MoviesService,
+        movieTmdbId: Int,
+        language: String?,
+        includeReleaseDates: Boolean,
+        action: String
+    ): TmdbNonNullResponse<Movie> {
+        return awaitTmdbCall(
+            tmdbMovies.summary(
+                movieTmdbId,
+                language,
+                if (includeReleaseDates)
+                    AppendToResponse(AppendToResponseItem.RELEASE_DATES)
+                else
+                    null
+            ),
+            action
+        )
+    }
+
+    /**
+     * Makes the call and returns [TmdbNonNullResponse.Success] with the body if successful or one
+     * of [TmdbErrorResponse] otherwise.
+     *
+     * If there is an error, logs and reports it.
+     */
+    private suspend fun <T> awaitTmdbCall(
+        call: Call<T>,
+        action: String
+    ): TmdbNonNullResponse<T> {
+        val response = try {
+            call.awaitResponse()
+        } catch (e: Exception) {
+            Errors.logAndReport(action, e)
+            return TmdbErrorResponse.Other()
+        }
+
+        if (!response.isSuccessful) {
+            // Always log and report an error
+            Errors.logAndReport(action, response)
+            return when {
+                response.code() == 404 -> TmdbErrorResponse.IsNotFound()
+                else -> TmdbErrorResponse.Other()
+            }
+        }
+
+        val body = response.body()
+
+        if (body == null) {
+            // Report if there might be a bigger API change
+            Errors.logAndReport(action, response, "body is null")
+            return TmdbErrorResponse.Other()
+        }
+
+        return TmdbNonNullResponse.Success(body)
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/util/AppUpgrade.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/AppUpgrade.kt
@@ -113,6 +113,14 @@ class AppUpgrade(
                 remove("com.battlelancer.seriesguide.listsActiveTab")
             }
         }
+
+        if (lastVersion <= SgApp.RELEASE_VERSION_2025_1_1) {
+            // In this and older versions movies might not have gotten added when signing into Cloud
+            // or Trakt if the TMDB request failed for any reason. As Cloud by default only
+            // downloads recently changed movies, reset its movie sync state so they are all
+            // downloaded again, adding any missing movies to the database.
+            HexagonSettings.resetMovieSyncState(context)
+        }
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/util/AppUpgrade.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/AppUpgrade.kt
@@ -119,7 +119,7 @@ class AppUpgrade(
             // or Trakt if the TMDB request failed for any reason. As Cloud by default only
             // downloads recently changed movies, reset its movie sync state so they are all
             // downloaded again, adding any missing movies to the database.
-            HexagonSettings.resetMovieSyncState(context)
+            HexagonSettings.resetLastMoviesSyncTime(context)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/util/SgPicassoRequestHandler.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/util/SgPicassoRequestHandler.kt
@@ -16,6 +16,7 @@ import com.squareup.picasso.Picasso.LoadedFrom.DISK
 import com.squareup.picasso.Picasso.LoadedFrom.NETWORK
 import com.squareup.picasso.Request
 import com.squareup.picasso.RequestHandler
+import kotlinx.coroutines.runBlocking
 import okhttp3.CacheControl
 import java.io.IOException
 
@@ -61,9 +62,14 @@ class SgPicassoRequestHandler(
         if (SCHEME_MOVIE_TMDB == scheme) {
             val movieTmdbId = host.toInt()
 
-            val posterPath = SgApp.getServicesComponent(context).movieTools()
-                .getMovieSummary(movieTmdbId)
-                ?.poster_path
+            val posterPath: String? = try {
+                runBlocking {
+                    SgApp.getServicesComponent(context).movieTools()
+                        .getMoviePosterPath(movieTmdbId)
+                }
+            } catch (e: InterruptedException) {
+                null // Do nothing
+            }
             if (posterPath != null) {
                 val imageUrl = TmdbSettings.getImageBaseUrl(context) +
                         TmdbSettings.POSTER_SIZE_SPEC_W342 + posterPath

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -312,6 +312,7 @@
     <string name="action_movies_sort_release">تاريخ الإصدار</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">خطأ في الإحصائيات.</string>
     <string name="shows_finished">%s انتهى مشاهدة</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -291,6 +291,7 @@
     <string name="action_movies_sort_release">Datum emitovanja</string>
     <string name="title_similar_movies">Slični filmovi</string>
     <string name="title_release_dates">Datumi emitovanja</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nije moguće izračunati statistiku</string>
     <string name="shows_finished">%s završio gledanje</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Дата на издаване</string>
     <string name="title_similar_movies">Подобни филми</string>
     <string name="title_release_dates">Дати на излизане</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Не може да се изчисли статистиката.</string>
     <string name="shows_finished">%s изгледани и приключени</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Data de llançament</string>
     <string name="title_similar_movies">Pel·lícules similars</string>
     <string name="title_release_dates">Dates de llançament</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">No s\'han pogut calcular les estadístiques.</string>
     <string name="shows_finished">%s acabat de veure</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">Datum vysílání</string>
     <string name="title_similar_movies">Podobné filmy</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nelze přepočítat statistiky.</string>
     <string name="shows_finished">%s dokončených zhlédnutí</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -312,6 +312,7 @@
     <string name="action_movies_sort_release">Dyddiad rhyddhau</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Methu cyfrifo ystadegau</string>
     <string name="shows_finished">%s gorffen gwylio</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Udgivelsesdato</string>
     <string name="title_similar_movies">Lignende film</string>
     <string name="title_release_dates">Udgivelsesdatoer</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Kunne ikke beregne statistik.</string>
     <string name="shows_finished">%s set færdig</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Erscheinungsdatum</string>
     <string name="title_similar_movies">Ähnliche Filme</string>
     <string name="title_release_dates">Veröffentlichungen</string>
+    <string name="error_movie_not_found">Film aus TMDB entfernt. Entferne ihn von Listen und markiere ihn als nicht angesehen. Trakt verbunden? Suche auf deren Website nach der TMDB ID und entfernen ihn aus Verlauf und Listen.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Statistik konnte nicht berechnet werden</string>
     <string name="shows_finished">%s komplett angesehen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Ημερομηνία προβολής</string>
     <string name="title_similar_movies">Παρόμοιες ταινίες</string>
     <string name="title_release_dates">Ημερομηνίες κυκλοφορίας</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Δε μπορέσαμε να υπολογίσουμε στατιστικά.</string>
     <string name="shows_finished">%s τελείωσε την προβολή</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Eldondato</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Ne povas kalkuli statistikaĵojn</string>
     <string name="shows_finished">%s finis spektadi</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Fecha de estreno</string>
     <string name="title_similar_movies">Películas similares</string>
     <string name="title_release_dates">Fechas de lanzamiento</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">No se pudieron calcular las estadísticas.</string>
     <string name="shows_finished">%s vistos completamente</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">تاریخ انتشار</string>
     <string name="title_similar_movies">فیلم‌های مشابه</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">نمی‌توان آمار را محاسبه کرد.</string>
     <string name="shows_finished">%s تماشا پایان یافته</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Julkaisupäivä</string>
     <string name="title_similar_movies">Samankaltaisia elokuvia</string>
     <string name="title_release_dates">Julkaisupäivät</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Tilastojen laskeminen ei onnistunut.</string>
     <string name="shows_finished">%s katsottu loppuun</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Date de parution</string>
     <string name="title_similar_movies">Films similaires</string>
     <string name="title_release_dates">Dates de sortie</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Impossible de calculer les statistiques.</string>
     <string name="shows_finished">%s visionnées en entier</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Data de estrea</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Non se puideron calcular as estatísticas</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -291,6 +291,7 @@
     <string name="action_movies_sort_release">Datum emitiranja</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nije moguće izračunati statistike.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Első adás</string>
     <string name="title_similar_movies">Hasonló filmek</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nem sikerült kiszámítani a statisztikát.</string>
     <string name="shows_finished">%s teljesen megnézve</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">Tanggal rilis</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Tidak dapat menghitung statistik.</string>
     <string name="shows_finished">%s selesai ditonton</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Data di uscita</string>
     <string name="title_similar_movies">Film simili</string>
     <string name="title_release_dates">Date di uscita</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Impossibile calcolare le statistiche</string>
     <string name="shows_finished">%s visti completamente</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">תאריך הפצה</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">לא ניתן לחשב את הסטטיסטיקה.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">発売日</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">統計情報を計算できませんでした。</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">개봉일</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">통계를 계산할 수 없습니다.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Датум на емитување</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Неможе да се пресмета статистика.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Utgivelsesdato</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Kunne ikke beregne statistikk.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Releasedatum</string>
     <string name="title_similar_movies">Vergelijkbare films</string>
     <string name="title_release_dates">Releasedatums</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Kon statistieken niet berekenen.</string>
     <string name="shows_finished">%s klaar met kijken</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">Data premiery</string>
     <string name="title_similar_movies">Podobne filmy</string>
     <string name="title_release_dates">Daty premier</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nie można obliczyć statystyk.</string>
     <string name="shows_finished">Zakończono oglądanie %s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Data de lançamento</string>
     <string name="title_similar_movies">Filmes parecidos</string>
     <string name="title_release_dates">Datas de lançamento</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Não é possível calcular as estatísticas.</string>
     <string name="shows_finished">%s assistido completamente</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Data de estreia</string>
     <string name="title_similar_movies">Filmes semelhantes</string>
     <string name="title_release_dates">Datas de estreia</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Não foi possível calcular as estatísticas.</string>
     <string name="shows_finished">%s vistas completamente</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -291,6 +291,7 @@
     <string name="action_movies_sort_release">Data de lansare</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nu am putut calcula statisticile.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">Дата выпуска</string>
     <string name="title_similar_movies">Похожие фильмы</string>
     <string name="title_release_dates">Даты выпуска</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Не удалось рассчитать статистику.</string>
     <string name="shows_finished">%s завершенных просмотров</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">Dátum premiéry</string>
     <string name="title_similar_movies">Podobné filmy</string>
     <string name="title_release_dates">Dátumy vydania</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nemožno vypočítať štatistiku.</string>
     <string name="shows_finished">%s dopozeraných</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -291,6 +291,7 @@
     <string name="action_movies_sort_release">Датум емитовања</string>
     <string name="title_similar_movies">Слични филмови</string>
     <string name="title_release_dates">Датуми емитовања</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Nije bilo moguće obraditi statistiku</string>
     <string name="shows_finished">%s завршио гледање</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Utgivningsdatum</string>
     <string name="title_similar_movies">Liknande filmer</string>
     <string name="title_release_dates">Premiärdatum</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Gick inte att beräkna statistik.</string>
     <string name="shows_finished">%s färdigtittade</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">வெளியீட்டு தேதி</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">புள்ளிவிவரம் கணக்கிட முடியவில்லை.</string>
     <string name="shows_finished">%s finished watching</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">วันที่ออกฉาย</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">ไม่สามารถคำนวณสถิติ</string>
     <string name="shows_finished">%s ดูจบแล้ว</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -284,6 +284,7 @@
     <string name="action_movies_sort_release">Yayın tarihi</string>
     <string name="title_similar_movies">Benzer filmler</string>
     <string name="title_release_dates">Yayın tarihleri</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">İstatistik hesaplanamadı.</string>
     <string name="shows_finished">%s izlendi</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -298,6 +298,7 @@
     <string name="action_movies_sort_release">Датою виходу</string>
     <string name="title_similar_movies">Схожі фільми</string>
     <string name="title_release_dates">Дати випусків</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">Не вдалося підрахувати статистику</string>
     <string name="shows_finished">%s завершених переглядів</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">按发行日期</string>
     <string name="title_similar_movies">相似电影</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">无法计算统计数据</string>
     <string name="shows_finished">看完了 %s 个节目</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -277,6 +277,7 @@
     <string name="action_movies_sort_release">播出日期</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
     <!-- Statistics -->
     <string name="statistics_failed">無法統計資料。</string>
     <string name="shows_finished">看完了 %s 個節目</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
     <string name="action_movies_sort_release">Release date</string>
     <string name="title_similar_movies">Similar movies</string>
     <string name="title_release_dates">Release dates</string>
+    <string name="error_movie_not_found">Movie removed from TMDB. Remove it from lists, set it not watched. Using Trakt? On their website, search for its TMDB ID and remove it from history and lists.</string>
 
     <!-- Statistics -->
     <string name="statistics_failed">Could not calculate statistics</string>


### PR DESCRIPTION
https://github.com/UweTrottmann/SeriesGuide-Internal/issues/375

- [x] Check that TMDB does not return 404 Not found if there is no translation in a given language.
- [x] Check if interrupted exception of `runBlocking` does not cause issues in calling code.
- [x] Trigger data merge for Cloud on upgrading. Trakt should be fine as always all movies are downloaded and compared with local set.
- [x] Add new string.
- [x] Change to only re-download all movies on app upgrade, do not upload (merge) again