### PR TITLE
Release  2025.2.15: watchlist pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Releases marked with 🧪 (or previously with the "beta" suffix) were released o
 * 📝 Removed the unsupported release for devices running Android 4 from Google Play, it is no longer
   working properly.
 
-### Next release
+### 2025.2.15 - 2026-03-05
 
 * 🔨 Trakt: support server changes to correctly fetch all watchlist items.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Releases marked with 🧪 (or previously with the "beta" suffix) were released o
 * 📝 Removed the unsupported release for devices running Android 4 from Google Play, it is no longer
   working properly.
 
+### Next release
+
+* 🔨 Trakt: support server changes to correctly fetch all watchlist items.
+
 ### 2025.2.14 - 2026-02-12
 
 * 📝 Trakt: support upcoming server changes when fetching collections.

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
@@ -28,7 +28,7 @@ import timber.log.Timber
 object TraktTools4 {
 
     // 1000 is the maximum limit according to https://github.com/trakt/trakt-api/discussions/681
-    private const val COLLECTION_MAX_LIMIT = 1000
+    private const val LIST_AND_COLLECTION_MAX_LIMIT = 1000
 
     sealed interface TraktResponse<T> {
         data class Success<T>(
@@ -85,7 +85,7 @@ object TraktTools4 {
             action = "get collected shows",
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
-            traktSync.collectionShows(page, COLLECTION_MAX_LIMIT, null)
+            traktSync.collectionShows(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
         }
     }
 
@@ -155,12 +155,13 @@ object TraktTools4 {
     suspend fun getShowsOnWatchlist(
         traktSync: Sync
     ): TraktNonNullResponse<List<BaseShow>> {
-        return awaitTraktCallNonNull(
-            // Use Extended.FULL to get show metadata
-            traktSync.watchlistShows(Extended.FULL),
-            "get shows on watchlist",
+        return fetchAllPages(
+            action = "get shows on watchlist",
             reportIsNotVip = true // Should work even if not VIP
-        )
+        ) { page ->
+            // Use Extended.FULL to get show metadata
+            traktSync.watchlistShows(page, LIST_AND_COLLECTION_MAX_LIMIT, Extended.FULL)
+        }
     }
 
     suspend fun getWatchedMoviesByTmdbId(
@@ -191,7 +192,7 @@ object TraktTools4 {
             action = "get collected movies",
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
-            traktSync.collectionMovies(page, COLLECTION_MAX_LIMIT, null)
+            traktSync.collectionMovies(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
         }
         return mapResponseData(response) { mapMoviesToTmdbIdSet(it) }
     }
@@ -199,11 +200,12 @@ object TraktTools4 {
     suspend fun getMoviesOnWatchlistByTmdbId(
         traktSync: Sync
     ): TraktNonNullResponse<MutableSet<Int>> {
-        val response = awaitTraktCallNonNull(
-            traktSync.watchlistMovies(null),
-            "get movie watchlist",
+        val response = fetchAllPages(
+            action = "get movie watchlist",
             reportIsNotVip = true // Should work even if not VIP
-        )
+        ) { page ->
+            traktSync.watchlistMovies(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
+        }
         return mapResponseData(response) { mapMoviesToTmdbIdSet(it) }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,9 @@ buildscript {
     // YYYY.<release-of-year>.<build> - like 2024.1.0
     // - allows to more easily judge how old a release is
     // - allows multiple releases per month (though currently unlikely)
-    val sgVersionName by extra("2025.2.14")
+    val sgVersionName by extra("2025.2.15")
     // version 21yyrrbb -> min SDK 21, year yy, release rr, build bb
-    val sgVersionCode by extra(21250217)
+    val sgVersionCode by extra(21250218)
 
     val isCiBuild by extra { System.getenv("CI") == "true" }
 


### PR DESCRIPTION
* 🔨 Trakt: support server changes to correctly fetch all watchlist items.