### PR TITLE
Trakt: prepare for watched pagination, new extended flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 Releases marked with 🧪 (or previously with the "beta" suffix) were released on
 [the preview program](https://www.seriesgui.de/help/how-to/basics/preview) only.
 
+## Next release
+
+* 📝 Trakt: prepare for server changes to correctly fetch all watched items.
+
 ## Version 2026.1
 
 * 📝 Trakt: support server changes to correctly fetch all collection and watchlist items.

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
@@ -13,6 +13,7 @@ import com.uwetrottmann.trakt5.entities.Note
 import com.uwetrottmann.trakt5.entities.Show
 import com.uwetrottmann.trakt5.entities.ShowIds
 import com.uwetrottmann.trakt5.enums.Extended
+import com.uwetrottmann.trakt5.enums.ExtendedShowsWatched
 import com.uwetrottmann.trakt5.services.Notes
 import com.uwetrottmann.trakt5.services.Sync
 import retrofit2.Call
@@ -29,7 +30,7 @@ object TraktTools4 {
 
     // 250 is the maximum limit according to the Trakt [Upcoming API Changes: Pagination & Sorting Updates](https://github.com/trakt/trakt-api/discussions/681)
     // discussion.
-    private const val LIST_AND_COLLECTION_MAX_LIMIT = 250
+    private const val MAX_LIMIT = 250
 
     sealed interface TraktResponse<T> {
         data class Success<T>(
@@ -86,7 +87,7 @@ object TraktTools4 {
             action = "get collected shows",
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
-            traktSync.collectionShows(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
+            traktSync.collectionShows(page, MAX_LIMIT, null)
         }
     }
 
@@ -161,7 +162,7 @@ object TraktTools4 {
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
             // Use Extended.FULL to get show metadata
-            traktSync.watchlistShows(page, LIST_AND_COLLECTION_MAX_LIMIT, Extended.FULL)
+            traktSync.watchlistShows(page, MAX_LIMIT, Extended.FULL)
         }
     }
 
@@ -193,7 +194,7 @@ object TraktTools4 {
             action = "get collected movies",
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
-            traktSync.collectionMovies(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
+            traktSync.collectionMovies(page, MAX_LIMIT, null)
         }
         return mapResponseData(response) { mapMoviesToTmdbIdSet(it) }
     }
@@ -205,7 +206,7 @@ object TraktTools4 {
             action = "get movie watchlist",
             reportIsNotVip = true // Should work even if not VIP
         ) { page ->
-            traktSync.watchlistMovies(page, LIST_AND_COLLECTION_MAX_LIMIT, null)
+            traktSync.watchlistMovies(page, MAX_LIMIT, null)
         }
         return mapResponseData(response) { mapMoviesToTmdbIdSet(it) }
     }

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
@@ -27,8 +27,9 @@ import timber.log.Timber
  */
 object TraktTools4 {
 
-    // 1000 is the maximum limit according to https://github.com/trakt/trakt-api/discussions/681
-    private const val LIST_AND_COLLECTION_MAX_LIMIT = 1000
+    // 250 is the maximum limit according to the Trakt [Upcoming API Changes: Pagination & Sorting Updates](https://github.com/trakt/trakt-api/discussions/681)
+    // discussion.
+    private const val LIST_AND_COLLECTION_MAX_LIMIT = 250
 
     sealed interface TraktResponse<T> {
         data class Success<T>(

--- a/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/traktapi/TraktTools4.kt
@@ -62,15 +62,36 @@ object TraktTools4 {
         class Other<T> : TraktResponse<T>, TraktNonNullResponse<T>
     }
 
+    /**
+     * If [noSeasons] is `true`, only show info is available. Starting 2026-05-30 also full info.
+     * If it's `false`, seasons and episodes are available. Starting 2026-05-30 also full info.
+     *
+     * See the Trakt [Upcoming API Changes: Watched Endpoints Pagination & Extended Defaults](https://github.com/trakt/trakt-api/discussions/775)
+     * discussion about details and updates.
+     */
     suspend fun getWatchedShows(
         traktSync: Sync,
         noSeasons: Boolean
     ): TraktNonNullResponse<List<BaseShow>> {
-        return awaitTraktCallNonNull(
-            traktSync.watchedShows(if (noSeasons) Extended.NOSEASONS else null),
-            "get watched shows",
+        return fetchAllPages(
+            action = "get watched shows",
             reportIsNotVip = true // Should work even if not VIP
-        )
+        ) { page ->
+            traktSync.watchedShows(
+                page,
+                MAX_LIMIT,
+                if (noSeasons) {
+                    // As of 2026-05-30 this should be the default, still request until then
+                    // https://github.com/trakt/trakt-api/discussions/775
+                    @Suppress("DEPRECATION")
+                    ExtendedShowsWatched.NOSEASONS
+                } else {
+                    // This should only work starting 2026-05-30, but already request it
+                    // https://github.com/trakt/trakt-api/discussions/775
+                    ExtendedShowsWatched.PROGRESS
+                }
+            )
+        }
     }
 
     suspend fun getWatchedShowsByTmdbId(
@@ -169,11 +190,12 @@ object TraktTools4 {
     suspend fun getWatchedMoviesByTmdbId(
         traktSync: Sync
     ): TraktNonNullResponse<MutableMap<Int, Int>> {
-        val response = awaitTraktCallNonNull(
-            traktSync.watchedMovies(null),
-            "get watched movies",
+        val response = fetchAllPages(
+            action = "get watched movies",
             reportIsNotVip = true // Should work even if not VIP
-        )
+        ) { page ->
+            traktSync.watchedMovies(page, MAX_LIMIT, null)
+        }
         return mapResponseData(response) { mapMoviesToTmdbIdWithPlays(it) }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,7 +124,7 @@ picasso = "com.squareup.picasso:picasso:2.8" # https://github.com/square/picasso
 retrofit2-gson = "com.squareup.retrofit2:converter-gson:3.0.0"
 retrofit2 = "com.squareup.retrofit2:retrofit:3.0.0"
 tmdb-java = "com.uwetrottmann.tmdb2:tmdb-java:2.13.0" # https://github.com/UweTrottmann/tmdb-java/blob/main/CHANGELOG.md
-trakt-java = "com.uwetrottmann.trakt5:trakt-java:6.18.0" # https://github.com/UweTrottmann/trakt-java/blob/main/CHANGELOG.md
+trakt-java = "com.uwetrottmann.trakt5:trakt-java:6.19.0" # https://github.com/UweTrottmann/trakt-java/blob/main/CHANGELOG.md
 
 # Billing
 amazon-appstore-sdk = "com.amazon.device:amazon-appstore-sdk:3.0.8" # https://developer.amazon.com/docs/in-app-purchasing/iap-whats-new.html


### PR DESCRIPTION
See the Trakt [Upcoming API Changes: Watched Endpoints Pagination & Extended Defaults](https://github.com/trakt/trakt-api/discussions/775) discussion about details and updates.

Also adjust the requested limit to 250, see the Trakt [Upcoming API Changes: Pagination & Sorting Updates](https://github.com/trakt/trakt-api/discussions/681) discussion.