### PR TITLE
Replace debug drawer with custom implementation

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -68,9 +68,6 @@ dagger 2 (https://github.com/google/dagger)
 Copyright 2012 Square, Inc.
 Copyright 2012 Google, Inc.
 
-DebugDrawer (https://github.com/palaima/DebugDrawer)
-Copyright 2016 Mantas Palaima
-
 drag-sort-listview (https://github.com/bauerca/drag-sort-listview)
 Copyright 2012 Carl Bauer
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -257,12 +257,6 @@ dependencies {
         exclude(group = "org.threeten", module = "threetenbp") // using ThreeTenABP instead
     }
 
-    implementation(libs.debugdrawer.base)
-    implementation(libs.debugdrawer.view)
-    implementation(libs.debugdrawer.commons)
-    implementation(libs.debugdrawer.actions)
-    implementation(libs.debugdrawer.timber)
-
     // Note: can not use Firebase BOM as firebase-ui-auth has not updated in a while
     // Crashlytics
     implementation(libs.firebase.crashlytics)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -197,6 +197,7 @@
                 <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
             </intent-filter>
         </activity>
+        <activity android:name=".diagnostics.DebugLogActivity" />
         <activity
             android:name="com.battlelancer.seriesguide.extensions.ExtensionsConfigurationActivity"
             android:exported="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,17 +76,6 @@
             android:exported="true"
             tools:ignore="ExportedContentProvider" />
 
-        <!-- File sharing content provider -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_provider_paths" />
-        </provider>
-
         <!-- Launch activity -->
         <activity
             android:name="com.battlelancer.seriesguide.ui.ShowsActivity"

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2011-2024 Uwe Trottmann
+// Copyright 2011-2025 Uwe Trottmann
 // Copyright 2013 Andrew Neal
 
 package com.battlelancer.seriesguide
@@ -176,6 +176,8 @@ class SgApp : Application() {
             // debug logging
             val debugLogBuffer = DebugLogBuffer.getInstance(this)
             Timber.plant(debugLogBuffer.timberTree())
+        }
+        if (BuildConfig.DEBUG) {
             // detailed logcat logging
             Timber.plant(Timber.DebugTree())
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -174,8 +174,7 @@ class SgApp : Application() {
 
         if (AppSettings.isUserDebugModeEnabled(this)) {
             // debug logging
-            val debugLogBuffer = DebugLogBuffer.getInstance(this)
-            Timber.plant(debugLogBuffer.timberTree())
+            DebugLogBuffer.getInstance(this).enable()
         }
         if (BuildConfig.DEBUG) {
             // detailed logcat logging

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.EventBusException
@@ -176,9 +175,6 @@ class SgApp : Application() {
         if (AppSettings.isUserDebugModeEnabled(this)) {
             // debug logging
             val debugLogBuffer = DebugLogBuffer.getInstance(this)
-            coroutineScope.launch(Dispatchers.IO) {
-                debugLogBuffer.cleanUp()
-            }
             Timber.plant(debugLogBuffer.timberTree())
             // detailed logcat logging
             Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -129,10 +129,12 @@ class SgApp : Application() {
             enableStrictMode()
         }
 
+        // Logging uses time APIs
+        AndroidThreeTen.init(this)
+
         // set up logging first so crashes during initialization are caught
         initializeLogging()
 
-        AndroidThreeTen.init(this)
         initializeEventBus()
         if (AndroidUtils.isAtLeastOreo) {
             initializeNotificationChannels()
@@ -166,20 +168,21 @@ class SgApp : Application() {
     }
 
     private fun initializeLogging() {
+        // Enable logging before any Timber log calls
+        if (BuildConfig.DEBUG) {
+            // logcat logging
+            Timber.plant(Timber.DebugTree())
+        }
+        if (AppSettings.isUserDebugModeEnabled(this)) {
+            // debug log
+            DebugLogBuffer.getInstance(this).enable()
+        }
+
         // Note: Firebase Crashlytics is automatically initialized through its content provider.
         // Pass current enabled state to Crashlytics (e.g. in case app was restored from backup).
         val isSendErrors = AppSettings.isSendErrorReports(this)
-        Timber.d("Turning error reporting %s", if (isSendErrors) "ON" else "OFF")
+        Timber.i("Turning error reporting %s", if (isSendErrors) "ON" else "OFF")
         Errors.getReporter()?.setCrashlyticsCollectionEnabled(isSendErrors)
-
-        if (AppSettings.isUserDebugModeEnabled(this)) {
-            // debug logging
-            DebugLogBuffer.getInstance(this).enable()
-        }
-        if (BuildConfig.DEBUG) {
-            // detailed logcat logging
-            Timber.plant(Timber.DebugTree())
-        }
         // crash and error reporting
         Timber.plant(AnalyticsTree())
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -4,6 +4,7 @@
 
 package com.battlelancer.seriesguide
 
+import android.app.Activity
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -13,7 +14,6 @@ import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import androidx.annotation.RequiresApi
-import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer
 import com.battlelancer.seriesguide.modules.AppModule
 import com.battlelancer.seriesguide.modules.DaggerServicesComponent
 import com.battlelancer.seriesguide.modules.HttpClientModule
@@ -49,6 +49,8 @@ import java.util.concurrent.Executors
  * Initializes logging and services.
  */
 class SgApp : Application() {
+
+    lateinit var appContainer: SgAppContainer
 
     companion object {
 
@@ -132,6 +134,8 @@ class SgApp : Application() {
         // Logging uses time APIs
         AndroidThreeTen.init(this)
 
+        appContainer = SgAppContainer(this)
+
         // set up logging first so crashes during initialization are caught
         initializeLogging()
 
@@ -175,7 +179,7 @@ class SgApp : Application() {
         }
         if (AppSettings.isUserDebugModeEnabled(this)) {
             // debug log
-            DebugLogBuffer.getInstance(this).enable()
+            appContainer.debugLogBuffer.enable()
         }
 
         // Note: Firebase Crashlytics is automatically initialized through its content provider.
@@ -289,4 +293,12 @@ class SgApp : Application() {
             StrictMode.setVmPolicy(build())
         }
     }
+}
+
+fun Application.getSgAppContainer(): SgAppContainer {
+    return (this as SgApp).appContainer
+}
+
+fun Activity.getSgAppContainer(): SgAppContainer {
+    return (application as SgApp).appContainer
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgApp.kt
@@ -13,6 +13,7 @@ import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
 import androidx.annotation.RequiresApi
+import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer
 import com.battlelancer.seriesguide.modules.AppModule
 import com.battlelancer.seriesguide.modules.DaggerServicesComponent
 import com.battlelancer.seriesguide.modules.HttpClientModule
@@ -33,7 +34,6 @@ import com.jakewharton.threetenabp.AndroidThreeTen
 import com.squareup.picasso.OkHttp3Downloader
 import com.squareup.picasso.Picasso
 import com.uwetrottmann.androidutils.AndroidUtils
-import io.palaima.debugdrawer.timber.data.LumberYard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -174,12 +174,12 @@ class SgApp : Application() {
         Errors.getReporter()?.setCrashlyticsCollectionEnabled(isSendErrors)
 
         if (AppSettings.isUserDebugModeEnabled(this)) {
-            // debug drawer logging
-            val lumberYard = LumberYard.getInstance(this)
+            // debug logging
+            val debugLogBuffer = DebugLogBuffer.getInstance(this)
             coroutineScope.launch(Dispatchers.IO) {
-                lumberYard.cleanUp()
+                debugLogBuffer.cleanUp()
             }
-            Timber.plant(lumberYard.tree())
+            Timber.plant(debugLogBuffer.timberTree())
             // detailed logcat logging
             Timber.plant(Timber.DebugTree())
         }

--- a/app/src/main/java/com/battlelancer/seriesguide/SgAppContainer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/SgAppContainer.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide
+
+import android.content.Context
+import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer
+
+class SgAppContainer(context: Context) {
+
+    val debugLogBuffer by lazy { DebugLogBuffer(context) }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
@@ -147,4 +147,8 @@ class DebugLogActivity : BaseThemeActivity() {
         model.updateDebugLogEntries()
     }
 
+    companion object {
+        fun intent(context: Context) = Intent(context, DebugLogActivity::class.java)
+    }
+
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
@@ -3,17 +3,36 @@
 
 package com.battlelancer.seriesguide.diagnostics
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.viewModels
+import androidx.core.view.MenuProvider
+import androidx.core.view.isGone
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.ActivityDebugLogBinding
 import com.battlelancer.seriesguide.ui.BaseThemeActivity
 import com.battlelancer.seriesguide.util.ThemeUtils
+import com.battlelancer.seriesguide.util.tryLaunch
+import kotlinx.coroutines.launch
 
 /**
  * Displays debug log from [DebugLogBuffer], allows to save it to a file.
  */
 class DebugLogActivity : BaseThemeActivity() {
+
+    private val model by viewModels<DebugLogActivityViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,10 +42,17 @@ class DebugLogActivity : BaseThemeActivity() {
         setupActionBar()
 
         initViews(binding)
+
+        addMenuProvider(
+            optionsMenuProvider,
+            this,
+            Lifecycle.State.RESUMED
+        )
     }
 
     override fun setupActionBar() {
         super.setupActionBar()
+        setTitle(R.string.title_debug_log)
         supportActionBar?.apply {
             setHomeAsUpIndicator(R.drawable.ic_clear_24dp)
             setDisplayHomeAsUpEnabled(true)
@@ -34,13 +60,91 @@ class DebugLogActivity : BaseThemeActivity() {
     }
 
     private fun initViews(binding: ActivityDebugLogBinding) {
-        ThemeUtils.applyBottomPaddingForNavigationBar(binding.recyclerViewDebugLogs)
+        ThemeUtils.applyBottomPaddingForNavigationBar(binding.recyclerViewDebugLog)
 
         val adapter = DebugLogAdapter()
-        binding.recyclerViewDebugLogs.adapter = adapter
-        binding.recyclerViewDebugLogs.layoutManager = LinearLayoutManager(this)
+        binding.recyclerViewDebugLog.adapter = adapter
+        binding.recyclerViewDebugLog.layoutManager = LinearLayoutManager(this)
 
-        adapter.setData(DebugLogBuffer.getInstance(this).bufferedLogs())
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                model.logEntries.collect {
+                    adapter.setData(it)
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                model.uiState.collect {
+                    binding.frameLayoutDebugLogProgress.isGone = !it.isSaving
+                    if (it.userMessage != null) {
+                        Toast.makeText(this@DebugLogActivity, it.userMessage, Toast.LENGTH_SHORT)
+                            .show()
+                        model.userMessageShown()
+                        // In case saving the file failed, the debug log may contain the error
+                        // information, so refresh the display
+                        model.updateDebugLogEntries()
+                    }
+                }
+            }
+        }
+    }
+
+    private val optionsMenuProvider = object : MenuProvider {
+        override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            menuInflater.inflate(R.menu.debug_log_menu, menu)
+        }
+
+        override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+            when (menuItem.itemId) {
+                R.id.menu_action_debug_log_save -> {
+                    createDebugLogFile()
+                    return true
+                }
+
+                else -> return false
+            }
+        }
+    }
+
+    fun createDebugLogFile() {
+        // Note: instead of saving the file in internal app storage and sharing it, let the user
+        // save the file and decide how to send it (via email, forum, ...).
+        createDebugFileCallback.tryLaunch(DebugLogBuffer.getInstance(this).logFileName, this)
+    }
+
+    /**
+     * Input is used as suggested file name.
+     */
+    class CreateDebugLogFileContract : ActivityResultContract<String, Uri?>() {
+        override fun createIntent(context: Context, input: String): Intent {
+            return Intent(Intent.ACTION_CREATE_DOCUMENT)
+                // Filter to only show results that can be "opened", such as
+                // a file (as opposed to a list of contacts or timezones).
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("text/plain")
+                .putExtra(Intent.EXTRA_TITLE, input)
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+            if (resultCode != Activity.RESULT_OK) {
+                return null
+            }
+            return intent?.data
+        }
+    }
+
+    private val createDebugFileCallback =
+        registerForActivityResult(CreateDebugLogFileContract()) { uri ->
+            if (uri != null) {
+                model.saveDebugLogToFile(uri)
+            }
+        }
+
+    override fun onResume() {
+        super.onResume()
+        model.updateDebugLogEntries()
     }
 
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.diagnostics
+
+import android.os.Bundle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.databinding.ActivityDebugLogBinding
+import com.battlelancer.seriesguide.ui.BaseThemeActivity
+import com.battlelancer.seriesguide.util.ThemeUtils
+
+/**
+ * Displays debug log from [DebugLogBuffer], allows to save it to a file.
+ */
+class DebugLogActivity : BaseThemeActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val binding = ActivityDebugLogBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ThemeUtils.configureForEdgeToEdge(binding.root)
+        setupActionBar()
+
+        initViews(binding)
+    }
+
+    override fun setupActionBar() {
+        super.setupActionBar()
+        supportActionBar?.apply {
+            setHomeAsUpIndicator(R.drawable.ic_clear_24dp)
+            setDisplayHomeAsUpEnabled(true)
+        }
+    }
+
+    private fun initViews(binding: ActivityDebugLogBinding) {
+        ThemeUtils.applyBottomPaddingForNavigationBar(binding.recyclerViewDebugLogs)
+
+        val adapter = DebugLogAdapter()
+        binding.recyclerViewDebugLogs.adapter = adapter
+        binding.recyclerViewDebugLogs.layoutManager = LinearLayoutManager(this)
+
+        adapter.setData(DebugLogBuffer.getInstance(this).bufferedLogs())
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivity.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.databinding.ActivityDebugLogBinding
+import com.battlelancer.seriesguide.getSgAppContainer
 import com.battlelancer.seriesguide.ui.BaseThemeActivity
 import com.battlelancer.seriesguide.util.ThemeUtils
 import com.battlelancer.seriesguide.util.tryLaunch
@@ -111,7 +112,7 @@ class DebugLogActivity : BaseThemeActivity() {
     fun createDebugLogFile() {
         // Note: instead of saving the file in internal app storage and sharing it, let the user
         // save the file and decide how to send it (via email, forum, ...).
-        createDebugFileCallback.tryLaunch(DebugLogBuffer.getInstance(this).logFileName, this)
+        createDebugFileCallback.tryLaunch(getSgAppContainer().debugLogBuffer.logFileName, this)
     }
 
     /**

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivityViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivityViewModel.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.diagnostics
+
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.battlelancer.seriesguide.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class DebugLogActivityViewModel(application: Application) : AndroidViewModel(application) {
+
+    data class DebugLogUiState(
+        val isSaving: Boolean = false,
+        val userMessage: String? = null
+    )
+
+    val uiState = MutableStateFlow(DebugLogUiState())
+    val logEntries = MutableStateFlow(emptyList<DebugLogEntry>())
+
+    fun updateDebugLogEntries() {
+        viewModelScope.launch(Dispatchers.Default) {
+            logEntries.value = DebugLogBuffer.getInstance(getApplication()).logBufferSnapshot()
+        }
+    }
+
+    fun userMessageShown() {
+        uiState.update {
+            it.copy(userMessage = null)
+        }
+    }
+
+    fun saveDebugLogToFile(uri: Uri) {
+        uiState.update {
+            it.copy(isSaving = true)
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            DebugLogBuffer.getInstance(getApplication())
+                .save(uri, object : DebugLogBuffer.OnSaveLogListener {
+                    override fun onSuccess() {
+                        uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                userMessage = getApplication<Application>().getString(R.string.status_saving_file_success)
+                            )
+                        }
+                    }
+
+                    override fun onError() {
+                        uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                userMessage = getApplication<Application>().getString(R.string.status_saving_file_failed)
+                            )
+                        }
+                    }
+                })
+        }
+    }
+
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivityViewModel.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogActivityViewModel.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.SgApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -23,9 +24,11 @@ class DebugLogActivityViewModel(application: Application) : AndroidViewModel(app
     val uiState = MutableStateFlow(DebugLogUiState())
     val logEntries = MutableStateFlow(emptyList<DebugLogEntry>())
 
+    private val debugLogBuffer = getApplication<SgApp>().appContainer.debugLogBuffer
+
     fun updateDebugLogEntries() {
         viewModelScope.launch(Dispatchers.Default) {
-            logEntries.value = DebugLogBuffer.getInstance(getApplication()).logBufferSnapshot()
+            logEntries.value = debugLogBuffer.logBufferSnapshot()
         }
     }
 
@@ -41,7 +44,7 @@ class DebugLogActivityViewModel(application: Application) : AndroidViewModel(app
         }
 
         viewModelScope.launch(Dispatchers.IO) {
-            DebugLogBuffer.getInstance(getApplication())
+            debugLogBuffer
                 .save(uri, object : DebugLogBuffer.OnSaveLogListener {
                     override fun onSuccess() {
                         uiState.update {

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogAdapter.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogAdapter.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.diagnostics
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.ColorRes
+import androidx.recyclerview.widget.RecyclerView
+import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.databinding.ItemDebugLogBinding
+
+/**
+ * Displays a list of [DebugLogEntry].
+ */
+class DebugLogAdapter : RecyclerView.Adapter<DebugLogViewHolder>() {
+
+    private val debugLogEntries = mutableListOf<DebugLogEntry>()
+
+    override fun getItemCount(): Int = debugLogEntries.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DebugLogViewHolder {
+        return DebugLogViewHolder.inflate(parent)
+    }
+
+    override fun onBindViewHolder(holder: DebugLogViewHolder, position: Int) {
+        val item = debugLogEntries.getOrNull(position)
+        holder.bindTo(item)
+    }
+
+    @SuppressLint("NotifyDataSetChanged") // Don't care about individual item change tracking
+    fun setData(items: List<DebugLogEntry>) {
+        debugLogEntries.clear()
+        debugLogEntries.addAll(items)
+        notifyDataSetChanged()
+    }
+
+}
+
+class DebugLogViewHolder(
+    private val binding: ItemDebugLogBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bindTo(entry: DebugLogEntry?) {
+        if (entry == null) {
+            binding.textViewItemDebugLogLevel.text = ""
+            binding.textViewItemDebugLogTag.text = ""
+            binding.textViewItemDebugLogMessage.text = ""
+        } else {
+            binding.textViewItemDebugLogLevel.apply {
+                setBackgroundResource(backgroundForLevel(entry.level))
+                text = entry.displayLevel()
+            }
+            binding.textViewItemDebugLogTag.text =
+                String.format("%s %s", entry.timeStamp, entry.tag)
+            binding.textViewItemDebugLogMessage.text = entry.message
+        }
+    }
+
+    @ColorRes
+    private fun backgroundForLevel(level: Int): Int {
+        return when (level) {
+            Log.VERBOSE, Log.DEBUG -> R.color.sg_debuglog_debug
+            Log.INFO -> R.color.sg_debuglog_info
+            Log.WARN -> R.color.sg_debuglog_warn
+            Log.ERROR, Log.ASSERT -> R.color.sg_debuglog_error
+            else -> R.color.sg_debuglog_unknown
+        }
+    }
+
+    companion object {
+        fun inflate(parent: ViewGroup) =
+            DebugLogViewHolder(
+                ItemDebugLogBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+    }
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
@@ -32,20 +32,36 @@ class DebugLogBuffer(context: Context) {
         BUFFER_SIZE + 1
     )
 
-    fun timberTree(): Timber.Tree {
-        return object : DebugTree() {
-            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-                addEntry(
-                    DebugLogEntry(
-                        priority,
-                        tag,
-                        message,
-                        Instant.now()
-                            .atZone(TimeTools.safeSystemDefaultZoneId())
-                            .format(LOG_DATE_PATTERN)
-                    )
+    private val timberTree = object : DebugTree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            addEntry(
+                DebugLogEntry(
+                    priority,
+                    tag,
+                    message,
+                    Instant.now()
+                        .atZone(TimeTools.safeSystemDefaultZoneId())
+                        .format(LOG_DATE_PATTERN)
                 )
-            }
+            )
+        }
+    }
+
+    /**
+     * Plants this [timberTree].
+     */
+    fun enable() {
+        if (!Timber.forest().contains(timberTree)) {
+            Timber.plant(timberTree)
+        }
+    }
+
+    /**
+     * Uproots this [timberTree].
+     */
+    fun disable() {
+        if (Timber.forest().contains(timberTree)) {
+            Timber.uproot(timberTree)
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
@@ -3,7 +3,6 @@
 
 package com.battlelancer.seriesguide.diagnostics
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.os.Build
@@ -164,16 +163,5 @@ class DebugLogBuffer(context: Context) {
         // When using the 'text/plain' MIME type, the Android Storage Access Framework appends the
         // '.txt' file extension regardless of which one is used, so use '.txt'.
         private const val LOG_FILE_END = ".txt"
-
-        @SuppressLint("StaticFieldLeak") // Using application context
-        private var sInstance: DebugLogBuffer? = null
-
-        fun getInstance(context: Context): DebugLogBuffer {
-            if (sInstance == null) {
-                sInstance = DebugLogBuffer(context)
-            }
-
-            return sInstance!!
-        }
     }
 }

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogBuffer.kt
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.diagnostics
+
+import android.annotation.SuppressLint
+import android.content.Context
+import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer.Companion.BUFFER_SIZE
+import timber.log.Timber
+import timber.log.Timber.DebugTree
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.ArrayDeque
+import java.util.Calendar
+import java.util.Deque
+import java.util.Locale
+
+/**
+ * Keeps any log sent through [Timber] up to [BUFFER_SIZE] in memory.
+ */
+class DebugLogBuffer(context: Context) {
+
+    private val context: Context = context.applicationContext
+
+    private val entries: Deque<DebugLogEntry> = ArrayDeque(
+        BUFFER_SIZE + 1
+    )
+
+    private var onLogListener: OnLogListener? = null
+
+    fun timberTree(): Timber.Tree {
+        return object : DebugTree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                addEntry(
+                    DebugLogEntry(
+                        priority,
+                        tag,
+                        message,
+                        LOG_DATE_PATTERN.format(Calendar.getInstance().time)
+                    )
+                )
+            }
+        }
+    }
+
+    fun setOnLogListener(onLogListener: OnLogListener?) {
+        this.onLogListener = onLogListener
+    }
+
+    @Synchronized
+    private fun addEntry(entry: DebugLogEntry) {
+        entries.addLast(entry)
+
+        if (entries.size > BUFFER_SIZE) {
+            entries.removeFirst()
+        }
+
+        onLog(entry)
+    }
+
+    fun bufferedLogs(): List<DebugLogEntry> {
+        return ArrayList(entries)
+    }
+
+    /**
+     * Save the current logs to disk.
+     */
+    fun save(listener: OnSaveLogListener) {
+        val dir = logDir
+
+        if (dir == null) {
+            listener.onError(
+                "Can't save logs. External storage is not mounted. " +
+                        "Check android.permission.WRITE_EXTERNAL_STORAGE permission"
+            )
+            return
+        }
+
+        var fileWriter: FileWriter? = null
+
+        try {
+            val output = File(dir, logFileName)
+            fileWriter = FileWriter(output, true)
+
+            val entries = bufferedLogs()
+            for (entry in entries) {
+                fileWriter.write(entry.prettyPrint() + "\n")
+            }
+
+            listener.onSave(output)
+        } catch (e: IOException) {
+            listener.onError(e.message)
+            e.printStackTrace()
+        } finally {
+            if (fileWriter != null) {
+                try {
+                    fileWriter.close()
+                } catch (e: IOException) {
+                    listener.onError(e.message)
+                    e.printStackTrace()
+                }
+            }
+        }
+    }
+
+    // TODO
+    fun cleanUp() {
+        val dir = logDir
+        if (dir != null) {
+            val files = dir.listFiles()
+            if (files != null) {
+                for (file in files) {
+                    if (file.name.endsWith(LOG_FILE_END)) {
+                        file.delete()
+                    }
+                }
+            }
+        }
+    }
+
+    private val logDir: File?
+        get() = context.getExternalFilesDir(null)
+
+    private fun onLog(entry: DebugLogEntry) {
+        if (onLogListener != null) {
+            onLogListener!!.onLog(entry)
+        }
+    }
+
+    private val logFileName: String
+        get() {
+            val pattern = "%s%s"
+            val currentDate = FILENAME_DATE.format(Calendar.getInstance().time)
+
+            return String.format(pattern, currentDate, LOG_FILE_END)
+        }
+
+    interface OnSaveLogListener {
+        fun onSave(file: File?)
+
+        fun onError(message: String?)
+    }
+
+    interface OnLogListener {
+        fun onLog(logEntry: DebugLogEntry?)
+    }
+
+    companion object {
+
+        private const val BUFFER_SIZE = 200
+
+        private val FILENAME_DATE: DateFormat = SimpleDateFormat("yyyy-MM-dd HHmm a", Locale.US)
+        private val LOG_DATE_PATTERN: DateFormat = SimpleDateFormat("MM-dd HH:mm:ss.S", Locale.US)
+
+        private const val LOG_FILE_END = ".log"
+
+        @SuppressLint("StaticFieldLeak") // Using application context
+        private var sInstance: DebugLogBuffer? = null
+
+        fun getInstance(context: Context): DebugLogBuffer {
+            if (sInstance == null) {
+                sInstance = DebugLogBuffer(context)
+            }
+
+            return sInstance!!
+        }
+    }
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogEntry.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogEntry.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Uwe Trottmann
+
+package com.battlelancer.seriesguide.diagnostics
+
+import android.util.Log
+
+class DebugLogEntry(
+    val level: Int,
+    val tag: String?,
+    val message: String,
+    val timeStamp: String
+) {
+    fun prettyPrint(): String {
+        return String.format("%18s %18s %s %s", timeStamp, tag, displayLevel(), message)
+    }
+
+    private fun displayLevel(): String {
+        return when (level) {
+            Log.VERBOSE -> "V"
+            Log.DEBUG -> "D"
+            Log.INFO -> "I"
+            Log.WARN -> "W"
+            Log.ERROR -> "E"
+            Log.ASSERT -> "A"
+            else -> "?"
+        }
+    }
+}

--- a/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogEntry.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/diagnostics/DebugLogEntry.kt
@@ -15,7 +15,7 @@ class DebugLogEntry(
         return String.format("%18s %18s %s %s", timeStamp, tag, displayLevel(), message)
     }
 
-    private fun displayLevel(): String {
+    fun displayLevel(): String {
         return when (level) {
             Log.VERBOSE -> "V"
             Log.DEBUG -> "D"

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
@@ -5,12 +5,14 @@ package com.battlelancer.seriesguide.preferences
 
 
 import android.app.Dialog
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.battlelancer.seriesguide.databinding.FragmentDebugViewBinding
+import com.battlelancer.seriesguide.diagnostics.DebugLogActivity
 import com.battlelancer.seriesguide.notifications.NotificationService
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.settings.AppSettings
@@ -31,7 +33,7 @@ class DebugViewFragment : AppCompatDialogFragment() {
         val binding = FragmentDebugViewBinding.inflate(layoutInflater)
 
         binding.buttonDebugViewDisplayLogs.setOnClickListener {
-            // TODO
+            startActivity(Intent(requireContext(), DebugLogActivity::class.java))
         }
 
         binding.buttonDebugViewTestNotification1.setOnClickListener {

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
@@ -1,19 +1,16 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2019-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.preferences
 
 
+import android.app.Dialog
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDialogFragment
-import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.sqlite.db.SimpleSQLiteQuery
-import com.battlelancer.seriesguide.R
+import com.battlelancer.seriesguide.databinding.FragmentDebugViewBinding
 import com.battlelancer.seriesguide.notifications.NotificationService
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.settings.AppSettings
@@ -21,53 +18,39 @@ import com.battlelancer.seriesguide.shows.database.SgEpisode2WithShow
 import com.battlelancer.seriesguide.sync.SgSyncAdapter
 import com.battlelancer.seriesguide.traktapi.TraktCredentials
 import com.battlelancer.seriesguide.traktapi.TraktOAuthSettings
-import io.palaima.debugdrawer.actions.ActionsModule
-import io.palaima.debugdrawer.actions.ButtonAction
-import io.palaima.debugdrawer.commons.DeviceModule
-import io.palaima.debugdrawer.timber.TimberModule
-import io.palaima.debugdrawer.view.DebugView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
- * Displays a [DebugView]. Notably allows to display and share logs.
+ * Displays debug actions. Notably allows to display and share logs.
  */
 class DebugViewFragment : AppCompatDialogFragment() {
 
-    private lateinit var debugView: DebugView
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val binding = FragmentDebugViewBinding.inflate(layoutInflater)
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        // LogAdapter is hard-coded to white background, so always use a light theme.
-        setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Theme_SeriesGuide_Light)
-    }
+        binding.buttonDebugViewDisplayLogs.setOnClickListener {
+            // TODO
+        }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val view = inflater.inflate(R.layout.fragment_debug_view, container, false)
-
-        debugView = view.findViewById(R.id.debugView)
-        debugView.background = null // for whatever reason uses windowBackground by default
-
-        val showTestNotification1 = ButtonAction("Show test notification (1)") {
+        binding.buttonDebugViewTestNotification1.setOnClickListener {
             showTestNotification(1)
         }
 
-        val showTestNotification3 = ButtonAction("Show test notification (3)") {
+        binding.buttonDebugViewTestNotification3.setOnClickListener {
             showTestNotification(3)
         }
 
-        val buttonClearTraktRefreshToken = ButtonAction("Clear trakt refresh token") {
+        binding.buttonDebugViewTraktClearRefreshToken.setOnClickListener {
             TraktOAuthSettings.storeRefreshData(requireContext(), "", 3600 /* 1 hour */)
         }
 
-        val buttonInvalidateTraktAccessToken = ButtonAction("Invalidate trakt access token") {
+        binding.buttonDebugViewTraktInvalidateAccessToken.setOnClickListener {
             TraktCredentials.get(requireContext()).storeAccessToken("invalid-token")
         }
 
-        val buttonInvalidateTraktRefreshToken = ButtonAction("Invalidate trakt refresh token") {
+        binding.buttonDebugViewTraktInvalidateRefreshToken.setOnClickListener {
             TraktOAuthSettings.storeRefreshData(
                 requireContext(),
                 "invalid-token",
@@ -75,43 +58,21 @@ class DebugViewFragment : AppCompatDialogFragment() {
             )
         }
 
-        val buttonTriggerJobProcessor = ButtonAction("Schedule job processing") {
+        binding.buttonDebugViewTriggerJobProcessing.setOnClickListener {
             SgSyncAdapter.requestSyncJobsImmediate(requireContext())
         }
 
-        val buttonDemoMode = ButtonAction("Toggle demo mode") {
+        binding.buttonDebugViewDemoMode.setOnClickListener {
             toggleDemoMode()
         }
 
-        debugView.modules(
-            ActionsModule(
-                "Notifications",
-                showTestNotification1,
-                showTestNotification3
-            ),
-            ActionsModule(
-                "Trakt",
-                buttonClearTraktRefreshToken,
-                buttonInvalidateTraktAccessToken,
-                buttonInvalidateTraktRefreshToken
-            ),
-            ActionsModule(
-                "Jobs",
-                buttonTriggerJobProcessor
-            ),
-            ActionsModule(
-                "Demo mode",
-                buttonDemoMode
-            ),
-            TimberModule("${requireContext().packageName}.fileprovider"),
-            DeviceModule()
-        )
-
-        return view
+        return MaterialAlertDialogBuilder(requireContext())
+            .setView(binding.getRoot())
+            .create()
     }
 
     private fun showTestNotification(episodeCount: Int) {
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.IO) {
             // To use different episodes for one vs. multiple just use OFFSET
             val query = ("${SgEpisode2WithShow.SELECT} LIMIT $episodeCount OFFSET $episodeCount")
             val episodes = SgRoomDatabase.getInstance(requireContext()).sgEpisode2Helper()

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/DebugViewFragment.kt
@@ -5,7 +5,6 @@ package com.battlelancer.seriesguide.preferences
 
 
 import android.app.Dialog
-import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatDialogFragment
@@ -33,7 +32,7 @@ class DebugViewFragment : AppCompatDialogFragment() {
         val binding = FragmentDebugViewBinding.inflate(layoutInflater)
 
         binding.buttonDebugViewDisplayLogs.setOnClickListener {
-            startActivity(Intent(requireContext(), DebugLogActivity::class.java))
+            startActivity(DebugLogActivity.intent(requireContext()))
         }
 
         binding.buttonDebugViewTestNotification1.setOnClickListener {

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/MoreOptionsActivity.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/MoreOptionsActivity.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2020-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.preferences
 
@@ -11,10 +11,12 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isGone
+import com.battlelancer.seriesguide.BuildConfig
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.backend.CloudSetupActivity
 import com.battlelancer.seriesguide.backend.settings.HexagonSettings
 import com.battlelancer.seriesguide.databinding.ActivityMoreOptionsBinding
+import com.battlelancer.seriesguide.diagnostics.DebugLogActivity
 import com.battlelancer.seriesguide.settings.AppSettings
 import com.battlelancer.seriesguide.sync.SyncProgress
 import com.battlelancer.seriesguide.traktapi.ConnectTraktActivity
@@ -81,10 +83,14 @@ class MoreOptionsActivity : BaseTopActivity() {
             startActivity(getFeedbackEmailIntent(this))
         }
         ViewTools.openUriOnClick(binding.buttonTranslations, getString(R.string.url_translations))
-        binding.buttonDebugView.setOnClickListener {
-            if (AppSettings.isUserDebugModeEnabled(this)) {
+        binding.buttonDebugLog.setOnClickListener {
+            startActivity(DebugLogActivity.intent(this))
+        }
+        binding.buttonDebugView.apply {
+            setOnClickListener {
                 DebugViewFragment().safeShow(supportFragmentManager, "debugViewDialog")
             }
+            isGone = !BuildConfig.DEBUG
         }
         binding.buttonMoreWhatsNew.setOnClickListener {
             WebTools.openInApp(this, getString(R.string.url_release_notes))
@@ -118,8 +124,8 @@ class MoreOptionsActivity : BaseTopActivity() {
         // Update supporter status.
         binding.textViewThankYouSupporters.isGone = !Utils.hasAccessToX(this)
 
-        // Show debug view button if debug mode is on.
-        binding.buttonDebugView.isGone = !AppSettings.isUserDebugModeEnabled(this)
+        // Show debug log button if debug mode is on.
+        binding.buttonDebugLog.isGone = !AppSettings.isUserDebugModeEnabled(this)
     }
 
 

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.os.Vibrator
 import android.provider.Settings
 import android.text.TextUtils
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.edit
@@ -26,6 +25,7 @@ import com.battlelancer.seriesguide.BuildConfig
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.appwidget.ListWidgetProvider
 import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity
+import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer
 import com.battlelancer.seriesguide.notifications.NotificationService
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.settings.AppSettings
@@ -372,12 +372,6 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             Utils.tryStartActivityForResult(this, intent, REQUEST_CODE_RINGTONE)
             return true
         }
-        if (AppSettings.KEY_USER_DEBUG_MODE_ENBALED == key) {
-            Toast.makeText(
-                context, R.string.pref_user_debug_mode_note, Toast.LENGTH_LONG
-            ).show()
-            return false // Let the pref handle the click (and change its value).
-        }
         return super.onPreferenceTreeClick(preference)
     }
 
@@ -452,6 +446,17 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             if (AppSettings.KEY_SEND_ERROR_REPORTS == key) {
                 val switchPref = pref as SwitchPreferenceCompat
                 AppSettings.setSendErrorReports(switchPref.context, switchPref.isChecked, false)
+            }
+
+            // Enable or disable debug log
+            if (AppSettings.KEY_USER_DEBUG_MODE_ENBALED == key) {
+                val switchPref = pref as SwitchPreferenceCompat
+                val debugLogBuffer = DebugLogBuffer.getInstance(requireContext())
+                if (switchPref.isChecked) {
+                    debugLogBuffer.enable()
+                } else {
+                    debugLogBuffer.disable()
+                }
             }
         }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
@@ -25,7 +25,7 @@ import com.battlelancer.seriesguide.BuildConfig
 import com.battlelancer.seriesguide.R
 import com.battlelancer.seriesguide.appwidget.ListWidgetProvider
 import com.battlelancer.seriesguide.dataliberation.DataLiberationActivity
-import com.battlelancer.seriesguide.diagnostics.DebugLogBuffer
+import com.battlelancer.seriesguide.getSgAppContainer
 import com.battlelancer.seriesguide.notifications.NotificationService
 import com.battlelancer.seriesguide.provider.SgRoomDatabase
 import com.battlelancer.seriesguide.settings.AppSettings
@@ -451,7 +451,7 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             // Enable or disable debug log
             if (AppSettings.KEY_USER_DEBUG_MODE_ENBALED == key) {
                 val switchPref = pref as SwitchPreferenceCompat
-                val debugLogBuffer = DebugLogBuffer.getInstance(requireContext())
+                val debugLogBuffer = requireActivity().getSgAppContainer().debugLogBuffer
                 if (switchPref.isChecked) {
                     debugLogBuffer.enable()
                 } else {

--- a/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/preferences/SgPreferencesFragment.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2019-2024 Uwe Trottmann
+// Copyright 2019-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.preferences
 
@@ -60,10 +60,12 @@ class SgPreferencesFragment : BasePreferencesFragment(),
                 setPreferencesFromResource(R.xml.settings_root, rootKey)
                 setupRootSettings()
             }
+
             KEY_SCREEN_BASIC -> {
                 setPreferencesFromResource(R.xml.settings_basic, rootKey)
                 setupBasicSettings()
             }
+
             KEY_SCREEN_NOTIFICATIONS -> {
                 setPreferencesFromResource(R.xml.settings_notifications, rootKey)
                 setupNotificationSettings()
@@ -317,6 +319,7 @@ class SgPreferencesFragment : BasePreferencesFragment(),
                 startActivity(DataLiberationActivity.intentToShowAutoBackup(requireActivity()))
                 return true
             }
+
             LINK_KEY_DATALIBERATION -> {
                 startActivity(Intent(activity, DataLiberationActivity::class.java))
                 return true
@@ -408,6 +411,7 @@ class SgPreferencesFragment : BasePreferencesFragment(),
         if (key == null) {
             return // Preferences were cleared, do nothing.
         }
+
         val pref: Preference? = findPreference(key)
         if (pref != null) {
             BackupManager(pref.context).dataChanged()
@@ -426,15 +430,28 @@ class SgPreferencesFragment : BasePreferencesFragment(),
             if (NotificationSettings.KEY_THRESHOLD == key) {
                 updateThresholdSummary(pref)
             }
+            if (StreamingSearch.KEY_SETTING_REGION == key) {
+                updateStreamSearchServiceSummary(pref)
+            }
+
+            // Demonstrate vibration pattern used by SeriesGuide
             if (NotificationSettings.KEY_VIBRATE == key
                 && NotificationSettings.isNotificationVibrating(pref.context)) {
-                // demonstrate vibration pattern used by SeriesGuide
                 val vibrator = requireActivity().getSystemService<Vibrator>()
                 @Suppress("DEPRECATION") // Not visible on O+, no need to use new API.
                 vibrator?.vibrate(NotificationService.VIBRATION_PATTERN, -1)
             }
-            if (StreamingSearch.KEY_SETTING_REGION == key) {
-                updateStreamSearchServiceSummary(pref)
+
+            // Toggle auto-update on SyncAdapter
+            if (UpdateSettings.KEY_AUTOUPDATE == key) {
+                val autoUpdatePref = pref as SwitchPreferenceCompat
+                SgSyncAdapter.setSyncAutomatically(requireContext(), autoUpdatePref.isChecked)
+            }
+
+            // Change error reports setting
+            if (AppSettings.KEY_SEND_ERROR_REPORTS == key) {
+                val switchPref = pref as SwitchPreferenceCompat
+                AppSettings.setSendErrorReports(switchPref.context, switchPref.isChecked, false)
             }
         }
 
@@ -461,21 +478,6 @@ class SgPreferencesFragment : BasePreferencesFragment(),
                 SgRoomDatabase.getInstance(requireContext()).sgEpisode2Helper()
                     .resetLastUpdatedForAll()
             }.start()
-        }
-
-        // Toggle auto-update on SyncAdapter
-        if (UpdateSettings.KEY_AUTOUPDATE == key) {
-            if (pref != null) {
-                val autoUpdatePref = pref as SwitchPreferenceCompat
-                SgSyncAdapter.setSyncAutomatically(requireContext(), autoUpdatePref.isChecked)
-            }
-        }
-
-        if (AppSettings.KEY_SEND_ERROR_REPORTS == key) {
-            pref?.also {
-                val switchPref = pref as SwitchPreferenceCompat
-                AppSettings.setSendErrorReports(switchPref.context, switchPref.isChecked, false)
-            }
         }
     }
 

--- a/app/src/main/java/com/battlelancer/seriesguide/settings/AppSettings.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/settings/AppSettings.kt
@@ -1,5 +1,5 @@
-// Copyright 2023 Uwe Trottmann
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2013-2025 Uwe Trottmann
 
 package com.battlelancer.seriesguide.settings
 
@@ -88,8 +88,8 @@ object AppSettings {
     }
 
     /**
-     * Returns if user-visible debug components should be enabled
-     * (e.g. logging to logcat, debug views). Always true for debug builds.
+     * Returns if debug components for users, which might have a performance impact, should be
+     * enabled (for ex. debug log). Always true for debug builds.
      */
     fun isUserDebugModeEnabled(context: Context): Boolean {
         return BuildConfig.DEBUG || PreferenceManager.getDefaultSharedPreferences(context)

--- a/app/src/main/res/layout/activity_debug_log.xml
+++ b/app/src/main/res/layout/activity_debug_log.xml
@@ -19,7 +19,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerViewDebugLogs"
+            android:id="@+id/recyclerViewDebugLog"
             style="@style/Widget.SeriesGuide.RecyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -29,6 +29,21 @@
             android:paddingEnd="@dimen/grid_item_margin_horizontal"
             android:paddingBottom="@dimen/default_padding"
             tools:listitem="@layout/item_debug_log" />
+
+        <FrameLayout
+            android:id="@+id/frameLayoutDebugLogProgress"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/sgColorBackgroundDim">
+
+            <ProgressBar
+                android:id="@+id/progressBarDebugLog"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+
+        </FrameLayout>
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/activity_debug_log.xml
+++ b/app/src/main/res/layout/activity_debug_log.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2025 Uwe Trottmann -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootLayoutDebugLog"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/top_app_bar_elevating" />
+
+    <FrameLayout
+        android:id="@+id/containerDebugLogScrolling"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewDebugLogs"
+            style="@style/Widget.SeriesGuide.RecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingStart="@dimen/grid_item_margin_horizontal"
+            android:paddingTop="@dimen/default_padding"
+            android:paddingEnd="@dimen/grid_item_margin_horizontal"
+            android:paddingBottom="@dimen/default_padding"
+            tools:listitem="@layout/item_debug_log" />
+
+    </FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_more_options.xml
+++ b/app/src/main/res/layout/activity_more_options.xml
@@ -196,6 +196,18 @@
                     app:layout_constraintTop_toBottomOf="@+id/buttonFeedback" />
 
                 <Button
+                    android:id="@+id/buttonDebugLog"
+                    style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:text="@string/title_debug_log"
+                    app:icon="@drawable/ic_extension_black_24dp"
+                    app:iconGravity="start"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/buttonTranslations" />
+
+                <Button
                     android:id="@+id/buttonDebugView"
                     style="@style/Widget.SeriesGuide.Button.Borderless.Sheet"
                     android:layout_width="0dp"
@@ -205,7 +217,7 @@
                     app:iconGravity="start"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/buttonTranslations" />
+                    app:layout_constraintTop_toBottomOf="@+id/buttonDebugLog" />
 
                 <Button
                     android:id="@+id/buttonMoreWhatsNew"

--- a/app/src/main/res/layout/fragment_debug_view.xml
+++ b/app/src/main/res/layout/fragment_debug_view.xml
@@ -1,12 +1,115 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2016-2025 Uwe Trottmann -->
+
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scrollViewDebugView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/colorSurface">
+    tools:ignore="HardcodedText">
 
-    <io.palaima.debugdrawer.view.DebugView
-        android:id="@+id/debugView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayoutDebugView"
+        style="@style/Page.Centered"
+        android:layout_height="wrap_content">
 
+        <Button
+            android:id="@+id/buttonDebugViewDisplayLogs"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Show logs"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/textViewDebugViewHeaderActions"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/large_padding"
+            android:text="Debug Actions"
+            android:textAppearance="@style/TextAppearance.SeriesGuide.Headline6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewDisplayLogs" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTestNotification1"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/default_padding"
+            android:text="Show test notification (1)"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textViewDebugViewHeaderActions" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTestNotification3"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Show test notification (3)"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewTestNotification1" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTriggerJobProcessing"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/large_padding"
+            android:text="Schedule job processing"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewTestNotification3" />
+
+        <Button
+            android:id="@+id/buttonDebugViewDemoMode"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/large_padding"
+            android:text="Toggle demo mode"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewTriggerJobProcessing" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTraktClearRefreshToken"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/large_padding"
+            android:text="Clear Trakt refresh token"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewDemoMode" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTraktInvalidateAccessToken"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Invalidate Trakt access token"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewTraktClearRefreshToken" />
+
+        <Button
+            android:id="@+id/buttonDebugViewTraktInvalidateRefreshToken"
+            style="@style/Widget.SeriesGuide.Button.Outlined"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="Invalidate Trakt refresh token"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonDebugViewTraktInvalidateAccessToken" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_debug_view.xml
+++ b/app/src/main/res/layout/fragment_debug_view.xml
@@ -20,7 +20,7 @@
             android:id="@+id/buttonDebugViewDisplayLogs"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Show logs"
+            android:text="@string/title_debug_log"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_debug_log.xml
+++ b/app/src/main/res/layout/item_debug_log.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2025 Uwe Trottmann -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/textViewItemDebugLogLevel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@color/sg_debuglog_debug"
+        android:gravity="center"
+        android:minWidth="20dp"
+        android:textColor="@color/sg_white"
+        android:textSize="11sp"
+        android:textStyle="bold"
+        tools:text="E" />
+
+    <TextView
+        android:id="@+id/textViewItemDebugLogTag"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_toEndOf="@id/textViewItemDebugLogLevel"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="11sp"
+        tools:text="06-19 08:30:23.2 SomeLogTag" />
+
+    <TextView
+        android:id="@+id/textViewItemDebugLogMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/textViewItemDebugLogTag"
+        android:layout_marginStart="2dp"
+        android:padding="4dp"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textStyle="bold"
+        tools:text="Log message" />
+
+</RelativeLayout>

--- a/app/src/main/res/menu/debug_log_menu.xml
+++ b/app/src/main/res/menu/debug_log_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_action_debug_log_save"
+        android:title="@string/action_save"
+        app:showAsAction="always" />
+
+</menu>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -499,7 +499,6 @@
     <string name="theme_app_dark">داكن</string>
     <string name="theme_app_light">فاتح</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">أخرى</string>
     <string name="pref_autoupdatesummary">مزامنة وتحديث بيانات SeriesGuide تلقائيا</string>
     <string name="backup">النسخ الإحتياطي / الإستعادة</string>
     <string name="backup_summary">لعمل نسخ احتياطي للمسلسلات، القوائم والأفلام أو استعادتها</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -457,7 +457,6 @@
     <string name="theme_app_dark">Tamna</string>
     <string name="theme_app_light">Svetlo</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Ostalo</string>
     <string name="pref_autoupdatesummary">Automatski sinhronizujte i ažurirajte sadržaj</string>
     <string name="backup">Arhiviranje/Povratak</string>
     <string name="backup_summary">Napravite rezervnu kopiju ili vratite svoje serije, liste i filmove</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Тъмна</string>
     <string name="theme_app_light">Светла</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Други</string>
     <string name="pref_autoupdatesummary">Автоматично синхронизиране и актуализиране данните на SeriesGuide</string>
     <string name="backup">Архивиране/Възстановяване</string>
     <string name="backup_summary">Архивиране или възстановяване на вашите сериали</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Fosc</string>
     <string name="theme_app_light">Clar</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Altres</string>
     <string name="pref_autoupdatesummary">Sincronitzar i actualitzar les dades de SeriesGuide automàticament</string>
     <string name="backup">Còpies de seguretat/Restaura</string>
     <string name="backup_summary">Creeu una còpia de seguretat de les vostres sèries o restaureu-ne alguna d\'existent</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">Tmavý</string>
     <string name="theme_app_light">Světlý</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Ostatní</string>
     <string name="pref_autoupdatesummary">Automaticky synchronizovat a aktualizovat obsah</string>
     <string name="backup">Zálohování/obnovení</string>
     <string name="backup_summary">Zálohování a obnovení Vašich pořadů</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -499,7 +499,6 @@
     <string name="theme_app_dark">Tywyll</string>
     <string name="theme_app_light">Golau</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Arall</string>
     <string name="pref_autoupdatesummary">Cysoni a diweddaru cynnwys yn awtomatig</string>
     <string name="backup">Gwneud copi wrth gefn / Adfer</string>
     <string name="backup_summary">Gwneud copi wrth gefn neu adfer eich sioeau, rhestrau a ffilmiau</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Mørk</string>
     <string name="theme_app_light">Lys</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Øvrige</string>
     <string name="pref_autoupdatesummary">Synkronisér og opdatér SeriesGuide-data automatisk</string>
     <string name="backup">Sikkerhedskopier/Gendan</string>
     <string name="backup_summary">Sikkerhedskopier eller gendan dine serier</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Dunkel</string>
     <string name="theme_app_light">Hell</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Anderes</string>
     <string name="pref_autoupdatesummary">Automatisch synchronisieren und Inhalte aktualisieren</string>
     <string name="backup">Sichern/Wiederherstellen</string>
     <string name="backup_summary">Sicherung aller Serien, Listen und Filme erstellen oder Sicherung wiederherstellen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Σκοτεινό</string>
     <string name="theme_app_light">Φωτεινό</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Άλλα</string>
     <string name="pref_autoupdatesummary">Αυτόματος συγχρονισμός και ενημέρωση περιεχομένου</string>
     <string name="backup">Δημιουργία αντιγράφου ασφαλείας/Επαναφορά</string>
     <string name="backup_summary">Δημιουργία αντιγράφου ασφαλείας ή επαναφορά των σειρών</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Malhela</string>
     <string name="theme_app_light">Hela</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Aliaj</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
     <string name="backup">Savkopii/Restaŭri</string>
     <string name="backup_summary">Back up or restore your shows, lists and movies</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -444,7 +444,6 @@ Asegúrate de quitarla también en tus otros dispositivos conectados.</string>
     <string name="theme_app_dark">Oscuro</string>
     <string name="theme_app_light">Claro</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Otros</string>
     <string name="pref_autoupdatesummary">Sincronizar y actualizar automáticamente datos de SeriesGuide</string>
     <string name="backup">Respaldo/Restauración</string>
     <string name="backup_summary">Respaldar o restaurar sus programas</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">تاریک</string>
     <string name="theme_app_light">روشن</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">دیگر</string>
     <string name="pref_autoupdatesummary">به‌روز رسانی و همگام سازی خودکار محتوا</string>
     <string name="backup">پشتیبان/بازیابی</string>
     <string name="backup_summary">پشتیبان گیری یا بازگردانی نمایش‌هایتان</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Tumma</string>
     <string name="theme_app_light">Vaalea</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Muu</string>
     <string name="pref_autoupdatesummary">Synkronoi ja päivitä sisältö automaattisesti</string>
     <string name="backup">Varmuuskopioi/Palauta</string>
     <string name="backup_summary">Varmuuskopioi tai palauta ohjelmasi</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Sombre</string>
     <string name="theme_app_light">Clair</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Autres</string>
     <string name="pref_autoupdatesummary">Synchroniser automatiquement et mettre à jour les données de SeriesGuide</string>
     <string name="backup">Sauvegarde/Restauration</string>
     <string name="backup_summary">Sauvegarder ou restaurer vos séries</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Escuro</string>
     <string name="theme_app_light">Claro</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Outros</string>
     <string name="pref_autoupdatesummary">Sincronizar e actualizar os datos automaticamente</string>
     <string name="backup">Copa de seguridade / Recuperar</string>
     <string name="backup_summary">Facer unha copia de seguridade ou restaurar as túas series</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -457,7 +457,6 @@
     <string name="theme_app_dark">Tamna</string>
     <string name="theme_app_light">Svijetla</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Ostalo</string>
     <string name="pref_autoupdatesummary">Automatski sinkronizirajte i ažurirajte SeriesGuide podatke</string>
     <string name="backup">Sigurnosno kopiranje/vraćanje</string>
     <string name="backup_summary">Napravi sigurnosnu kopiju ili obnovi svoje serije</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Sötét</string>
     <string name="theme_app_light">Világos</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Egyéb</string>
     <string name="pref_autoupdatesummary">SeriesGuide adatok automatikus szinkronizálása és frissítése</string>
     <string name="backup">Biztonsági Mentés/Visszaállítás</string>
     <string name="backup_summary">A sorozatokról biztonsági mentés készítése vagy annak visszaállítása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">Gelap</string>
     <string name="theme_app_light">Terang</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Lainnya</string>
     <string name="pref_autoupdatesummary">Secara otomatis melakukan sinkronisasi dan memperbarui data SeriesGuide</string>
     <string name="backup">Cadangkan/Pulihkan</string>
     <string name="backup_summary">Cadangkan atau pulihkan acara anda</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Scuro</string>
     <string name="theme_app_light">Chiaro</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Altro</string>
     <string name="pref_autoupdatesummary">Sincronizza e aggiorna automaticamente i dati di SeriesGuide</string>
     <string name="backup">Backup/Ripristino</string>
     <string name="backup_summary">Esegui il backup o ripristina le tue serie</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">כהה</string>
     <string name="theme_app_light">בהיר</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">אחר</string>
     <string name="pref_autoupdatesummary">בצע סנכרון אוטומטי ועדכן נתונים של SeriesGuide</string>
     <string name="backup">גיבוי/שחזור</string>
     <string name="backup_summary">גבה או שחזר את סדרותיך</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">ダーク</string>
     <string name="theme_app_light">ライト</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">その他</string>
     <string name="pref_autoupdatesummary">SeriesGuide データを自動的に同期および更新します</string>
     <string name="backup">バックアップ/復元</string>
     <string name="backup_summary">番組をバックアップまたは復元します</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">Dark</string>
     <string name="theme_app_light">Light</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">기타</string>
     <string name="pref_autoupdatesummary">자동으로 콘텐츠 동기화 및 업데이트</string>
     <string name="backup">백업/복원</string>
     <string name="backup_summary">프로그램 목록을 백업학거나 복원합니다</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Dark</string>
     <string name="theme_app_light">Light</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Друго</string>
     <string name="pref_autoupdatesummary">Автоматиско синхронизирање и абдејтирање опции</string>
     <string name="backup">Backup/Restore</string>
     <string name="backup_summary">Backup или обновување на вашиите серии</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Mørk</string>
     <string name="theme_app_light">Lys</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Annet</string>
     <string name="pref_autoupdatesummary">Synkroniser automatisk og oppdater SeriesGuide data</string>
     <string name="backup">Sikkerhetskopiering/gjenoppretting</string>
     <string name="backup_summary">Sikkerhetskopier eller gjenopprett dine serier</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Donker</string>
     <string name="theme_app_light">Licht</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Andere</string>
     <string name="pref_autoupdatesummary">Automatisch data synchroniseren en bijwerken</string>
     <string name="backup">Back-up maken/herstellen</string>
     <string name="backup_summary">Back-up van series maken/herstellen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">Ciemny</string>
     <string name="theme_app_light">Jasny</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Inne</string>
     <string name="pref_autoupdatesummary">Automatycznie synchronizuje i aktualizuje dane SeriesGuide</string>
     <string name="backup">Kopia zapasowa</string>
     <string name="backup_summary">Utwórz/Przywróć kopię bazy seriali</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Escuro</string>
     <string name="theme_app_light">Claro</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Outro</string>
     <string name="pref_autoupdatesummary">Sincronizar e atualizar os dados automaticamente</string>
     <string name="backup">Backup/Restauração</string>
     <string name="backup_summary">Fazer backup ou restaurar as suas séries</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Escuro</string>
     <string name="theme_app_light">Claro</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Outro</string>
     <string name="pref_autoupdatesummary">Sincroniza e atualiza automaticamente os dados do SeriesGuide</string>
     <string name="backup">Cópia de Segurança/Restaurar</string>
     <string name="backup_summary">Faz uma cópia de segurança ou restaura as tuas séries, listas e filmes</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -457,7 +457,6 @@
     <string name="theme_app_dark">Dark</string>
     <string name="theme_app_light">Light</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Alte</string>
     <string name="pref_autoupdatesummary">Sincronizează automat și actualizează datele de pe SeriesGuide</string>
     <string name="backup">Arhivare/Restaurare</string>
     <string name="backup_summary">Arhivează sau restaurează emisiunile</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">Тёмная</string>
     <string name="theme_app_light">Светлая</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Другое</string>
     <string name="pref_autoupdatesummary">Автоматически синхронизировать и обновлять данные SeriesGuide</string>
     <string name="backup">Резервное копирование/восстановление</string>
     <string name="backup_summary">Резервное копирование или восстановление ваших сериалов</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">Tmavá</string>
     <string name="theme_app_light">Svetlá</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Ostatné</string>
     <string name="pref_autoupdatesummary">Automaticky synchronizovať a aktualizovať SeriesGuide dáta</string>
     <string name="backup">Zálohovanie / obnovenie</string>
     <string name="backup_summary">Zálohovanie alebo obnovenie vašich seriálov</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -457,7 +457,6 @@
     <string name="theme_app_dark">Тамно</string>
     <string name="theme_app_light">Светло</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Остало</string>
     <string name="pref_autoupdatesummary">Аутоматски синхронизујте и ажурирајте садржај</string>
     <string name="backup">Архивирање/ повраћај архиве</string>
     <string name="backup_summary">Архивирај или врати архивиране серије</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Mörk</string>
     <string name="theme_app_light">Ljust</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Övrigt</string>
     <string name="pref_autoupdatesummary">Automatiskt synkronisera och uppdatera SeriesGuide-data</string>
     <string name="backup">Säkerhetskopiera/återställ</string>
     <string name="backup_summary">Säkerhetskopiera eller återställ dina serier</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Dark</string>
     <string name="theme_app_light">Light</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">மற்ற</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
     <string name="backup">மறுபிரதி/மீட்டெடுத்தல்</string>
     <string name="backup_summary">மறுபிரதி எடு அல்லது மீட்டெடு உங்கள் காட்சிகள்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">มืด</string>
     <string name="theme_app_light">สว่าง</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">อื่นๆ</string>
     <string name="pref_autoupdatesummary">ซิงค์และอัปเดตข้อมูล SeriesGuide อัตโนมัติ</string>
     <string name="backup">สำรอง/กู้คืน</string>
     <string name="backup_summary">สำรองหรือกู้คืนซีรีส์ของคุณ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -443,7 +443,6 @@
     <string name="theme_app_dark">Karanlık</string>
     <string name="theme_app_light">Aydınlık</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Diğer</string>
     <string name="pref_autoupdatesummary">İçeriği otomatik olarak senkronize et ve güncelle</string>
     <string name="backup">Yedekle/Geri Yükle</string>
     <string name="backup_summary">Dizilerinizi, listelerinizi ve filmlerinizi yedekleyin veya geri yükleyin</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -471,7 +471,6 @@
     <string name="theme_app_dark">Темна</string>
     <string name="theme_app_light">Світла</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">Інші</string>
     <string name="pref_autoupdatesummary">Автоматично синхронізування та оновлення даних SeriesGuide</string>
     <string name="backup">Бекап/Відновлення</string>
     <string name="backup_summary">Резервна копія або відновлення ваших серіалів</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">深色</string>
     <string name="theme_app_light">浅色</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">其它</string>
     <string name="pref_autoupdatesummary">自动同步并更新 SeriesGuide 数据</string>
     <string name="backup">备份或恢复</string>
     <string name="backup_summary">备份或恢复您的节目、列表和电影</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -429,7 +429,6 @@
     <string name="theme_app_dark">深色</string>
     <string name="theme_app_light">淺色</string>
     <!-- Other advanced settings -->
-    <string name="pref_other">其他</string>
     <string name="pref_autoupdatesummary">自動同步和更新 SeriesGuide 資料</string>
     <string name="backup">備份/還原</string>
     <string name="backup_summary">備份或還原你的影集</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -82,4 +82,11 @@
     <color name="sg_ripple_material_dark">#33ffffff</color>
     <color name="sg_ripple_material_light">#1f000000</color>
 
+    <!-- Debug log -->
+    <color name="sg_debuglog_debug">#2196F3</color>
+    <color name="sg_debuglog_info">#8BC34A</color>
+    <color name="sg_debuglog_warn">#FFC107</color>
+    <color name="sg_debuglog_error">#F44336</color>
+    <color name="sg_debuglog_unknown">#9C27B0</color>
+
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -67,7 +67,7 @@
     <!-- Settings -->
     <string name="pref_key_notifications_hidden">com.battlelancer.seriesguide.notifications.hidden</string>
     <string name="pref_community">Community</string>
-    <string name="pref_category_danger">Danger Zone</string>
+    <string name="pref_category_danger">Diagnostics</string>
     <string name="pref_user_debug_mode">Debug mode</string>
     <string name="pref_user_debug_mode_summary">Allows to diagnose errors, but slows down the app.</string>
     <string name="debug_view">Debug View</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -70,7 +70,6 @@
     <string name="pref_category_danger">Danger Zone</string>
     <string name="pref_user_debug_mode">Debug mode</string>
     <string name="pref_user_debug_mode_summary">Allows to diagnose errors, but slows down the app.</string>
-    <string name="pref_user_debug_mode_note">Now force stop and restart the app!</string>
     <string name="debug_view">Debug View</string>
 
     <!-- Season sort orders -->

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -67,9 +67,6 @@
     <!-- Settings -->
     <string name="pref_key_notifications_hidden">com.battlelancer.seriesguide.notifications.hidden</string>
     <string name="pref_community">Community</string>
-    <string name="pref_category_danger">Diagnostics</string>
-    <string name="pref_user_debug_mode">Debug mode</string>
-    <string name="pref_user_debug_mode_summary">Allows to diagnose errors, but slows down the app.</string>
     <string name="debug_view">Debug View</string>
 
     <!-- Season sort orders -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,7 +481,7 @@
     <string name="theme_app_light">Light</string>
 
     <!-- Other advanced settings -->
-    <string name="pref_other">Other</string>
+    <string name="pref_category_diagnostics">Diagnostics</string>
     <string name="pref_autoupdatesummary">Automatically sync and update content</string>
     <string name="backup">Backup/Restore</string>
     <string name="backup_summary">Back up or restore your shows, lists and movies</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -612,4 +612,9 @@
     <!-- Support -->
     <string name="support_the_dev">Support the developer?</string>
 
+    <!-- Diagnostics -->
+    <string name="title_debug_log">Debug log</string>
+    <string name="status_saving_file_success">File saved</string>
+    <string name="status_saving_file_failed">Failed to save file</string>
+
 </resources>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <external-files-path name="logs" path="." />
-</paths>

--- a/app/src/main/res/xml/settings_root.xml
+++ b/app/src/main/res/xml/settings_root.xml
@@ -75,7 +75,7 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:title="@string/pref_other">
+        app:title="@string/pref_category_diagnostics">
 
         <Preference
             app:iconSpaceReserved="false"
@@ -83,26 +83,19 @@
             app:summary="@string/clear_cache_summary"
             app:title="@string/clear_cache" />
 
+        <!-- AppSettings -->
         <SwitchPreferenceCompat
             app:defaultValue="True"
             app:iconSpaceReserved="false"
             app:key="com.battlelancer.seriesguide.sendErrorReports"
             app:title="@string/pref_error_reports" />
 
-    </PreferenceCategory>
-
-    <!-- Danger Zone - not translated -->
-    <PreferenceCategory
-        app:iconSpaceReserved="false"
-        app:title="@string/pref_category_danger">
-
         <!-- AppSettings -->
         <SwitchPreferenceCompat
             app:defaultValue="False"
             app:iconSpaceReserved="false"
             app:key="com.battlelancer.seriesguide.userDebugModeEnabled"
-            app:summary="@string/pref_user_debug_mode_summary"
-            app:title="@string/pref_user_debug_mode" />
+            app:title="@string/title_debug_log" />
 
     </PreferenceCategory>
 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -39,6 +39,47 @@ The methods are named based on what is clicked.
 
 Example: `onMoreOptionsClick`.
 
+### RecyclerView
+
+Use the following pattern for `ViewHolder` classes:
+
+```kotlin
+class LinkViewHolder(
+    private val binding: ItemDiscoverLinkBinding,
+    itemClickListener: ItemClickListener
+) : RecyclerView.ViewHolder(binding.root) {
+
+    interface ItemClickListener {
+        fun onItemClick()
+    }
+    
+    init {
+        binding.button.setOnClickListener {
+            itemClickListener.onItemClick()
+        }
+    }
+
+    fun bindTo(text: String) {
+        binding.textView.text = text
+    }
+
+    companion object {
+        fun inflate(parent: ViewGroup, itemClickListener: ItemClickListener) =
+            LinkViewHolder(
+                ItemDiscoverLinkBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                ),
+                itemClickListener
+            )
+    }
+}
+```
+
+- Keeps the view binding class imports inside the `ViewHolder` class.
+- Keeps binding logic inside the `ViewHolder` class.
+
 ### SharedPreferences and settings
 
 SharedPreferences should be edited by a dedicated settings class. Other code should get and set 

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -17,6 +17,13 @@ doSomething(avoidWork = true)
 doSomething(true)
 ```
 
+### Application dependency injection
+
+Existing code is using Dagger and a [ServicesComponent](/app/src/main/java/com/battlelancer/seriesguide/modules/ServicesComponent.kt).
+
+New code should avoid relying on Dagger (and its annotation processor) and use the 
+[SgAppContainer](/app/src/main/java/com/battlelancer/seriesguide/SgAppContainer.kt) instead.
+
 ### Room database
 
 The `@Entity` data classes should use nullable types for all columns (besides the ID). Validation,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 
 [versions]
 androidx-lifecycle = "2.8.7" # https://developer.android.com/jetpack/androidx/releases/lifecycle
-debugdrawer = "0.9.0" # https://github.com/lenguyenthanh/DebugDrawer
 eventbus = "3.3.1"
 google-api-client = "2.6.0" # https://github.com/googleapis/google-api-java-client/releases
 retrofit2 = "2.11.0" # https://github.com/square/retrofit/blob/master/CHANGELOG.md
@@ -62,11 +61,6 @@ billing = "com.android.billingclient:billing-ktx:6.0.1" # https://developer.andr
 # https://github.com/google/dagger/releases
 dagger = "com.google.dagger:dagger:2.56.2"
 dagger-compiler = "com.google.dagger:dagger-compiler:2.56.2"
-debugdrawer-actions = { module = "com.github.lenguyenthanh.debugdrawer:debugdrawer-actions", version.ref = "debugdrawer" }
-debugdrawer-base = { module = "com.github.lenguyenthanh.debugdrawer:debugdrawer-base", version.ref = "debugdrawer" }
-debugdrawer-commons = { module = "com.github.lenguyenthanh.debugdrawer:debugdrawer-commons", version.ref = "debugdrawer" }
-debugdrawer-timber = { module = "com.github.lenguyenthanh.debugdrawer:debugdrawer-timber", version.ref = "debugdrawer" }
-debugdrawer-view = { module = "com.github.lenguyenthanh.debugdrawer:debugdrawer-view", version.ref = "debugdrawer" }
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 # https://firebase.google.com/support/release-notes/android
 firebase-crashlytics = "com.google.firebase:firebase-crashlytics:19.0.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2024 Uwe Trottmann
-
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -22,7 +19,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // For debugdrawer.
+        // For com.github.chrisbanes:PhotoView
         maven { url = uri("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
The debugdrawer fork seems to have disappeared from jitpack. Anyhow, wanted to redo this so switched to a custom implementation borrowing ideas from debugdrawer and Signal.

The debug log file is now saved by the user, instead of shared. This lets the user decide how to share the file (like via email, or forum, or on the issue tracker).