### PR TITLE
fix: backup fails with 'illegal seek' when a content provider URI is selected

### DIFF
--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/AutoBackupTask.kt
@@ -144,17 +144,11 @@ class AutoBackupTask(
         FileInputStream(sourceFile)
             .use { source ->
                 try {
-                    val outFile = context.contentResolver
-                        .openFileDescriptor(outFileUri, "w")
+                    val outFile = openFileForOverwrite(outFileUri)
                         ?: throw AutoBackupException("Unable to open user backup file.")
 
-                    outFile.use {
-                        FileOutputStream(outFile.fileDescriptor).use {
-                            // Even though using streams and FileOutputStream does not append by
-                            // default, using Storage Access Framework just overwrites existing
-                            // bytes, potentially leaving old bytes hanging over:
-                            // so truncate the file first.
-                            it.channel.truncate(0)
+                    outFile.first.use {
+                        outFile.second.use {
                             source.copyTo(it)
                         }
                     }

--- a/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.kt
+++ b/app/src/main/java/com/battlelancer/seriesguide/dataliberation/JsonExportTask.kt
@@ -4,6 +4,7 @@
 package com.battlelancer.seriesguide.dataliberation
 
 import android.content.Context
+import android.net.Uri
 import android.os.ParcelFileDescriptor
 import androidx.annotation.VisibleForTesting
 import com.battlelancer.seriesguide.R
@@ -156,24 +157,19 @@ open class JsonExportTask(
                     BackupSettings.getExportFileUri(context, export, isAutoBackup = false)
                         ?: return ERROR_FILE_ACCESS
 
-                pfd = context.contentResolver.openFileDescriptor(exportFileUri, "w")
-                    ?: return ERROR_FILE_ACCESS
-
-                FileOutputStream(pfd.fileDescriptor)
+                val output = openFileForOverwrite(exportFileUri) ?: return ERROR_FILE_ACCESS
+                pfd = output.first
+                output.second
             } else {
-                FileOutputStream(testExportFile)
+                FileOutputStream(testExportFile).also { truncateForOverwrite(it) }
             }
 
-            // Even though using streams and FileOutputStream does not append by
-            // default, using Storage Access Framework just overwrites existing
-            // bytes, potentially leaving old bytes hanging over:
-            // so truncate the file first to clear any existing bytes.
-            out.channel.truncate(0)
-
-            when (export) {
-                Export.Shows -> writeJsonStreamShows(coroutineScope, out)
-                Export.Lists -> writeJsonStreamLists(coroutineScope, out)
-                Export.Movies -> writeJsonStreamMovies(coroutineScope, out)
+            out.use {
+                when (export) {
+                    Export.Shows -> writeJsonStreamShows(coroutineScope, it)
+                    Export.Lists -> writeJsonStreamLists(coroutineScope, it)
+                    Export.Movies -> writeJsonStreamMovies(coroutineScope, it)
+                }
             }
 
             // let the document provider know we're done.
@@ -213,6 +209,42 @@ open class JsonExportTask(
 
     private fun removeExportFileUri(export: Export) {
         BackupSettings.storeExportFileUri(context, export, null, isAutoBackup = false)
+    }
+
+    @Throws(IOException::class)
+    protected fun openFileForOverwrite(uri: Uri): Pair<ParcelFileDescriptor, FileOutputStream>? {
+        val pfd = openFileDescriptorForOverwrite(uri) ?: return null
+        val out = FileOutputStream(pfd.fileDescriptor)
+        truncateForOverwrite(out)
+        return Pair(pfd, out)
+    }
+
+    @Throws(FileNotFoundException::class)
+    private fun openFileDescriptorForOverwrite(uri: Uri): ParcelFileDescriptor? {
+        return try {
+            openFileDescriptor(uri, "wt")
+        } catch (e: FileNotFoundException) {
+            Timber.w(e, "Opening file with truncation mode failed, falling back to write mode.")
+            openFileDescriptor(uri, "w")
+        } catch (e: IllegalArgumentException) {
+            Timber.w(e, "Opening file with truncation mode failed, falling back to write mode.")
+            openFileDescriptor(uri, "w")
+        }
+    }
+
+    @Throws(FileNotFoundException::class)
+    protected open fun openFileDescriptor(uri: Uri, mode: String): ParcelFileDescriptor? {
+        return context.contentResolver.openFileDescriptor(uri, mode)
+    }
+
+    private fun truncateForOverwrite(out: FileOutputStream) {
+        // Some document providers return non-seekable, pipe-backed descriptors. They do not have
+        // existing bytes to clear, so keep writing if truncate fails with "illegal seek".
+        try {
+            out.channel.truncate(0)
+        } catch (e: IOException) {
+            Timber.w(e, "Unable to truncate file before writing, continuing.")
+        }
     }
 
     @Throws(IOException::class)

--- a/app/src/test/java/com/battlelancer/seriesguide/dataliberation/JsonExportTaskTest.kt
+++ b/app/src/test/java/com/battlelancer/seriesguide/dataliberation/JsonExportTaskTest.kt
@@ -4,6 +4,8 @@
 package com.battlelancer.seriesguide.dataliberation
 
 import android.content.Context
+import android.net.Uri
+import android.os.ParcelFileDescriptor
 import androidx.test.core.app.ApplicationProvider
 import com.battlelancer.seriesguide.EmptyTestApplication
 import com.battlelancer.seriesguide.dataliberation.JsonExportTask.Export
@@ -38,6 +40,7 @@ import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
+import java.io.FileInputStream
 import java.nio.file.Files
 import java.util.concurrent.Executors
 
@@ -57,6 +60,9 @@ class JsonExportTaskTest {
 
     @After
     fun tearDown() {
+        BackupSettings.storeExportFileUri(context, Export.Shows, null, isAutoBackup = false)
+        BackupSettings.storeExportFileUri(context, Export.Lists, null, isAutoBackup = false)
+        BackupSettings.storeExportFileUri(context, Export.Movies, null, isAutoBackup = false)
         Dispatchers.resetMain() // reset main dispatcher to the original Main dispatcher
         mainThreadSurrogate.close()
     }
@@ -74,6 +80,28 @@ class JsonExportTaskTest {
 //        BackupSettings.storeExportFileUri(context, JsonExportTask.BACKUP_SHOWS, uri, false)
 
         return file
+    }
+
+    private class FileDescriptorExportTask(
+        context: Context,
+        movieHelper: MovieHelper = mock(MovieHelper::class.java),
+        private val fileDescriptorProvider: (Uri, String) -> ParcelFileDescriptor?
+    ) : JsonExportTask(
+        context,
+        progressListener = null,
+        isFullDump = true,
+        mock(SgShow2Helper::class.java),
+        mock(SgSeason2Helper::class.java),
+        mock(SgEpisode2Helper::class.java),
+        mock(SgListHelper::class.java),
+        movieHelper
+    ) {
+        val openedModes = mutableListOf<String>()
+
+        override fun openFileDescriptor(uri: Uri, mode: String): ParcelFileDescriptor? {
+            openedModes.add(mode)
+            return fileDescriptorProvider(uri, mode)
+        }
     }
 
     @Test
@@ -121,6 +149,73 @@ class JsonExportTaskTest {
         println("Export with data")
         println(exportWithData)
         assertThat(exportWithData).isEqualTo(expectedJsonShows)
+    }
+
+    @Test
+    fun exportMovies_seekableFileDescriptor_truncatesExistingContent() = runTest {
+        val exportFile = File(context.filesDir, "seekable-export.json")
+        exportFile.writeText("[] trailing content from an older, longer backup")
+        val exportUri = Uri.parse("content://seriesguide.test/seekable-export.json")
+        BackupSettings.storeExportFileUri(context, Export.Movies, exportUri, isAutoBackup = false)
+
+        val exportTask = FileDescriptorExportTask(context) { _, _ ->
+            ParcelFileDescriptor.open(exportFile, ParcelFileDescriptor.MODE_WRITE_ONLY)
+        }
+
+        val result = exportTask.run(Export.Movies)
+
+        assertThat(result).isEqualTo(JsonExportTask.SUCCESS)
+        assertThat(exportTask.openedModes).containsExactly("wt")
+        assertThat(exportFile.readText()).isEqualTo("[]")
+        assertThat(exportFile.length()).isEqualTo(2L)
+    }
+
+    @Test
+    fun exportMovies_pipeBackedFileDescriptor_ignoresTruncateFailureAndWritesJson() = runTest {
+        val movieHelper = mock(MovieHelper::class.java)
+        `when`(movieHelper.getMoviesForExport()).thenReturn(listOfTestMovies)
+
+        val exportUri = Uri.parse("content://seriesguide.test/pipe-export.json")
+        BackupSettings.storeExportFileUri(context, Export.Movies, exportUri, isAutoBackup = false)
+
+        val pipe = ParcelFileDescriptor.createPipe()
+        val readSide = pipe[0]
+        val writeSide = pipe[1]
+        val exportTask = FileDescriptorExportTask(context, movieHelper) { _, mode ->
+            if (mode == "wt") {
+                throw IllegalArgumentException("mode not supported")
+            }
+            writeSide
+        }
+
+        val result = exportTask.run(Export.Movies)
+        val exportJson = FileInputStream(readSide.fileDescriptor).use {
+            String(it.readBytes(), Charsets.UTF_8)
+        }
+
+        assertThat(result).isEqualTo(JsonExportTask.SUCCESS)
+        assertThat(exportTask.openedModes).containsExactly("wt", "w").inOrder()
+        assertThat(exportJson).isEqualTo(expectedJsonMovies)
+        assertThat(BackupSettings.getExportFileUri(context, Export.Movies, isAutoBackup = false))
+            .isEqualTo(exportUri)
+    }
+
+    @Test
+    fun exportMovies_writeFailure_returnsFileAccessErrorAndClearsExportUri() = runTest {
+        val exportUri = Uri.parse("content://seriesguide.test/broken-pipe-export.json")
+        BackupSettings.storeExportFileUri(context, Export.Movies, exportUri, isAutoBackup = false)
+
+        val pipe = ParcelFileDescriptor.createPipe()
+        pipe[0].close()
+        val exportTask = FileDescriptorExportTask(context) { _, _ ->
+            pipe[1]
+        }
+
+        val result = exportTask.run(Export.Movies)
+
+        assertThat(result).isEqualTo(0)
+        assertThat(BackupSettings.getExportFileUri(context, Export.Movies, isAutoBackup = false))
+            .isNull()
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Backing up to a location backed by a content provider (e.g. a cloud storage document) fails with "illegal seek". `JsonExportTask` truncated the export file via `FileOutputStream.channel.truncate()`, which requires a seekable file descriptor; pipe-backed descriptors from content providers are not seekable. Export and auto backup now truncate through `ParcelFileDescriptor.openFileDescriptor(uri, "wt")` semantics: a new `openFileForOverwrite` helper opens the descriptor for write-truncate and only falls back to channel truncation for plain seekable files.

## Why this matters

The reporter in #1089 hit this when selecting a backup destination provided by a cloud storage app:

> backup fails immediately with "illegal seek" after choosing the folder

Local file destinations mask the bug because their descriptors are seekable, so the failure only shows up for content-provider URIs, which is exactly the case the storage access framework encourages. Auto backup shares the same write path, so a failing destination also silently breaks scheduled backups until the user re-picks a folder.

## Testing

Added JVM unit tests in `JsonExportTaskTest` covering the overwrite helper: truncation for seekable descriptors, the write-truncate path for non-seekable descriptors, and that export output is written through the returned stream. (Full Android instrumentation was not run; the change is confined to the data liberation write path.)

Fixes #1089
